### PR TITLE
chore(docs): v0.3.5 follow-up — per-rule docs + release note + #27 close

### DIFF
--- a/docs/rules/AAK-AZURE-MCP-001.md
+++ b/docs/rules/AAK-AZURE-MCP-001.md
@@ -1,0 +1,69 @@
+# AAK-AZURE-MCP-001
+
+**Azure MCP server consumed without authentication**
+
+| Field | Value |
+|---|---|
+| Severity | HIGH |
+| Category | `MCP_CONFIG` |
+| Shipped | v0.3.5 (2026-04-25) |
+| Scanner | `agent_audit_kit/scanners/supply_chain.py` (extension) |
+| CWE | CWE-306 (Missing Authentication for Critical Function) |
+| OWASP MCP | MCP02:2025 |
+| OWASP Agentic | ASI04 |
+| AICM | IAM-01, IAM-16 |
+| CVE | [CVE-2026-32211](https://dev.to/michael_onyekwere/cve-2026-32211-what-the-azure-mcp-server-flaw-means-for-your-agent-security-14db) (CVSS 9.1) |
+| Incident | MSRC-2026-04-03-AZUREMCP |
+
+## What it catches
+
+An `.mcp.json`, `.cursor/mcp.json`, `.vscode/mcp.json`,
+`.amazonq/mcp.json`, `mcp.json`, or any file under `.azure-mcp/`
+references an Azure MCP endpoint (host matches `*.azure.com`,
+`*.azurewebsites.net`, `*.cognitiveservices.azure.com`,
+`*.openai.azure.com`, or contains `azure-mcp` / `azure_mcp`) without
+one of the recognised auth markers:
+
+- `Authorization` header
+- `client_certificate` / `client_cert` / `mtls` marker
+- `api_key` / `x-functions-key` field
+- `DefaultAzureCredential` / `ManagedIdentity` / `WorkloadIdentity`
+- `azure_ad` / `bearer_token`
+
+CVE-2026-32211 documented the server-side default of zero auth on the
+MCP endpoint; downstream agents must add a transport-layer credential
+or risk session-hijack / tool-impersonation by anyone reachable on the
+network.
+
+## What it does NOT catch
+
+- Server-side AAK does not currently scan the Azure MCP server's own
+  config — the consumer-side check above is the load-bearing
+  detection. Server operators should bump to the patched version per
+  the MSRC advisory.
+- `.mcp.json` files that build the auth header at runtime via
+  `headers_from_env: true` or similar non-standard schemes — the
+  scanner cannot prove a header arrives at request time. Add an
+  explicit `Authorization` placeholder in the JSON to silence.
+
+## Remediation
+
+Add an `Authorization` header sourced from a managed identity token,
+mTLS cert, or vault-issued API key:
+
+```json
+{
+  "mcpServers": {
+    "azure-data": {
+      "url": "https://my-mcp.azurewebsites.net/mcp",
+      "transport": "http",
+      "headers": {
+        "Authorization": "Bearer ${AZURE_AD_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+For production deployments, prefer Azure-AD managed identities or
+workload-identity federation over static API keys.

--- a/docs/rules/AAK-LANGCHAIN-SSRF-REDIR-001.md
+++ b/docs/rules/AAK-LANGCHAIN-SSRF-REDIR-001.md
@@ -1,0 +1,106 @@
+# AAK-LANGCHAIN-SSRF-REDIR-001
+
+**Validate-then-fetch SSRF (redirects enabled past allow-list)**
+
+| Field | Value |
+|---|---|
+| Severity | HIGH |
+| Category | `TRANSPORT_SECURITY` |
+| Shipped | v0.3.5 (2026-04-25) |
+| Scanner | `agent_audit_kit/scanners/ssrf_redirect.py` |
+| CWE | CWE-601 (Open Redirect) + CWE-918 (SSRF) |
+| OWASP MCP | MCP05:2025 |
+| OWASP Agentic | ASI04, ASI09 |
+| AICM | IVS-04, AIS-08 |
+| CVE | [CVE-2026-41481](https://nvd.nist.gov/vuln/detail/CVE-2026-41481) |
+| Advisory | [GHSA-fv5p-p927-qmxr](https://advisories.gitlab.com/pypi/langchain-text-splitters/GHSA-fv5p-p927-qmxr/) |
+
+## What it catches
+
+A function calls a known SSRF guard helper
+(`validate_safe_url`, `is_safe_url`, `validateSafeUrl`, `ensure_safe_url`,
+`check_safe_url`, `ssrf_guard`, `is_url_safe`) and then fetches the same
+URL via `requests.get` / `httpx.get` / `urllib.request.urlopen` /
+`fetch` / `axios.get` / `got` without disabling redirects.
+
+The allow-list fires once on the URL the caller supplied, but
+`requests` follows 3xx by default. A 302 from an attacker-controlled
+host into `http://169.254.169.254/...`, `http://localhost`, or another
+blocked target bypasses the guard and pulls the response back into the
+calling context.
+
+CVE-2026-41481 is the canonical example: `langchain-text-splitters <
+1.1.2`'s `HTMLHeaderTextSplitter.split_text_from_url()` did exactly
+this. Same shape applies in any agent-tooling code that does
+validate→fetch without `allow_redirects=False`.
+
+## Detection
+
+The Python pass walks the AST and orders calls by source line (`ast.walk`
+is BFS, so naive walk-order would visit `requests.get` before
+`validate_safe_url` when the validator is inside an `if` and the fetch
+is on the next line). For each function:
+
+1. First call to a `_VALIDATOR_NAMES` helper sets `validator_seen=True`.
+2. Subsequent call whose attribute name is in `_FETCH_NAMES` fires the
+   rule unless one of these kwargs disables redirects:
+   - `allow_redirects=False`
+   - `follow_redirects=False`
+   - `max_redirects=0`
+   - `redirect="manual"` / `redirect="error"`
+
+The TS/JS pass is a regex pair: `_TS_VALIDATOR_RE` followed within 2 KB
+by `_TS_FETCH_RE`, suppress on `_TS_REDIRECT_OFF_RE`.
+
+The rule also ships a pin check across `requirements*.txt`,
+`pyproject.toml`, `poetry.lock`, `Pipfile.lock`, and `uv.lock` for
+`langchain-text-splitters < 1.1.2`.
+
+## What it does NOT catch
+
+- Two-statement validate/fetch where the URL flows through an
+  intermediate variable that is not the first argument to the fetch.
+  Use AAK-SSRF-TOCTOU-001 (sibling rule) for the DNS-rebind class
+  shape that does not require redirect-following.
+- Manual redirect handling that re-validates each hop. We currently
+  only check the kwargs at the fetch call site; if the caller manages
+  redirects in a loop with their own validator we cannot prove safety
+  without flow analysis. False positives here can be silenced with a
+  `# aak: ignore[AAK-LANGCHAIN-SSRF-REDIR-001]` comment.
+
+## Remediation
+
+Disable redirects at the fetch call:
+
+```python
+# Python — requests
+response = requests.get(url, allow_redirects=False, timeout=5)
+
+# Python — httpx
+response = httpx.get(url, follow_redirects=False)
+
+# Python — urllib
+opener = urllib.request.build_opener(urllib.request.HTTPRedirectHandler())
+opener.open(url)  # or override redirect_request()
+```
+
+```typescript
+// TypeScript — fetch
+const r = await fetch(url, { redirect: 'manual' });
+
+// Node — got
+const r = await got(url, { followRedirect: false });
+
+// Node — axios
+const r = await axios.get(url, { maxRedirects: 0 });
+```
+
+Or revalidate the URL on every redirect hop (tighter but more code).
+
+For `langchain-text-splitters`, bump to `>= 1.1.2`.
+
+## Sister rule
+
+[AAK-SSRF-TOCTOU-001](./AAK-SSRF-TOCTOU-001.md) covers the
+DNS-rebinding shape: validate-then-fetch-with-fresh-DNS-resolution
+(CVE-2026-41488).

--- a/docs/rules/AAK-SSRF-TOCTOU-001.md
+++ b/docs/rules/AAK-SSRF-TOCTOU-001.md
@@ -1,0 +1,91 @@
+# AAK-SSRF-TOCTOU-001
+
+**Validate-then-fetch DNS-rebind / TOCTOU on URL allow-list**
+
+| Field | Value |
+|---|---|
+| Severity | MEDIUM |
+| Category | `TRANSPORT_SECURITY` |
+| Shipped | v0.3.5 (2026-04-25) |
+| Scanner | `agent_audit_kit/scanners/ssrf_toctou.py` |
+| CWE | CWE-367 (TOCTOU) + CWE-918 (SSRF) |
+| OWASP MCP | MCP05:2025 |
+| OWASP Agentic | ASI04 |
+| AICM | IVS-04, AIS-08 |
+| CVE | [CVE-2026-41488](https://nvd.nist.gov/vuln/detail/CVE-2026-41488) |
+| Advisory | [GHSA-r7w7-9xr2-qq2r](https://advisories.gitlab.com/pypi/langchain-openai/GHSA-r7w7-9xr2-qq2r/) |
+
+## What it catches
+
+A function validates a URL via an SSRF guard, then performs a separate
+network fetch that triggers an *independent* DNS resolution. Between
+the two resolutions a malicious hostname can rotate from a public IP
+to a private/localhost/cloud-metadata IP (DNS rebinding), bypassing
+the allow-list.
+
+CVE-2026-41488 (`langchain-openai < 1.1.14`'s `_url_to_size`) is the
+canonical example. The validator did its own DNS resolution to check
+the IP, then `requests.get(url)` did a fresh resolution against the
+same hostname — long enough for the attacker's authoritative DNS
+server to flip the answer.
+
+## Detection
+
+Python AST walk, calls sorted by source line. For each function:
+
+1. First call to `_VALIDATOR_NAMES` sets `validator_seen`.
+2. Subsequent call whose attribute is in `_FETCH_NAMES` fires the rule
+   unless an IP-pinning marker is reachable in the same function:
+   - `socket.getaddrinfo`
+   - `HTTPAdapter` / `requests.adapters.HTTPAdapter`
+   - `session.mount` / `session.get_adapter`
+   - `resolved_ip`, `pinned_ip`, `resolved_host`, `resolve_once`,
+     `dns_pin`, `host_header_pin`
+
+The pin check covers `langchain-openai < 1.1.14` across
+`requirements*.txt`, `pyproject.toml`, `poetry.lock`, `Pipfile.lock`,
+`uv.lock`.
+
+## What it does NOT catch
+
+- Cross-function flow where the validator runs in one helper and the
+  fetch in another — we look only within a single function body.
+  Refactor to consolidate, or silence with
+  `# aak: ignore[AAK-SSRF-TOCTOU-001]` if the cross-function design
+  has its own TTL-bounded DNS pin.
+- Any pattern AAK-LANGCHAIN-SSRF-REDIR-001 already catches — when both
+  rules would fire on the same code, the redirect-bypass rule wins
+  by being CRITICAL-class.
+
+## Remediation
+
+Resolve once, pin the IP, reuse the pinned `Session`:
+
+```python
+import socket
+import requests
+from requests.adapters import HTTPAdapter
+
+def url_to_size(url: str) -> int:
+    if not validate_safe_url(url):
+        raise ValueError("unsafe url")
+    # Resolve ONCE.
+    resolved_ip = socket.getaddrinfo(url, 443)[0][4][0]
+    # Reuse the resolved IP for the fetch.
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter())
+    response = session.get(
+        url,
+        headers={"Host": resolved_ip},
+        timeout=5,
+    )
+    return len(response.content)
+```
+
+For `langchain-openai`, bump to `>= 1.1.14`.
+
+## Sister rule
+
+[AAK-LANGCHAIN-SSRF-REDIR-001](./AAK-LANGCHAIN-SSRF-REDIR-001.md)
+covers the redirect-bypass shape: validate-then-fetch-with-redirects
+(CVE-2026-41481).

--- a/docs/rules/AAK-TOXICFLOW-001.md
+++ b/docs/rules/AAK-TOXICFLOW-001.md
@@ -1,0 +1,85 @@
+# AAK-TOXICFLOW-001
+
+**Toxic flow: sensitive source paired with external sink**
+
+| Field | Value |
+|---|---|
+| Severity | HIGH |
+| Category | `TOOL_POISONING` |
+| Shipped | v0.3.5 (2026-04-25) — **feature-flagged** |
+| Scanner | `agent_audit_kit/scanners/toxic_flow.py` |
+| Data | `agent_audit_kit/data/toxic_flow_pairs.yml` |
+| OWASP MCP | MCP06:2025 |
+| OWASP Agentic | ASI02, ASI09 |
+| AICM | AIS-12, CCC-08 |
+| Origin | [Snyk Agent Scan](https://github.com/snyk/agent-scan) parity |
+
+## Feature-flag status
+
+This rule is **off by default in v0.3.5**. Set `AAK_TOXIC_FLOW=1` in
+the environment to opt in. The full deny-graph design review queues
+for v0.4.0; the v0.3.5 surface is a starter pair-set sufficient for
+field validation.
+
+## What it catches
+
+An agent project exposes both a sensitive source tool (filesystem
+read, secrets read, database query) and an external sink tool
+(HTTP POST, email send, git push, shell exec). Even if each tool is
+individually safe, the LLM can chain them — the canonical exfiltration
+pattern is `read_file -> http.post`.
+
+The scanner builds a per-scan tool graph from:
+
+- MCP server names + arg strings in `.mcp.json` /
+  `.cursor/mcp.json` / `.vscode/mcp.json` / `.amazonq/mcp.json` /
+  `mcp.json`
+- Function names of `@tool` / `@mcp.tool` / `@server.tool` decorated
+  Python functions in the repo
+
+Tool identifiers are matched against `agent_audit_kit/data/toxic_flow_pairs.yml`
+which lists known source families (`fs_read`, `secrets_read`,
+`db_query`) and sink families (`http_post`, `email_send`, `git_push`,
+`shell_exec`) plus the pairs that fire.
+
+## Suppression
+
+Add the source/sink pair to `.aak-toxic-flow-trust.yml` with a
+non-empty `justification:`:
+
+```yaml
+trust:
+  - source: fs_read
+    sink: http_post
+    justification: "Documented data-export feature; sink is allow-listed in egress proxy."
+```
+
+A trust entry without a justification does **not** suppress (we want
+the audit trail to carry the reason, not just the decision).
+
+## What it does NOT catch
+
+- Implicit toxic flows where the LLM bridges two non-tool capabilities
+  (e.g. system-prompt context + a shell pipe). Prompt-level controls
+  belong elsewhere.
+- Pairs not yet enumerated in `toxic_flow_pairs.yml`. Submit a PR
+  with the new family + cite the canonical incident.
+- Tool calls inside other-language repos (TS / Java / Rust). v0.3.5
+  walks Python decorators only; multi-language graph queues for v0.4.0.
+
+## Remediation
+
+Three knobs, in priority order:
+
+1. **Remove the pairing.** Drop the source or the sink if the agent
+   does not actually need both at once.
+2. **Scope the source.** Restrict `fs_read` / `db_query` to a
+   directory or schema the sink cannot reach.
+3. **Allow-list with justification.** Add the pair to
+   `.aak-toxic-flow-trust.yml` and document the egress controls that
+   make the chain safe.
+
+## Roadmap
+
+- v0.4.0: full deny-graph DR + multi-language tool discovery + TUI
+  visualization (`agent-audit-kit toxic-flow --explain`).

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -1,0 +1,27 @@
+# Rule reference
+
+Per-rule pages for the AAK rule registry. The canonical source of truth
+is `agent_audit_kit/rules/builtin.py` — these pages exist to give
+operators a click-through reference with the full description, the
+remediation recipe, and the linked CVE/OWASP/AICM mapping.
+
+The pages are written by hand for high-traffic rules (CVE-driven, public
+SLA) and from `RuleDefinition` data for the rest. v0.3.5 ships the
+first batch — expect coverage to fill in over subsequent releases.
+
+## v0.3.5 (2026-04-25) — net-new
+
+| Rule | Severity | Class | CVE / source |
+|---|---|---|---|
+| [AAK-LANGCHAIN-SSRF-REDIR-001](./AAK-LANGCHAIN-SSRF-REDIR-001.md) | HIGH | TRANSPORT_SECURITY | [CVE-2026-41481](https://nvd.nist.gov/vuln/detail/CVE-2026-41481) |
+| [AAK-SSRF-TOCTOU-001](./AAK-SSRF-TOCTOU-001.md) | MEDIUM | TRANSPORT_SECURITY | [CVE-2026-41488](https://nvd.nist.gov/vuln/detail/CVE-2026-41488) |
+| [AAK-AZURE-MCP-001](./AAK-AZURE-MCP-001.md) | HIGH | MCP_CONFIG | [CVE-2026-32211](https://dev.to/michael_onyekwere/cve-2026-32211-what-the-azure-mcp-server-flaw-means-for-your-agent-security-14db) |
+| [AAK-TOXICFLOW-001](./AAK-TOXICFLOW-001.md) | HIGH | TOOL_POISONING | Snyk Agent Scan parity (feature-flagged) |
+
+## Coverage
+
+Full rule list with one-line descriptions: [docs/rules.md](../rules.md).
+
+OWASP Agentic Top 10 2026 mapping: [docs/owasp-agentic-coverage.md](../owasp-agentic-coverage.md).
+
+OWASP MCP Top 10 mapping: [docs/owasp-mapping.md](../owasp-mapping.md).

--- a/releases/v0.3.5.md
+++ b/releases/v0.3.5.md
@@ -1,0 +1,110 @@
+# AgentAuditKit v0.3.5 — release notes
+
+**Released:** 2026-04-25 14:39 UTC
+**Tag:** `v0.3.5`
+**Rule count:** 161 (was 157)
+**Test count:** 772 (was 749)
+**Predecessor:** [v0.3.4](https://github.com/sattyamjjain/agent-audit-kit/releases/tag/v0.3.4) (2026-04-24)
+
+## Headline
+
+LangChain SSRF redirect bypass (CVE-2026-41481), URL-allow-list TOCTOU
+/ DNS rebinding (CVE-2026-41488), Azure MCP missing-auth (CVE-2026-32211),
+toxic-flow source/sink scanner (Snyk Agent Scan parity, feature-flagged),
+pre-commit `rev:` pin sync, GitHub verified-creator application packet.
+
+CVE-response SLA met within 48h on both watcher-filed issues (#61, #62).
+
+## What's new
+
+### Rules (4 new)
+
+| Rule | Severity | Class | CVE / source |
+|---|---|---|---|
+| `AAK-LANGCHAIN-SSRF-REDIR-001` | HIGH | TRANSPORT_SECURITY | CVE-2026-41481 |
+| `AAK-SSRF-TOCTOU-001` | MEDIUM | TRANSPORT_SECURITY | CVE-2026-41488 |
+| `AAK-AZURE-MCP-001` | HIGH | MCP_CONFIG | CVE-2026-32211 |
+| `AAK-TOXICFLOW-001` | HIGH | TOOL_POISONING | Snyk Agent Scan parity (off by default) |
+
+Per-rule docs:
+- [AAK-LANGCHAIN-SSRF-REDIR-001](../docs/rules/AAK-LANGCHAIN-SSRF-REDIR-001.md)
+- [AAK-SSRF-TOCTOU-001](../docs/rules/AAK-SSRF-TOCTOU-001.md)
+- [AAK-AZURE-MCP-001](../docs/rules/AAK-AZURE-MCP-001.md)
+- [AAK-TOXICFLOW-001](../docs/rules/AAK-TOXICFLOW-001.md)
+
+### Scanners (3 new + 1 extension)
+
+- `agent_audit_kit/scanners/ssrf_redirect.py` — Python AST + TS/JS
+  regex. Calls sorted by source line so BFS-walk doesn't reorder
+  fetch-before-guard.
+- `agent_audit_kit/scanners/ssrf_toctou.py` — Python AST. Suppresses
+  on IP-pinning markers (`socket.getaddrinfo`, `HTTPAdapter`,
+  `pinned_ip`, `Host:` header pin).
+- `agent_audit_kit/scanners/toxic_flow.py` — per-scan tool graph
+  from `.mcp.json` + `@tool`-decorated functions. Behind
+  `AAK_TOXIC_FLOW=1` feature flag.
+- `agent_audit_kit/scanners/supply_chain.py` — extended with
+  `_check_azure_mcp_auth`.
+
+### Release infrastructure
+
+- `scripts/sync_repo_metadata.py` extended with `_PRECOMMIT_BLOCK_RE`
+  — rewrites `rev: vX.Y.Z` lines under `repo: …/agent-audit-kit`
+  only. New regression test `test_pre_commit_rev_pin_matches_version`
+  fences README + docs.
+- `docs/launch/github-verified-creator-application.md` — pre-filled
+  application packet for the GitHub Marketplace verified-creator
+  badge.
+
+### Issue closures
+
+- **#61** — CVE-response: CVE-2026-41481 → AAK-LANGCHAIN-SSRF-REDIR-001
+- **#62** — CVE-response: CVE-2026-41488 → AAK-SSRF-TOCTOU-001
+- **#27** — Sigstore signatures missing from Release assets
+  (resolved as of v0.3.5; bundles `rules.json.sigstore.json`,
+  `sbom.cdx.json.sigstore.json`, `sbom.spdx.json.sigstore.json` ship
+  on every release)
+
+### v0.4.0 tracking issues opened
+
+- **#64** — P1: Hosted aak.dev SARIF dashboard
+- **#65** — P2: Pre-commit one-liner installer
+- **#66** — P3: Slack / PagerDuty / Linear webhook
+- **#67** — P4: Public OWASP coverage leaderboard
+- **#68** — P5: `aak suggest-fix` auto-PR mode
+
+## Verification
+
+```bash
+pip install agent-audit-kit==0.3.5
+agent-audit-kit --version  # 0.3.5
+
+# Sigstore verify the rule bundle
+pip install sigstore
+sigstore verify identity \
+  --cert-identity https://github.com/sattyamjjain/agent-audit-kit/.github/workflows/release.yml@refs/tags/v0.3.5 \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com \
+  --bundle rules.json.sigstore.json \
+  rules.json
+```
+
+## Distribution
+
+- **PyPI:** `pip install agent-audit-kit==0.3.5` (OIDC trusted-publisher)
+- **GHCR:** `docker pull ghcr.io/sattyamjjain/agent-audit-kit:0.3.5`
+- **GitHub Marketplace:** Action listing auto-bumps from `action.yml`
+- **GitHub Release:** [v0.3.5](https://github.com/sattyamjjain/agent-audit-kit/releases/tag/v0.3.5) with 7 assets (rules + sha256 + 3 sigstore bundles + 2 SBOMs)
+
+## Acknowledgements
+
+The CVE-watcher pipeline auto-filed issues #61 and #62 within minutes
+of NVD disclosure on 2026-04-25 03:32 UTC. The 48h SLA-watcher-dedup
+from v0.3.3 is what made same-day shipping safe — every CVE in this
+release was tracked end-to-end with no duplicate issue churn.
+
+## What's next
+
+v0.4.0 will land the five product-surface features tracked at #64–#68
+(hosted dashboard, one-liner installer, webhook integrations, public
+coverage leaderboard, auto-PR fixes). CSA MCP Security Baseline v1.0
+mapping remains deferred pending public RC1.


### PR DESCRIPTION
## Summary

Closes the v3.6 wrap-up checklist items missed during the v0.3.5 cut.
Docs + meta only — no code, no version bump.

## What lands

- `docs/rules/` (new dir) with per-rule pages for the 4 v0.3.5 rules + index:
  - `AAK-LANGCHAIN-SSRF-REDIR-001.md` (CVE-2026-41481)
  - `AAK-SSRF-TOCTOU-001.md` (CVE-2026-41488)
  - `AAK-AZURE-MCP-001.md` (CVE-2026-32211)
  - `AAK-TOXICFLOW-001.md` (Snyk parity, feature-flagged)
- `releases/v0.3.5.md` — long-form release note (verified-creator artefact).

## Already executed (linked from this PR)

- **Closes #27** — Sigstore signatures missing from Release assets. v0.3.5 ships `rules.json.sigstore.json` + 2 SBOM sigstore bundles. Issue closed at commit-time with evidence.
- **Tracking opened for v0.4.0 (#64–#68)** — P1 hosted dashboard, P2 pre-commit installer, P3 Slack/PD/Linear webhook, P4 OWASP leaderboard, P5 aak suggest-fix auto-PR.

## Test plan

- [x] `pytest` unchanged from v0.3.5 — 772 passed (no code touched).
- [x] Doc cross-links resolve (relative paths under `docs/rules/`).
- [x] No `[TODO]` / `[REPLACE]` / `[FIXME]` markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)