### PR TITLE
fix(compliance): close NSA MCP CSI coverage gaps (17 rules)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — NSA MCP Security CSI mapping: coverage-gap audit (17 rules added)
+
+A gap audit of the `nsa-mcp-csi-2026` compliance mapping (originally added in
+PR #294) found rules that plainly evidence an existing CSI recommendation but
+were never cited — and, in three cases, carry **no OWASP-Agentic ASI tag**, so
+the `also_covers_asi` fan-out could never reach them. **17 rules** are now
+explicitly mapped across 8 of the 9 CSI recommendation sections:
+
+- **Constrain and sandbox tool execution (p.11)** — `AAK-HOOK-RCE-002`,
+  `AAK-HOOK-RCE-003` (the same family as the already-cited `-001`), and generic
+  egress SSRF `AAK-SSRF-001` / `-004` / `-005` (the v1 map cited only
+  vendor-specific SSRF).
+- **Scan local network for open/vulnerable MCP servers (p.14)** —
+  `AAK-SSRF-002` (loopback reach), `AAK-SSRF-003` (cloud-metadata reach).
+- **Validate parameters (p.11)** — `AAK-MCP-015` (path traversal in MCP
+  resource handler), `AAK-LANGCHAIN-001` / `-002` (`load_prompt` path traversal).
+- **Design for boundaries (p.10)** — `AAK-A2A-009` (unbounded delegation).
+- **Sign and verify MCP messages (p.12)** — `AAK-A2A-004` (plaintext HTTP).
+- **Instrument for logging and detection (p.13)** — `AAK-AGENT-004`.
+- **Filter and monitor output pipelines (p.12)** — `AAK-AGENT-005`.
+- **Track and patch MCP related vulnerabilities (p.13)** — `AAK-MCPFRAME-001`,
+  `AAK-MCP-STATELESS-002` (ASI-less), `AAK-CLAUDE-WIN-001`.
+
+Explicit NSA-cited rules went **94 → 111**. Thirteen rules remain deliberately
+unmapped (internal sentinel, info-only coverage manifests, privacy-policy-doc,
+frontend-DoS, pricing, and EU-locale-eval rules) — mapping them would fabricate
+coverage; a new `test_deliberate_exclusions_stay_out_of_scope` test documents
+and guards that decision. NSA test suite **25 → 43**.
+
+**No new rule ID, no new framework, no version bump** — this only enriches an
+existing framework's rule-to-control map.
+
 ### Changed — TS/JS taint scanner now covers SQL-injection sinks (AAK-TAINT-005 parity)
 
 The TypeScript/JavaScript pattern scanner

--- a/agent_audit_kit/output/compliance.py
+++ b/agent_audit_kit/output/compliance.py
@@ -132,7 +132,8 @@ FRAMEWORKS = {
                     "AAK-TRUST-001", "AAK-TRUST-002", "AAK-TRUST-003",
                     "AAK-TRUST-004", "AAK-TRUST-005", "AAK-TRUST-006",
                     "AAK-TRUST-007",
-                    "AAK-A2A-001", "AAK-A2A-002", "AAK-A2A-008", "AAK-A2A-010",
+                    "AAK-A2A-001", "AAK-A2A-002", "AAK-A2A-008",
+                    "AAK-A2A-009", "AAK-A2A-010",
                     "AAK-MCP-ATTEST-001", "AAK-MCP-TUNNEL-001",
                     "AAK-MCP-TUNNEL-002", "AAK-MCP-010",
                 ],
@@ -143,6 +144,8 @@ FRAMEWORKS = {
                     "AAK-POISON-002", "AAK-MCP-FHI-001",
                     "AAK-IPI-WILD-CORPUS-001", "AAK-PRTITLE-IPI-001",
                     "AAK-LANGCHAIN-PROMPT-LOADER-PATH-001",
+                    "AAK-LANGCHAIN-001", "AAK-LANGCHAIN-002",
+                    "AAK-MCP-015",
                     "AAK-A2A-003", "AAK-DEEPSEEK-V4-MOE-TOOL-INJ-001",
                 ],
                 "also_covers_asi": ["ASI02", "ASI05"],
@@ -153,14 +156,17 @@ FRAMEWORKS = {
                     "AAK-MCP-STDIO-CMD-INJ-001", "AAK-MCP-STDIO-CMD-INJ-002",
                     "AAK-MCP-STDIO-CMD-INJ-003", "AAK-MCP-STDIO-CMD-INJ-004",
                     "AAK-MCP-TOOL-UNSAFE-EVAL-001", "AAK-MCP-010",
-                    "AAK-HOOK-RCE-001",
+                    "AAK-HOOK-RCE-001", "AAK-HOOK-RCE-002", "AAK-HOOK-RCE-003",
+                    # Egress sandboxing of tool execution: a tool that can
+                    # reach arbitrary outbound hosts is not sandboxed.
+                    "AAK-SSRF-001", "AAK-SSRF-004", "AAK-SSRF-005",
                 ],
                 "also_covers_asi": ["ASI02", "ASI05"],
             },
             "Sign and verify MCP messages (p.12)": {
                 "rule_ids": [
                     "AAK-MCP-ATTEST-001",
-                    "AAK-A2A-005", "AAK-A2A-006", "AAK-A2A-011",
+                    "AAK-A2A-004", "AAK-A2A-005", "AAK-A2A-006", "AAK-A2A-011",
                     "AAK-WINDSURF-001", "AAK-MCP-LINEAGE-STAINLESS-001",
                     "AAK-MCP-TUNNEL-003",
                 ],
@@ -179,6 +185,9 @@ FRAMEWORKS = {
                     "AAK-SKILL-004", "AAK-SKILL-005",
                     "AAK-METIS-REFUSAL-REFEED-001",
                     "AAK-METIS-SCORING-SINK-001",
+                    # Hidden content in an instruction file is a chained-
+                    # execution injection vector that output filtering catches.
+                    "AAK-AGENT-005",
                 ],
                 "also_covers_asi": ["ASI05"],
             },
@@ -188,6 +197,7 @@ FRAMEWORKS = {
                     "AAK-SPLUNK-TOKLOG-001",
                     "AAK-SPLUNK-MCP-TOKEN-LEAK-001",
                     "AAK-AGENT-001", "AAK-AGENT-002", "AAK-AGENT-003",
+                    "AAK-AGENT-004",
                     "AAK-WINDSURF-001",
                 ],
                 "also_covers_asi": ["ASI08", "ASI10"],
@@ -211,6 +221,12 @@ FRAMEWORKS = {
                     "AAK-MCP-ATLASSIAN-CVE-2026-27826-001",
                     "AAK-LANGCHAIN-SSRF-REDIR-001",
                     "AAK-LMDEPLOY-VL-SSRF-001",
+                    # MCP-stack CVE/patch hygiene: framework DoS, a removed
+                    # protocol method still in use, and the Claude Code
+                    # managed-settings path-trust CVE.
+                    "AAK-MCPFRAME-001",
+                    "AAK-MCP-STATELESS-002",
+                    "AAK-CLAUDE-WIN-001",
                 ],
                 "also_covers_asi": ["ASI04"],
             },
@@ -221,6 +237,10 @@ FRAMEWORKS = {
                     "AAK-MCP-009",
                     "AAK-MCPWN-001",
                     "AAK-MCP-INSPECTOR-CVE-2026-23744-001",
+                    # Lateral-movement reach: a tool that can hit loopback or
+                    # the cloud-metadata endpoint is the SSRF-to-internal class
+                    # this recommendation warns about.
+                    "AAK-SSRF-002", "AAK-SSRF-003",
                 ],
                 "also_covers_asi": ["ASI03", "ASI04"],
             },

--- a/tests/test_nsa_mcp_csi.py
+++ b/tests/test_nsa_mcp_csi.py
@@ -242,3 +242,87 @@ def test_legacy_framework_still_resolves(legacy_fw: str) -> None:
         # (e.g. very narrow ASI tokens with no live rules) may legitimately
         # be empty. We just assert that resolution doesn't crash.
         assert isinstance(rules, list)
+
+
+# ---------------------------------------------------------------------------
+# Coverage-gap closures (audit of the v1 mapping)
+#
+# The initial mapping (PR #294) omitted several rules that plainly evidence a
+# CSI recommendation, while the OWASP-Agentic `also_covers_asi` fan-out could
+# not reach the ASI-less ones (e.g. AAK-MCP-STATELESS-002 carries no ASI tag).
+# A gap audit added them explicitly. These tests pin those closures so a
+# future rule rename or mapping edit cannot silently re-open the gap.
+# ---------------------------------------------------------------------------
+
+
+def _cited_in(control_substr: str) -> set[str]:
+    """Return the explicitly-cited rule_ids for the control whose heading
+    contains `control_substr`."""
+    for ctrl, val in FRAMEWORKS[FRAMEWORK_KEY]["controls"].items():
+        if control_substr in ctrl and isinstance(val, dict):
+            return set(val.get("rule_ids", []))
+    raise AssertionError(f"no control heading contains {control_substr!r}")
+
+
+@pytest.mark.parametrize("rule_id, control_substr", [
+    # Generic SSRF family — the v1 map cited only vendor-specific SSRF.
+    ("AAK-SSRF-001", "Constrain and sandbox tool execution"),
+    ("AAK-SSRF-004", "Constrain and sandbox tool execution"),
+    ("AAK-SSRF-005", "Constrain and sandbox tool execution"),
+    ("AAK-SSRF-002", "Scan local network"),   # loopback reach
+    ("AAK-SSRF-003", "Scan local network"),   # cloud-metadata reach
+    # HOOK-RCE family — v1 cited only -001 of the same family/section.
+    ("AAK-HOOK-RCE-002", "Constrain and sandbox tool execution"),
+    ("AAK-HOOK-RCE-003", "Constrain and sandbox tool execution"),
+    # Path-traversal / input-validation in the MCP server itself.
+    ("AAK-MCP-015", "Validate parameters"),
+    ("AAK-LANGCHAIN-001", "Validate parameters"),
+    ("AAK-LANGCHAIN-002", "Validate parameters"),
+    # Boundary / transport.
+    ("AAK-A2A-009", "Design for boundaries"),
+    ("AAK-A2A-004", "Sign and verify MCP messages"),
+    # Detection / logging hygiene.
+    ("AAK-AGENT-004", "Instrument for logging and detection"),
+    ("AAK-AGENT-005", "Filter and monitor output pipelines"),
+    # MCP-stack patch hygiene — incl. the ASI-less STATELESS rule that the
+    # fan-out can never reach.
+    ("AAK-MCPFRAME-001", "Track and patch MCP related vulnerabilities"),
+    ("AAK-MCP-STATELESS-002", "Track and patch MCP related vulnerabilities"),
+    ("AAK-CLAUDE-WIN-001", "Track and patch MCP related vulnerabilities"),
+])
+def test_gap_closure_rule_is_mapped(rule_id: str, control_substr: str) -> None:
+    """Each audited gap rule must be explicitly cited under its control and
+    must exist in the live registry."""
+    assert rule_id in RULES, f"{rule_id} missing from RULES registry"
+    assert rule_id in _cited_in(control_substr), (
+        f"{rule_id} not explicitly cited under a control matching "
+        f"{control_substr!r} — coverage gap re-opened"
+    )
+
+
+def test_deliberate_exclusions_stay_out_of_scope() -> None:
+    """These rules are intentionally NOT mapped to the NSA MCP CSI: they are
+    either internal sentinels, info-only coverage manifests, or controls
+    outside MCP security scope (privacy-policy docs, frontend DoS, pricing,
+    EU-locale eval). Mapping them would fabricate coverage. This test
+    documents the decision and guards against an over-broad future edit.
+    """
+    out_of_scope = {
+        "AAK-INTERNAL-SCANNER-FAIL",
+        "AAK-EU-AI-ACT-ART15-LOCALE-001",
+        "AAK-OX-COVERAGE-MANIFEST-001",
+        "AAK-PRISMA-AIRS-COVERAGE-001",
+        "AAK-STATE-PRIVACY-001",
+        "AAK-STATE-PRIVACY-002",
+        "AAK-STATE-PRIVACY-003",
+        "AAK-NEXT-AI-DRAW-001",
+        "AAK-PROJECT-DEAL-DRIFT-001",
+    }
+    cited: set[str] = set()
+    for val in FRAMEWORKS[FRAMEWORK_KEY]["controls"].values():
+        if isinstance(val, dict):
+            cited.update(val.get("rule_ids", []))
+    leaked = out_of_scope & cited
+    assert not leaked, (
+        f"out-of-scope rules were mapped into the NSA CSI framework: {leaked}"
+    )


### PR DESCRIPTION
## Summary

Gap audit of the `nsa-mcp-csi-2026` compliance mapping (originally added in #294). Found rules that plainly evidence an existing NSA CSI recommendation but were never cited — and **three** (incl. `AAK-MCP-STATELESS-002`) carry **no OWASP-Agentic ASI tag**, so the `also_covers_asi` fan-out could never reach them. This enriches the existing mapping only — **no new rule, no new framework, no version bump.**

**17 rules** added across **8 of the 9** CSI recommendation sections:

| CSI recommendation | Added rules | Why |
|---|---|---|
| Constrain and sandbox tool execution (p.11) | `AAK-HOOK-RCE-002`, `AAK-HOOK-RCE-003`, `AAK-SSRF-001/004/005` | Same HOOK-RCE family as the already-cited `-001`; v1 cited only *vendor-specific* SSRF — generic egress SSRF was missing |
| Scan local network (p.14) | `AAK-SSRF-002`, `AAK-SSRF-003` | Loopback + cloud-metadata reach = the SSRF-to-internal class this section warns about |
| Validate parameters (p.11) | `AAK-MCP-015`, `AAK-LANGCHAIN-001/002` | Path traversal in MCP resource handler / `load_prompt` — same class as already-cited `AAK-LANGCHAIN-PROMPT-LOADER-PATH-001` |
| Design for boundaries (p.10) | `AAK-A2A-009` | Unbounded delegation = boundary failure |
| Sign and verify MCP messages (p.12) | `AAK-A2A-004` | Plaintext HTTP defeats message integrity |
| Instrument for logging and detection (p.13) | `AAK-AGENT-004` | Credential refs in agent instructions |
| Filter and monitor output pipelines (p.12) | `AAK-AGENT-005` | Hidden instruction content = chained-execution injection vector |
| Track and patch MCP vulns (p.13) | `AAK-MCPFRAME-001`, `AAK-MCP-STATELESS-002`, `AAK-CLAUDE-WIN-001` | MCP-framework DoS CVE, removed `tasks/list` method (ASI-less), Claude Code path-trust CVE |

Explicit NSA-cited rules: **94 → 111**.

### Deliberately NOT mapped (no fabricated coverage)
13 rules remain unmapped because they're outside MCP-security scope: internal sentinel (`AAK-INTERNAL-SCANNER-FAIL`), info-only coverage manifests, privacy-policy-doc rules (`AAK-STATE-PRIVACY-*`), frontend DoS (`AAK-NEXT-AI-DRAW-001`), pricing (`AAK-PROJECT-DEAL-DRIFT-001`), EU-locale eval. A new `test_deliberate_exclusions_stay_out_of_scope` documents and guards this decision against an over-broad future edit.

## Test Plan
- `test_gap_closure_rule_is_mapped` (17 params) — each audited rule is cited under its control and exists in the registry
- `test_deliberate_exclusions_stay_out_of_scope` — out-of-scope rules stay unmapped
- Existing `test_each_control_has_at_least_one_existing_rule` auto-validates every cited ID exists
- NSA suite **25 → 43 passing**; full suite **1113 passing**; `ruff` + `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)