### PR TITLE
chore(docs): record 2nd decline of CVE-2026-33032 duplicate-rule proposal

### DIFF
--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -55,3 +55,49 @@ recorded in the rule's `cve_references` list and in CHANGELOG.cves.md.
 Where a rule is derived from a class-of-attacks pattern (OWASP MCP Top
 10 entries, MCP spec, CWE), the rule cites the spec/OWASP ID and does
 NOT fabricate a CVE number.
+
+---
+
+## 2026-06-01 — CVE-2026-33032 duplicate-rule proposal declined (2nd time)
+
+**Sources:**
+- https://nvd.nist.gov/vuln/detail/CVE-2026-33032 (re-verified 2026-06-01)
+- `agent_audit_kit/rules/builtin.py` — `AAK-MCPWN-001`, `AAK-MCP-011`,
+  `AAK-MCP-012`, `AAK-MCP-020` all carry `CVE-2026-33032` in
+  `cve_references`
+- `agent_audit_kit/scanners/mcp_middleware.py` — dedicated scanner for
+  the MCPwn twin-route asymmetry
+- `CHANGELOG.cves.md:150` — ledger: CVE-2026-33032 → `AAK-MCPWN-001`
+  (primary) + `AAK-MCP-011/012/020` (secondary), shipped 2026-04-20
+- `CHANGELOG.md:738` — first decline of the same duplicate proposal
+  ("`AAK-MCP-067`", 2026-05-17)
+
+**Conclusion:** A second prompt proposed adding a new MCP STDIO
+command-injection rule citing CVE-2026-33032. Declined for two
+independent reasons:
+
+1. **Already covered** — the CVE is in `cve_references` on 4 production
+   rules + a dedicated scanner; the per-CVE ledger in
+   `CHANGELOG.cves.md` records `AAK-MCPWN-001` as the primary mapping
+   shipped 2026-04-20. The same duplicate was already declined on
+   2026-05-17 (CHANGELOG.md:738).
+2. **CVE mis-characterisation** — NVD classes CVE-2026-33032 as
+   **CWE-306 (Missing Authentication for Critical Function)**: an
+   unauthenticated `/mcp_message` endpoint paired with an authed
+   `/mcp` endpoint in nginx-ui ≤ 2.3.5, with an empty default IP
+   allowlist. It is **not** a STDIO command-injection. STDIO
+   command-injection across the Ox 2026-05-01 disclosure cluster is
+   already covered by `AAK-MCP-STDIO-CMD-INJ-001..004` and cites
+   different CVEs (CVE-2025-65720, CVE-2026-22252, CVE-2026-26015,
+   CVE-2026-30615, CVE-2026-30617, CVE-2026-30623, CVE-2026-33224,
+   CVE-2026-40933, CVE-2026-6980, et al.). Filing a STDIO rule under
+   CVE-2026-33032 would encode a false CVE-to-attack mapping.
+
+**Rules shipped:** none (intentional no-op).
+
+**Minor follow-up noted, not actioned:** NVD's CVE-2026-33032 page does
+not surface a KEV listing in its summary block; `AAK-MCPWN-001`'s
+description claims *"VulnCheck KEV-listed on 2026-04-13"*. KEV is
+maintained by CISA / VulnCheck separately from NVD and may simply not
+render on NVD's page; if a future verification finds the rule's KEV
+claim is wrong, refresh the description in a dedicated chore PR.

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-05-31T11:30:38Z",
+  "last_updated": "2026-06-01T04:25:01Z",
   "aak_version": "0.3.27",
   "rule_count": 215,
   "coverage": [


### PR DESCRIPTION
## Summary

A second prompt proposed adding a new MCP STDIO command-injection rule citing CVE-2026-33032. **Declined** for two independent reasons; this PR records the decline in `docs/research-log.md` so a 3rd attempt can be triaged in seconds rather than re-doing the registry sweep + NVD verification each time.

**No rule changes, no scanner changes, no version bump, no release.**

## Why the rule wasn't added

### 1. Already covered (anti-duplicate)

CVE-2026-33032 is cited by **4 production rules + 1 dedicated scanner**:

| Rule | Role | Severity |
|---|---|---|
| **`AAK-MCPWN-001`** | primary (twin-route asymmetry) | CRITICAL |
| `AAK-MCP-011` | secondary (handler lacks auth middleware) | CRITICAL |
| `AAK-MCP-012` | secondary (default IP allowlist empty) | CRITICAL |
| `AAK-MCP-020` | secondary (handler shares routing with unauth path) | CRITICAL |

Plus `agent_audit_kit/scanners/mcp_middleware.py` — dedicated scanner for the MCPwn twin-route asymmetry. Per-CVE ledger entry: `CHANGELOG.cves.md:150` (shipped 2026-04-20). **The same duplicate was already declined on 2026-05-17** (`CHANGELOG.md:738`).

### 2. CVE mis-characterisation

[NVD CVE-2026-33032](https://nvd.nist.gov/vuln/detail/CVE-2026-33032) classifies the CVE as **CWE-306 (Missing Authentication for Critical Function)** — an unauthenticated `/mcp_message` endpoint paired with an authed `/mcp` endpoint in nginx-ui ≤ 2.3.5, with an empty default IP allowlist. It is **not** a STDIO command-injection.

STDIO command-injection across the Ox 2026-05-01 disclosure cluster is already covered by `AAK-MCP-STDIO-CMD-INJ-001..004` and cites different CVEs (CVE-2025-65720, CVE-2026-22252, CVE-2026-26015, CVE-2026-30615, CVE-2026-30617, CVE-2026-30623, CVE-2026-33224, CVE-2026-40933, CVE-2026-6980, …). Filing a STDIO rule under CVE-2026-33032 would encode a **false CVE-to-attack mapping** in the rules database.

## What this PR ships

A single ~46-line entry appended to `docs/research-log.md` (`## 2026-06-01 — CVE-2026-33032 duplicate-rule proposal declined (2nd time)`) with:
- Source citations
- Both decline reasons (already-covered + mis-characterisation)
- A minor follow-up note about NVD-vs-rule KEV-status drift, deferred to a separate chore PR if verification confirms it.

## Gate

| Command | Result |
|---|---|
| `python3 -m pytest` | **1083 passed** (unchanged) |
| `ruff check .` | All checks passed |
| `mypy agent_audit_kit/` | Success — 129 source files |

Coverage artefact `public/owasp-agentic-coverage.json` had its `last_updated` timestamp refreshed (auto-generated; harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)