### PR TITLE
fix: enforce one canonical rule count across README/pyproject/CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — single canonical rule count enforced in CI (was drifting 77/148/169/194 across surfaces)
+
+The rule count is computed from `len(RULES)` (the registry in
+`agent_audit_kit/rules/builtin.py`) and asserted equal across every
+current-state surface by `tests/test_rule_count_sync.py::test_rule_count_is_canonical`:
+README badge + total-anchors, `action.yml` description, `__init__.RULE_COUNT`,
+the signed `rules.json` bundle, the pyproject `description`, and the
+present-tense launch copy (`docs/launch/{hn,reddit,x-thread}.md`). Fixed the
+last drifting surface — launch copy still said "221 rules" — to the canonical
+**225**. Historical/version-stamped/per-category counts (CHANGELOG, ROADMAP
+Apr-2026 starting point, `(v0.3.5)` snapshots, per-OWASP-category tables) are
+intentionally out of scope and left unchanged. Version **0.3.40 → 0.3.41**.
+
 ### Added — AAK-MCP-NOAUTH-DEFAULT: MCP server unauthenticated-by-default / fail-open auth ([CVE-2026-48814](https://nvd.nist.gov/vuln/detail/CVE-2026-48814))
 
 CVE-response cycle item. New **HIGH** rule + scanner

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 Security scanner for MCP-connected AI agent pipelines. Finds misconfigurations, hardcoded secrets, tool poisoning, rug pulls, trust boundary violations, and tainted data flows across **13 agent platforms**.
 
 - **<!-- rule-count:total -->225<!-- /rule-count --> rules** across 11 security categories, covering the 2026 CVE wave
+  - Rule count is computed from the registry and verified in CI (`test_rule_count_is_canonical`).
 - **<!-- scanner-count:total -->79<!-- /scanner-count --> scanner modules** including AST-based Python taint analysis and regex pattern scanners for TypeScript/JavaScript and Rust
 - **16 CLI commands**: `scan`, `discover`, `pin`, `verify`, `fix`, `score`, `update`, `proxy`, `kill`, `watch`, plus `export-rules`, `verify-bundle`, `sbom`, `report`, `install-precommit`, and the Security-Advisories scan flag
 - **OWASP coverage**: Agentic Top 10 (10/10), MCP Top 10 (10/10), Adversa AI Top 25
@@ -61,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.40
+      - uses: sattyamjjain/agent-audit-kit@v0.3.41
         with:
           fail-on: high
 ```
@@ -81,7 +82,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.40
+    rev: v0.3.41
     hooks:
       - id: agent-audit-kit
 ```

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,6 +1,6 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.40"
+__version__ = "0.3.41"
 RULE_COUNT = 225
 SCANNER_COUNT = 79

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.40
+      - uses: sattyamjjain/agent-audit-kit@v0.3.41
         with:
           severity: low
           fail-on: high
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.40
+    rev: v0.3.41
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.40
+    rev: v0.3.41
     hooks:
       - id: agent-audit-kit
 ```
@@ -59,7 +59,7 @@ repos:
 ## GitHub Action
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.40
+- uses: sattyamjjain/agent-audit-kit@v0.3.41
   with:
     severity: low
     fail-on: high

--- a/docs/launch/hn.md
+++ b/docs/launch/hn.md
@@ -23,7 +23,7 @@
 > evidence output** — SARIF + OWASP MCP Top 10 + EU AI Act Article 15
 > + SOC 2 + ISO 27001 / 42001 + HIPAA + NIST AI RMF in one scan.
 >
-> agent-audit-kit is that. 221 deterministic rules. Zero cloud
+> agent-audit-kit is that. 225 deterministic rules. Zero cloud
 > dependencies, no auth required. MIT.
 >
 > The leaderboard: we run the scanner weekly against 500 public MCP
@@ -44,7 +44,7 @@
 - **"Does it use an LLM?"**
   → No. The moat is deterministic rules. We keep an optional
   `--llm-scan` flag for semantic tool-description checks, but the core
-  221 rules are regex + AST patterns that run in <50 ms on a normal
+  225 rules are regex + AST patterns that run in <50 ms on a normal
   project.
 - **"What's your false-positive rate?"**
   → We scan 500 public MCP servers weekly. Ground-truth is unknown

--- a/docs/launch/reddit.md
+++ b/docs/launch/reddit.md
@@ -19,7 +19,7 @@ the #1 channel for this repo.
 > that default to allow-all, path traversal in resource handlers,
 > SSRF in outbound-fetch tools, tokens in query params.
 >
-> We built agent-audit-kit, an OSS scanner: 221 deterministic rules,
+> We built agent-audit-kit, an OSS scanner: 225 deterministic rules,
 > SARIF + OWASP MCP Top 10 + compliance report for EU AI Act /
 > SOC 2 / ISO 27001 / HIPAA / NIST AI RMF. No auth, no cloud. MIT.
 >
@@ -54,7 +54,7 @@ the #1 channel for this repo.
 > `pip install agent-audit-kit && agent-audit-kit scan .`
 > Finds misconfigured hooks (CVE-2025-59536 was the catalyst), MCP
 > servers without auth, skill poisoning in SKILL.md files, supply-chain
-> risks in marketplace manifests, missing OAuth 2.1 PKCE. 221 rules.
+> risks in marketplace manifests, missing OAuth 2.1 PKCE. 225 rules.
 > Outputs SARIF for GitHub Security tab.
 >
 > Repo: https://github.com/sattyamjjain/agent-audit-kit
@@ -78,7 +78,7 @@ the #1 channel for this repo.
 > OWASP MCP Top 10 reference scanner — 10/10 coverage, SARIF, EU AI Act evidence
 
 **Body:** developer-audience, technical:
-> If you maintain an MCP server, this is the linter. 221 rules mapped
+> If you maintain an MCP server, this is the linter. 225 rules mapped
 > to OWASP MCP Top 10 and OWASP Agentic 2026 (ASI01–ASI10). GitHub
 > Action that surfaces findings in the Security tab via SARIF. Docker
 > image at ghcr.io. VS Code extension with on-save diagnostics.

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -22,7 +22,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 
 > agent-audit-kit — OSS static scanner for MCP-connected AI agents.
 >
-> 221 deterministic rules. SARIF → GitHub Security tab.
+> 225 deterministic rules. SARIF → GitHub Security tab.
 > Compliance evidence for EU AI Act Article 15, SOC 2, ISO 27001/42001,
 > HIPAA, NIST AI RMF.
 >
@@ -91,7 +91,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.40
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.41
 >
 > MIT. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.40
+- uses: sattyamjjain/agent-audit-kit@v0.3.41
   with:
     preset: mcp-ox-2026-04
 ```

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-06-21T16:59:49Z",
-  "aak_version": "0.3.40",
+  "last_updated": "2026-06-23T10:18:20Z",
+  "aak_version": "0.3.41",
   "rule_count": 225,
   "coverage": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.40"
+version = "0.3.41"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.40"
+    assert __version__ == "0.3.41"

--- a/tests/test_rule_count_sync.py
+++ b/tests/test_rule_count_sync.py
@@ -105,3 +105,57 @@ def test_no_stale_hardcoded_counts_in_prose() -> None:
                 f"{rel} still contains stale phrase {stale!r}; "
                 "run scripts/sync_rule_count.py."
             )
+
+
+def test_rule_count_is_canonical() -> None:
+    """One canonical number, computed from len(RULES), shown everywhere it is
+    claimed as current state. Fails if any authoritative surface — README badge,
+    README total-anchors, action.yml description, __init__.RULE_COUNT, the signed
+    rules.json bundle — or the present-tense launch copy diverges from the
+    registry. Historical/version-stamped/category counts (CHANGELOG, ROADMAP
+    starting point, per-OWASP-category tables, "(v0.3.5)" snapshots) are NOT
+    current-state claims and are intentionally out of scope.
+    """
+    count = _actual_rule_count()
+
+    # 1. Authoritative current-state surfaces must all equal len(RULES).
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    badge = re.search(r"img\.shields\.io/badge/rules-(\d+)-[a-z]+\.svg", readme)
+    assert badge and int(badge.group(1)) == count, "README badge != len(RULES)"
+    anchors = re.findall(
+        r"<!--\s*rule-count:total\s*-->(\d+)<!--\s*/rule-count\s*-->", readme
+    )
+    assert anchors and all(int(a) == count for a in anchors), "README anchor drift"
+
+    action = (REPO_ROOT / "action.yml").read_text(encoding="utf-8")
+    am = re.search(r"description:.*?(\d+)\s+rules", action)
+    assert am and int(am.group(1)) == count, "action.yml description != len(RULES)"
+
+    from agent_audit_kit import RULE_COUNT
+
+    assert RULE_COUNT == count, "__init__.RULE_COUNT != len(RULES)"
+
+    bundle = json.loads((REPO_ROOT / "rules.json").read_text(encoding="utf-8"))
+    assert len(bundle["rules"]) == count, "rules.json bundle != len(RULES)"
+
+    # 2. The package meta must not carry a divergent hard-coded count.
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    desc = re.search(r'^description\s*=\s*"([^"]*)"', pyproject, re.MULTILINE)
+    assert desc, "pyproject description missing"
+    bad = re.search(r"(\d+)\s+rules", desc.group(1))
+    assert not bad or int(bad.group(1)) == count, (
+        "pyproject description hard-codes a divergent rule count"
+    )
+
+    # 3. Present-tense launch copy (marketing claims) must match the registry.
+    for rel in (
+        "docs/launch/hn.md",
+        "docs/launch/reddit.md",
+        "docs/launch/x-thread.md",
+    ):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for claimed in re.findall(r"(\d+)\s+(?:deterministic\s+)?rules?\b", text):
+            assert int(claimed) == count, (
+                f"{rel} claims {claimed} rules; canonical is {count}. "
+                "Update launch copy or run scripts/sync_rule_count.py."
+            )


### PR DESCRIPTION
## Summary
One canonical rule count — computed from `len(RULES)` (the registry in `agent_audit_kit/rules/builtin.py`) — shown and verified everywhere it's claimed as current state.

**Note on scope:** the canonical mechanism already existed (`scripts/sync_rule_count.py` + `tests/test_rule_count_sync.py`). This PR **consolidates** the cross-surface guarantee under the requested test name and **extends** it to docs + pyproject, rather than building a parallel mechanism.

## What changed
- **`test_rule_count_is_canonical`** (in `tests/test_rule_count_sync.py`) asserts `len(RULES)` equals every current-state surface: README badge + `rule-count:total` anchors, `action.yml` description, `__init__.RULE_COUNT`, the signed `rules.json` bundle, the pyproject `description`, and present-tense launch copy (`docs/launch/{hn,reddit,x-thread}.md`).
- **Fixed the one real remaining drift:** launch copy still said **221 rules** → corrected to the canonical **225**.
- **README** gains: *"Rule count is computed from the registry and verified in CI (`test_rule_count_is_canonical`)."*
- **CHANGELOG** `[Unreleased]` entry; version **0.3.40 → 0.3.41**.

## Deliberately out of scope (left unchanged — changing them would be dishonest)
Historical / version-stamped / category counts are **not** current-state claims: CHANGELOG entries, ROADMAP's "v0.2.0 · 77 rules" Apr-2026 starting point, `github-verified-creator-application.md` "159 rules (v0.3.5)", per-OWASP-category tables ("14 rules" etc.), the README A2A comparison cell ("12 rules"), competitor counts ("49 rules"). The test only guards present-tense total claims.

## Test plan
- `pytest` — **1225 passed** (incl. new `test_rule_count_is_canonical`); `ruff check .` clean; `mypy agent_audit_kit` clean (139 files); all 3 sync `--check` gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)