### PR TITLE
fix(v0.3.9): bump pyproject.toml version 0.3.8 → 0.3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.8
+      - uses: sattyamjjain/agent-audit-kit@v0.3.9
         with:
           fail-on: high
 ```
@@ -79,7 +79,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.8
+    rev: v0.3.9
     hooks:
       - id: agent-audit-kit
 ```

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.8
+    rev: v0.3.9
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.8
+    rev: v0.3.9
     hooks:
       - id: agent-audit-kit
 ```

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -91,7 +91,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.8
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.9
 >
 > Apache 2.0. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.8
+- uses: sattyamjjain/agent-audit-kit@v0.3.9
   with:
     preset: mcp-ox-2026-04
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.8"
+version = "0.3.9"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}
@@ -51,9 +51,6 @@ Issues = "https://github.com/sattyamjjain/agent-audit-kit/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["agent_audit_kit"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"agent_audit_kit/data" = "agent_audit_kit/data"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Missed `pyproject.toml` version bump in the v0.3.9 commit; the merged main has `__init__.py` at 0.3.9 but pyproject still says 0.3.8.
- PyPI publish in the release workflow rejected the build with `400 Bad Request` because the wheel was tagged `agent_audit_kit-0.3.8-py3-none-any.whl` (0.3.8 already exists from yesterday's release).
- Drop the redundant `force-include data/` directive from the hatch wheel target — hatch already picks up `agent_audit_kit/data/` because `packages = ["agent_audit_kit"]` includes the entire package tree. The duplicate caused `Duplicate name` warnings during `python -m build`.

After this merges, the v0.3.9 tag will be moved to the new HEAD and the release workflow re-run.

## Test plan

- [x] `python3 -m build --wheel` produces `agent_audit_kit-0.3.9-py3-none-any.whl` cleanly with no duplicate-name warnings
- [x] `unzip -l` confirms `agent_audit_kit/data/ox-cve-manifest.json` is included
- [x] No other `0.3.8` strings in `pyproject.toml`, `__init__.py`, or `action.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)