### PR TITLE
feat(agent-audit-kit): v0.3.23 — per-category README anchors + sync (81-rule drift fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to AgentAuditKit are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.23] - 2026-05-20
+
+**Headline: README per-category anchor sync — closes the 81-rule
+undercount the "What It Scans" table was carrying against the live
+registry (no rule changes; docs + sync-script + regression test).**
+
+### Fixed — Documentation drift (docs-only)
+
+- **README "What It Scans" table** — at v0.3.22 ship the table summed
+  to **124 rules** vs the registry's 205 (badge + `RULE_COUNT` were
+  correct; only the per-category cells drifted). Every category cell
+  was undercount; Supply Chain alone was off by +28. Each of the 11
+  category rows now carries an HTML anchor in the form
+  `<!-- category-count:CATEGORY_NAME -->NN<!-- /category-count -->`
+  (matching the live `Category` enum name verbatim), and the prose
+  has been refreshed to mention every rule shipped through this week
+  (Tasks-primitive leakage, OAuth 2.1 DPoP, OX MCP-STDIO command
+  injection, `apache-doris-mcp-server`, `excel-mcp-server`, MCP
+  Calculate Server, Project Deal economic-drift, Metis POMDP,
+  SkillsVote attribution, Code-as-Harness, MCP Inspector vendored
+  fork, DNS-rebinding, transport-flip MITM, etc.).
+
+### Added — Tooling
+
+- **`scripts/sync_rule_count.py`** now also rewrites every
+  `<!-- category-count:NAME -->NN<!-- /category-count -->` anchor in
+  README in lockstep with the registry, and exits 1 with a typo guard
+  if the README references a `Category` enum name the registry does
+  not have. Regex character class is `[A-Z0-9_]+` so `A2A_PROTOCOL`
+  matches (the digit was load-bearing — the regression test below
+  caught a silent skip).
+
+- **`tests/test_repo_metadata_sync.py::test_readme_per_category_anchors_match_registry`** —
+  new regression test that locks every per-category anchor to
+  `Counter(r.category.name for r in RULES.values())` and asserts the
+  sum matches the live total. Future drift will fail CI rather than
+  ship undetected.
+
+### Why this is a separate release
+
+The v0.3.22 release notes already shipped — the table drift is
+docs-only, but it materially understates how much surface the
+scanner covers (124 vs 205). Re-tagging today fixes the public
+README without rewriting v0.3.22 history.
+
+---
+
 ## [0.3.22] - 2026-05-20
 
 **Headline: 2 new research-grade MEDIUM rules (205 total) anchored

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.22
+      - uses: sattyamjjain/agent-audit-kit@v0.3.23
         with:
           fail-on: high
 ```
@@ -81,7 +81,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.22
+    rev: v0.3.23
     hooks:
       - id: agent-audit-kit
 ```
@@ -105,17 +105,17 @@ agent-audit-kit scan examples/vulnerable-configs/04-hook-exfiltration/
 
 | Category | Rules | What It Detects |
 |----------|:-----:|-----------------|
-| **MCP Configuration** | 33 | Missing auth middleware (CVE-2026-33032 class), empty IP allowlists, wildcard CORS, path traversal in resource handlers, SSRF (CWE-918), OAuth 2.1 misconfig (PKCE/S256/DPoP), Tasks primitive leakage (SEP-1686), shell injection |
-| **Tool Poisoning** | 14 | Invisible Unicode / bidi, skill frontmatter injection, SKILL.md post-install commands, data-exfil primitives, skill name hijacking, cross-tool references, rug-pull (SHA-256 pinning) |
-| **Hook Injection** | 12 | Hook RCE (CVE-2025-59536 class), `shell=True` + interpolation, pre-trust execution, network-capable hooks, credential exfiltration |
-| **Supply Chain** | 12 | Vulnerable LangChain versions (CVE-2026-34070, CVE-2025-68664), marketplace.json signatures / permissions / typosquat / mutable refs, unpinned packages, dangerous install scripts |
-| **A2A Protocol** | 12 | Missing mutual auth, unbounded delegation, transitive trust, replay protection, schema confusion, HTTP endpoints, JWT lifetime/validation, impersonation |
-| **Secret Exposure** | 9 | Anthropic/OpenAI/AWS/GitHub/GitLab/GCP keys, Shannon-entropy detection, `.env` leaks, private-key files |
-| **Agent Config** | 9 | Routines permission escalation + schedule injection + audit-log gaps, AGENTS.md/CLAUDE.md/.cursorrules hijacking, hidden Unicode, encoded payloads, internal scanner-fail signal |
-| **Taint Analysis** | 9 | `@tool` param flows to shell/eval/SQL/SSRF/file/deserialization sinks (Python AST), `load_prompt()` user-path reachability |
-| **Trust Boundaries** | 7 | `enableAllProjectMcpServers`, API URL redirects, wildcard permissions, missing deny rules, missing allowlists |
-| **Transport Security** | 4 | HTTP endpoints, TLS disabled, deprecated SSE, tokens in URL query strings |
-| **Legal Compliance** | 3 | Copyleft licenses (AGPL/SSPL), missing licenses, DMCA-flagged packages |
+| **MCP Configuration** | <!-- category-count:MCP_CONFIG -->38<!-- /category-count --> | Missing auth middleware (CVE-2026-33032 class), empty IP allowlists, wildcard CORS, path traversal in resource handlers, SSRF (CWE-918), OAuth 2.1 misconfig (PKCE/S256/DPoP), Tasks primitive leakage (SEP-1686), shell injection, MCPwn middleware-asymmetry, Azure MCP no-auth (CVE-2026-32211), MCP Inspector vendored fork (CVE-2026-23744) |
+| **Supply Chain** | <!-- category-count:SUPPLY_CHAIN -->40<!-- /category-count --> | Vulnerable LangChain / langchain-text-splitters versions, named pin rules for `astro-mcp-server` / `chatgpt-mcp-server` / `docsgpt` / `gpt-researcher` / `litellm` / `mcp-calculate-server` / `semantic-kernel` / `@anthropic-ai/claude-code` / `apache-doris-mcp-server` / `excel-mcp-server`, OX MCP-STDIO command-injection (Python/TS/Java/Rust) — `AAK-MCP-STDIO-CMD-INJ-001..004` — Stainless-generator lineage, marketplace.json signatures / typosquat / mutable refs, unpinned packages, dangerous install scripts |
+| **Tool Poisoning** | <!-- category-count:TOOL_POISONING -->26<!-- /category-count --> | Invisible Unicode / bidi, skill frontmatter injection, SKILL.md post-install commands, data-exfil primitives, skill name hijacking, cross-tool references, rug-pull (SHA-256 pinning), `@mcp.tool` unsafe-eval (CVE-2026-44717 generalization), OpenAPI smells (Hermes paper LAZY/BLOATED/TANGLED), Metis POMDP refusal-refeed + scoring-sink, SkillsVote lifecycle attribution, MCP Calculate Server pin |
+| **Secret Exposure** | <!-- category-count:SECRET_EXPOSURE -->17<!-- /category-count --> | Anthropic/OpenAI/AWS/GitHub/GitLab/GCP keys, Shannon-entropy detection, `.env` leaks, private-key files, hardcoded credential surface, token-leak via log sinks (CVE-2026-20205) |
+| **Agent Config** | <!-- category-count:AGENT_CONFIG -->15<!-- /category-count --> | Routines permission escalation + schedule injection + audit-log gaps, AGENTS.md/CLAUDE.md/.cursorrules hijacking, hidden Unicode, encoded payloads, internal scanner-fail signal, Project Deal economic-drift detection |
+| **A2A Protocol** | <!-- category-count:A2A_PROTOCOL -->13<!-- /category-count --> | Missing mutual auth, unbounded delegation, transitive trust, replay protection, schema confusion, HTTP endpoints, JWT lifetime/validation, impersonation, multi-agent shared-state without lock (Code-as-Harness) |
+| **Hook Injection** | <!-- category-count:HOOK_INJECTION -->12<!-- /category-count --> | Hook RCE (CVE-2025-59536 class), `shell=True` + interpolation, pre-trust execution, network-capable hooks, credential exfiltration |
+| **Taint Analysis** | <!-- category-count:TAINT_ANALYSIS -->12<!-- /category-count --> | `@tool` param flows to shell/eval/SQL/SSRF/file/deserialization sinks (Python AST), `load_prompt()` user-path reachability, transport-flip MITM (DocsGPT + GPT-Researcher) |
+| **Transport Security** | <!-- category-count:TRANSPORT_SECURITY -->11<!-- /category-count --> | HTTP endpoints, TLS disabled, deprecated SSE, tokens in URL query strings, transport body-size limits (CVE-2026-39313), SSRF redirect bypass (CVE-2026-41481), DNS-rebinding (CVE-2025-66414/66416, CVE-2026-35568/35577) |
+| **Legal Compliance** | <!-- category-count:LEGAL_COMPLIANCE -->11<!-- /category-count --> | Copyleft licenses (AGPL/SSPL), missing licenses, DMCA-flagged packages, India PII surface, US-state consumer privacy (Alabama HB 351, Tennessee SB 1580), Singapore Agentic AI, healthcare AI triggers |
+| **Trust Boundaries** | <!-- category-count:TRUST_BOUNDARY -->10<!-- /category-count --> | `enableAllProjectMcpServers`, API URL redirects, wildcard permissions, missing deny rules, missing allowlists, Claude Code folder-trust bypass (CVE-2026-40068) |
 
 **<!-- rule-count:total -->205<!-- /rule-count --> rules total.** Every finding includes severity, evidence, remediation, OWASP references, Adversa references, and CVE links where applicable.
 

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,6 +1,6 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.22"
+__version__ = "0.3.23"
 RULE_COUNT = 205
 SCANNER_COUNT = 65

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.22
+    rev: v0.3.23
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.22
+    rev: v0.3.23
     hooks:
       - id: agent-audit-kit
 ```

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -91,7 +91,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.22
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.23
 >
 > Apache 2.0. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.22
+- uses: sattyamjjain/agent-audit-kit@v0.3.23
   with:
     preset: mcp-ox-2026-04
 ```

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-05-20T14:00:01Z",
-  "aak_version": "0.3.22",
+  "last_updated": "2026-05-20T17:43:52Z",
+  "aak_version": "0.3.23",
   "rule_count": 205,
   "coverage": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.22"
+version = "0.3.23"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/sync_rule_count.py
+++ b/scripts/sync_rule_count.py
@@ -45,10 +45,27 @@ _README_ANCHOR_RE = re.compile(
     r"(<!--\s*rule-count:total\s*-->)(.*?)(<!--\s*/rule-count\s*-->)",
     re.DOTALL,
 )
+# Per-category anchors added v0.3.23 to fix the "What It Scans" table
+# drifting independently of the total badge (the table sum was 81 rules
+# under-counted before the anchors landed). Each anchor matches the
+# Category enum name verbatim — e.g. `<!-- category-count:SUPPLY_CHAIN -->`.
+# NOTE: must include `0-9` — `A2A_PROTOCOL` would otherwise be silently
+# skipped, which is exactly the bug the v0.3.23 regression test caught.
+_README_CATEGORY_ANCHOR_RE = re.compile(
+    r"(<!--\s*category-count:([A-Z0-9_]+)\s*-->)(.*?)(<!--\s*/category-count\s*-->)",
+    re.DOTALL,
+)
 _INIT_CONSTANT_RE = re.compile(
     r"^(RULE_COUNT\s*[:=]\s*)\d+(.*)$",
     re.MULTILINE,
 )
+
+
+def _category_counts() -> dict[str, int]:
+    """Group the live rule registry by Category.name → count."""
+    from collections import Counter
+    from agent_audit_kit.rules.builtin import RULES
+    return {cat.name: n for cat, n in Counter(r.category for r in RULES.values()).items()}
 
 
 def _load_rule_count(bundle: pathlib.Path, regenerate: bool) -> int:
@@ -67,6 +84,7 @@ def _load_rule_count(bundle: pathlib.Path, regenerate: bool) -> int:
 
 def _update_readme(count: int, *, check: bool) -> bool:
     """Rewrite the badge URL + every `<!-- rule-count:total -->...<!-- /rule-count -->`
+    anchor + every `<!-- category-count:NAME -->...<!-- /category-count -->`
     anchor. Also keep the shields alt-text in lockstep with the badge."""
     readme = REPO_ROOT / "README.md"
     text = readme.read_text(encoding="utf-8")
@@ -74,10 +92,27 @@ def _update_readme(count: int, *, check: bool) -> bool:
     text = _README_BADGE_RE.sub(rf"\g<1>{count}\g<2>", text)
     text = re.sub(r"alt=\"Rules:\s*\d+\"", f'alt="Rules: {count}"', text)
 
-    def _sub_anchor(match: re.Match) -> str:
+    def _sub_total_anchor(match: re.Match) -> str:
         return f"{match.group(1)}{count}{match.group(3)}"
 
-    text = _README_ANCHOR_RE.sub(_sub_anchor, text)
+    text = _README_ANCHOR_RE.sub(_sub_total_anchor, text)
+
+    # Per-category anchors — fail loudly if the README references a
+    # Category name the registry doesn't have. That catches typos and
+    # stops the table from claiming a category that no longer exists.
+    cat_counts = _category_counts()
+
+    def _sub_category_anchor(match: re.Match) -> str:
+        cat_name = match.group(2)
+        if cat_name not in cat_counts:
+            raise SystemExit(
+                f"sync_rule_count: README references unknown category "
+                f"`{cat_name}` — valid Category enum names: "
+                f"{sorted(cat_counts.keys())}"
+            )
+        return f"{match.group(1)}{cat_counts[cat_name]}{match.group(4)}"
+
+    text = _README_CATEGORY_ANCHOR_RE.sub(_sub_category_anchor, text)
     if text == original:
         return False
     if check:

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.22"
+    assert __version__ == "0.3.23"

--- a/tests/test_repo_metadata_sync.py
+++ b/tests/test_repo_metadata_sync.py
@@ -144,3 +144,46 @@ def test_scanner_count_check_mode_passes_on_clean_tree() -> None:
     assert rc == 0
     rc = sync.main(["--check"])
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# v0.3.23 per-category anchor regression (#README sync drift fix)
+# The "What It Scans" table was undercount by 81 rules at v0.3.22 ship
+# time because each category cell was bare text, not an anchor. As of
+# v0.3.23 every cell carries a `<!-- category-count:CATEGORY_NAME -->`
+# anchor that `sync_rule_count.py` rewrites in lockstep with the registry.
+# ---------------------------------------------------------------------------
+
+
+def test_readme_per_category_anchors_match_registry() -> None:
+    """Every `<!-- category-count:NAME -->` anchor in README must match
+    the live `len([r for r in RULES if r.category.name == NAME])`."""
+    from collections import Counter
+    from agent_audit_kit.rules.builtin import RULES
+
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    # `[A-Z0-9_]+` — digits are load-bearing so `A2A_PROTOCOL` is matched.
+    pattern = re.compile(
+        r"<!--\s*category-count:([A-Z0-9_]+)\s*-->(\d+)<!--\s*/category-count\s*-->",
+    )
+    matches = pattern.findall(readme)
+    assert matches, (
+        "README has no `<!-- category-count:NAME -->NN<!-- /category-count -->` "
+        "anchors. Run `python scripts/sync_rule_count.py` after re-adding the "
+        '"What It Scans" table or accept the v0.3.23 schema.'
+    )
+    live_counts = Counter(r.category.name for r in RULES.values())
+    for cat_name, claimed_str in matches:
+        claimed = int(claimed_str)
+        actual = live_counts.get(cat_name, 0)
+        assert claimed == actual, (
+            f"README category-count anchor for `{cat_name}` reports "
+            f"{claimed}, registry has {actual}. "
+            "Run `python scripts/sync_rule_count.py` and commit."
+        )
+    # Sum of per-category anchors must match the total RULE_COUNT.
+    anchor_sum = sum(int(c) for _, c in matches)
+    assert anchor_sum == sum(live_counts.values()), (
+        f"Per-category anchors sum to {anchor_sum} but live registry has "
+        f"{sum(live_counts.values())}. Run `python scripts/sync_rule_count.py`."
+    )


### PR DESCRIPTION
## Summary

- v0.3.22 ship left the README "What It Scans" table summing to **124 rules** vs the registry's 205 (headline badge + `RULE_COUNT` were correct; only the per-category cells drifted). Every category was undercount; Supply Chain alone was off by +28.
- Each category cell now carries a `<!-- category-count:CATEGORY_NAME -->NN<!-- /category-count -->` anchor matching the live `Category` enum name verbatim. The 11 anchors sum to **205**.
- `scripts/sync_rule_count.py` rewrites every per-category anchor in lockstep with the registry and exits 1 with a typo guard if README references an unknown enum name. Regex `[A-Z0-9_]+` so `A2A_PROTOCOL` matches (the digit was load-bearing — the regression test caught a silent skip).
- New `test_readme_per_category_anchors_match_registry` regression test locks every cell to `Counter(r.category.name for r in RULES.values())` and asserts the sum matches the total. Future drift fails CI rather than ship undetected.
- Docs-only — no rule changes. Prose refreshed to mention every rule shipped through this week.
- Version-pin sweep across `docs/` (action `uses:`, `rev:`, CI snippets) now points at `v0.3.23`.

| Category | v0.3.22 prose | v0.3.23 anchor (live) |
|---|---:|---:|
| MCP Configuration | (drifted) | 38 |
| Supply Chain | (drifted, -28) | 40 |
| Tool Poisoning | (drifted) | 26 |
| Secret Exposure | (drifted) | 17 |
| Agent Config | (drifted) | 15 |
| A2A Protocol | (drifted) | 13 |
| Hook Injection | (drifted) | 12 |
| Taint Analysis | (drifted) | 12 |
| Transport Security | (drifted) | 11 |
| Legal Compliance | (drifted) | 11 |
| Trust Boundaries | (drifted) | 10 |
| **Total** | **124** | **205** ✓ |

## Test plan

- [x] `python3 -m pytest -x -q` → **981 passed**
- [x] `ruff check agent_audit_kit tests scripts` → clean
- [x] `mypy agent_audit_kit/` → no issues in 125 source files
- [x] `python3 scripts/sync_rule_count.py --check` → clean (205 everywhere)
- [x] `python3 scripts/sync_scanner_count.py --check` → clean (65 everywhere)
- [x] `python3 scripts/sync_repo_metadata.py --check` → clean
- [x] New regression test passes locally and intentionally caught the `[A-Z_]+` → `[A-Z0-9_]+` fix that the manual review missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)