### PR TITLE
v0.3.7 — release-mechanics patch (Dockerfile + ignore_paths fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to AgentAuditKit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7] - 2026-04-26
+
+**Headline: critical Action / Dockerfile fix — published v0.3.6 was
+unwriteable for every consumer; v0.3.7 makes the GitHub Marketplace
+listing actually work.**
+
+No new rules. No new scanners. v0.3.7 is a release-mechanics patch:
+the Dockerfile fix is load-bearing for any consumer who ran the
+Action from Marketplace and hit `Permission denied:
+'agent-audit-results.sarif'`. Engine ignore_paths fix lands at the
+same time so `--ignore-paths` finally works the way the docs claim.
+
+### Fixed
+
+- **Critical: Docker container ran as `USER scanner`** (UID 999) but
+  `/github/workspace` is mounted from the runner's checkout owned by
+  the runner UID; the container could not write the SARIF output.
+  Every consumer of `sattyamjjain/agent-audit-kit@v0.3.6` (and
+  earlier) saw `Permission denied: 'agent-audit-results.sarif'`.
+  Surfaced via the new dogfood self-scan workflow (PR #71) — the
+  loop validates that what we publish actually runs end-to-end.
+  Dropped the `USER scanner` directive; container isolation, not
+  in-container UID, is the load-bearing security boundary for an
+  ephemeral GitHub Docker Action.
+- **`engine.run_scan` now applies `--ignore-paths` globally** instead
+  of only via the `secret_exposure` scanner kwarg. Every scanner now
+  honours the flag. 5 new tests in `tests/test_engine_ignore_paths.py`
+  fence the behaviour (subpath match, prefix-not-substring, exact
+  file match, trailing-slash insensitivity, multi-scanner suppression).
+
+### Added — release infrastructure
+
+- `.github/workflows/self-scan.yml` — runs the local Action against
+  this repo on every push / PR. `default-scan` job (full ruleset,
+  `fail-on: critical`) plus `preset-mcp-ox-2026-04` job that
+  exercises the `--preset` input end-to-end.
+
+### Upgrade impact
+
+- **Anyone using `sattyamjjain/agent-audit-kit@v0.3.6`** should bump
+  to `@v0.3.7` immediately. v0.3.6 silently failed to produce SARIF
+  output. Workflow YAML is otherwise compatible — no input/output
+  changes.
+
 ## [0.3.6] - 2026-04-26
 
 **Headline: OX MCP STDIO architectural class — Python/TS/Java/Rust SDK

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.6
+      - uses: sattyamjjain/agent-audit-kit@v0.3.7
         with:
           fail-on: high
 ```
@@ -79,7 +79,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.6
+    rev: v0.3.7
     hooks:
       - id: agent-audit-kit
 ```

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,5 +1,5 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.6"
+__version__ = "0.3.7"
 RULE_COUNT = 169

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.6
+    rev: v0.3.7
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.6
+    rev: v0.3.7
     hooks:
       - id: agent-audit-kit
 ```

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -91,7 +91,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.6
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.7
 >
 > Apache 2.0. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.6
+- uses: sattyamjjain/agent-audit-kit@v0.3.7
   with:
     preset: mcp-ox-2026-04
 ```

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-04-26T05:29:14Z",
-  "aak_version": "0.3.6",
+  "last_updated": "2026-04-26T05:39:18Z",
+  "aak_version": "0.3.7",
   "rule_count": 169,
   "coverage": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.6"
+version = "0.3.7"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/releases/v0.3.7.md
+++ b/releases/v0.3.7.md
@@ -1,0 +1,72 @@
+# AgentAuditKit v0.3.7 — release notes
+
+**Released:** 2026-04-26
+**Tag:** `v0.3.7`
+**Rule count:** 169 (unchanged from v0.3.6)
+**Test count:** 810 (was 805)
+**Predecessor:** [v0.3.6](https://github.com/sattyamjjain/agent-audit-kit/releases/tag/v0.3.6) (2026-04-26)
+
+## Headline
+
+**Critical Action fix.** v0.3.6 was unwriteable on `/github/workspace`
+for every Marketplace consumer — `Permission denied:
+'agent-audit-results.sarif'` on the SARIF write. v0.3.7 makes the
+published Action actually work.
+
+This is a release-mechanics patch. No new rules. No new scanners.
+
+## What changed
+
+### Fixed
+
+- **Dockerfile dropped `USER scanner`.** Container now runs as root,
+  matching the standard pattern for GitHub Docker Actions
+  (`actions/*` and the rest of the Marketplace). Container isolation
+  is the security boundary; in-container UID is not.
+  Surfaced via the new dogfood self-scan workflow (PR #71) — the
+  feedback loop now catches this class of bug pre-merge.
+- **`engine.run_scan` applies `--ignore-paths` globally.** Previously
+  only the `secret_exposure` scanner consumed the kwarg; every other
+  scanner returned findings from explicitly-excluded directories.
+  Centralised the filter post-scan so every scanner honours the flag.
+
+### Added
+
+- `.github/workflows/self-scan.yml` — runs the local Action against
+  this repo on every push / PR with `fail-on: critical`. Two jobs:
+  `default-scan` and `preset-mcp-ox-2026-04` (validates the
+  `--preset` input end-to-end).
+- 5 new tests in `tests/test_engine_ignore_paths.py`.
+
+### Caveat
+
+The `USER scanner` directive shipped in every release back to v0.2.0.
+If you've been running AAK from `pip install` or directly with
+`agent-audit-kit scan ...` (CLI), nothing changed for you — the bug
+was specific to the Docker GitHub Action. If you're on the
+Marketplace `uses: sattyamjjain/agent-audit-kit@v0.3.x`, **bump to
+v0.3.7**; v0.3.6 and earlier silently failed before the SARIF upload
+step.
+
+## Verification
+
+```bash
+pip install agent-audit-kit==0.3.7
+agent-audit-kit --version  # 0.3.7
+
+# Sigstore verify
+pip install sigstore
+sigstore verify identity \
+  --cert-identity https://github.com/sattyamjjain/agent-audit-kit/.github/workflows/release.yml@refs/tags/v0.3.7 \
+  --cert-oidc-issuer https://token.actions.githubusercontent.com \
+  --bundle rules.json.sigstore.json \
+  rules.json
+```
+
+## What's next
+
+After v0.3.7 the team commits to the dogfood-workflow gate as
+permanent CI. Any future regression to the published Action surface
+(Dockerfile, action.yml inputs, entrypoint.sh argv) fails CI on the PR
+that introduces it. Net-new product surfaces (#64–#68) become the
+v0.4.0 focus.

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.6"
+    assert __version__ == "0.3.7"


### PR DESCRIPTION
## Summary

Release-mechanics patch. **No new rules. No new scanners.** v0.3.7 ships the two critical fixes that landed in PR #71 to a Marketplace tag:

1. **Dockerfile** drops `USER scanner` — v0.3.6 was unwriteable on `/github/workspace` for every consumer (`Permission denied: 'agent-audit-results.sarif'`)
2. **`engine.run_scan`** applies `--ignore-paths` globally — previously only `secret_exposure` honoured it

## Why a fast-follow release

The Dockerfile bug means anyone who installed `sattyamjjain/agent-audit-kit@v0.3.6` from the Marketplace silently failed before SARIF upload. That's worse than not shipping at all (their CI is "passing" but the Action produced no findings). v0.3.7 makes the Marketplace listing actually work.

## What's NOT in this PR

- New rules — none
- New scanners — none
- API changes — none (workflow YAML compatible with v0.3.6)

## Verified

- pytest — 810 passed (matches v0.3.6 + the 5 new ignore_paths tests already merged in #71)
- ruff clean
- README / docs `@v0.3.7` pin propagated via `scripts/sync_repo_metadata.py`
- `releases/v0.3.7.md` written
- The new dogfood self-scan workflow runs against this PR's Dockerfile + entrypoint, so the Action surface is exercised end-to-end pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)