### PR TITLE
docs: retire public 48h CVE-to-rule SLA; lead with offline + compliance wedges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — retire public 48h CVE-to-rule SLA (unbounded solo liability); lead with offline + compliance-evidence wedges
+
+Removed the public "48h CVE-to-rule SLA" promise — a clock a solo maintainer
+can't reliably carry — from the README badge/bullet, ROADMAP_2026.md, and the
+live launch copy (`docs/launch/{hn,reddit,x-thread}.md`). Replaced it with a
+capability statement (no deadline): newly disclosed MCP CVEs are triaged and
+turned into rules as they land, surfaced by the NVD watcher
+(`.github/workflows/cve-watcher.yml`) and logged in `CHANGELOG.cves.md`. The
+README now leads with the two defensible wedges — **fully offline / deterministic
+scanning** and **auditor-ready compliance-evidence packs** — instead of response
+speed. No detection logic, no version bump. The NVD watcher and the `sla-48h`
+automation label (a release-gate dependency) are unchanged.
+
 ### Fixed — single canonical rule count enforced in CI (was drifting 77/148/169/194 across surfaces)
 
 The rule count is computed from `len(RULES)` (the registry in

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="#frameworks--standards"><img src="https://img.shields.io/badge/OWASP_Agentic-10%2F10-green.svg" alt="OWASP Agentic: 10/10"></a>
   <a href="#frameworks--standards"><img src="https://img.shields.io/badge/OWASP_MCP-10%2F10-green.svg" alt="OWASP MCP: 10/10"></a>
   <a href="https://sattyamjjain.github.io/agent-audit-kit/"><img src="https://img.shields.io/badge/MCP_Security_Index-live-blue.svg" alt="MCP Security Index"></a>
-  <a href="CHANGELOG.cves.md"><img src="https://img.shields.io/badge/CVE%E2%86%92rule_SLA-48h-orange.svg" alt="48h CVE-to-rule SLA"></a>
 </p>
 
 ---
@@ -23,6 +22,11 @@
 
 Security scanner for MCP-connected AI agent pipelines. Finds misconfigurations, hardcoded secrets, tool poisoning, rug pulls, trust boundary violations, and tainted data flows across **13 agent platforms**.
 
+**Two things it does that hosted scanners can't:**
+
+1. **Runs fully offline and deterministically.** Your code, configs, and secrets never leave the machine; the default scan path makes zero network calls, and the same input always yields the same finding (no model in the loop). No account, no telemetry.
+2. **Produces auditor-ready compliance-evidence packs.** SARIF for the GitHub Security tab plus PDF evidence reports mapped to 13 frameworks (EU AI Act, SOC 2, ISO 27001/42001, HIPAA, NIST AI RMF, and regional regimes) — what you hand an auditor, not just a list of findings.
+
 - **<!-- rule-count:total -->225<!-- /rule-count --> rules** across 11 security categories, covering the 2026 CVE wave
   - Rule count is computed from the registry and verified in CI (`test_rule_count_is_canonical`).
 - **<!-- scanner-count:total -->79<!-- /scanner-count --> scanner modules** including AST-based Python taint analysis and regex pattern scanners for TypeScript/JavaScript and Rust
@@ -31,7 +35,7 @@ Security scanner for MCP-connected AI agent pipelines. Finds misconfigurations, 
 - **Compliance mapping** (13 frameworks): EU AI Act Art. 15 + 55, SOC 2, ISO 27001, ISO/IEC 42001, HIPAA, NIST AI RMF, **NSA MCP Security CSI (U/OO/6030316-26, May 2026)**, Singapore Agentic AI, India DPDP 2023, **Alabama Personal Data Protection Act (HB 351, 2026)**, **Tennessee SB 1580 Health Care AI (PRA)**, **MCP 2026 Roadmap (May 2026)** — PDF reports via `agent-audit-kit report --format pdf --framework <name>`
 - **Supply chain**: deterministic rule bundle (`export-rules`), Sigstore-signed releases, CycloneDX + SPDX SBOM (`sbom`)
 - **MCP Security Index**: weekly public leaderboard at [sattyamjjain.github.io/agent-audit-kit](https://sattyamjjain.github.io/agent-audit-kit/) — per-server grade cards (A–F), 90-day [disclosure policy](docs/disclosure-policy.md)
-- **AAK Response SLA**: rule coverage within **48 hours** of any disclosed MCP CVE — ledger in [CHANGELOG.cves.md](CHANGELOG.cves.md)
+- **CVE coverage**: newly disclosed MCP CVEs are triaged and turned into rules as they land — surfaced automatically by the NVD watcher ([`cve-watcher.yml`](.github/workflows/cve-watcher.yml)) and logged in [CHANGELOG.cves.md](CHANGELOG.cves.md)
 - **Zero cloud dependencies** — runs fully offline, zero network calls in the default scan path
 
 ### Why This Exists
@@ -336,7 +340,7 @@ See [`docs/comparisons.md`](docs/comparisons.md) for a fully-sourced version. Ve
 | Regional frameworks (IN/SG/AL/TN) | **Yes** | No | No | No |
 | Sigstore-signed rule bundle | **Yes** | SLSA provenance | No | No |
 | CycloneDX + SPDX SBOM output | **Yes** | No | No | No |
-| Public CVE-to-rule ledger | **Yes** | No | No | No |
+| Public CVE-response ledger | **Yes** | No | No | No |
 | Public grade leaderboard | **Yes** (MCP Security Index) | No | No | No |
 | Pin + drift verification | **Yes** | Yes (runtime rings) | No | No |
 | Auto-fix CVE dependency bumps | **Yes** (`fix --cve`) | No | No | No |

--- a/ROADMAP_2026.md
+++ b/ROADMAP_2026.md
@@ -51,7 +51,7 @@ Every one of these rules ships with (a) a fixture under `tests/fixtures/`, (b) a
 
 ### 2.3 Features that widen the moat
 
-1. **CVE-to-rule velocity commitment** — ship rule packs within 48 hours of any MCP CVE disclosure. Document this publicly as the **AAK Response SLA**. Run a public `CHANGELOG.cves.md` showing "CVE-2026-33032 → AAK-MCP-012 shipped 2026-03-16, 17 hours after NVD disclosure". This mirrors `npm audit`'s core value prop.
+1. **Disclosed-CVE rule coverage** — triage newly disclosed MCP CVEs and turn them into rules as they land, surfaced automatically by the NVD watcher (`.github/workflows/cve-watcher.yml`) and logged in a public `CHANGELOG.cves.md` (e.g. "CVE-2026-33032 → AAK-MCP-012, 2026-03-16"). No public deadline is promised — a solo maintainer can't carry an unbounded clock — but the ledger makes actual coverage and timing transparent.
 2. **Compliance-report v2** — today you map to EU AI Act / SOC 2 / ISO 27001 / HIPAA / NIST AI RMF. Add:
    - **ISO/IEC 42001** AI Management System evidence block.
    - **Singapore Agentic AI Governance Framework** (Jan 2026, first national).
@@ -86,7 +86,7 @@ Your honest answer to "why not Snyk Agent Scan?":
 
 - Land the four correctness fixes (dead rules, scanner exception handling, TypeScript/Rust rename or rewrite, explicit LLM flag).
 - Ship the 10 new 2026-CVE rule families as v0.3.0.
-- Publish the **AAK Response SLA** commitment.
+- Publish the public CVE-response ledger (`CHANGELOG.cves.md`) — coverage transparency, no clock commitment.
 - Scan 1,000 public MCP servers and compute the grade distribution. This is a blog post.
 - Run ToxicSkills head-to-head; publish numbers.
 
@@ -127,7 +127,7 @@ Your honest answer to "why not Snyk Agent Scan?":
 | GitHub stars | ~3 | 200 | 2,000 | 10,000 |
 | PyPI downloads/month | <30 | 3,000 | 40,000 | 400,000 |
 | Rules | 77 | 100 | 140 | 200 |
-| CVE-to-rule SLA compliance | n/a | 100% of new MCP CVEs in <48 h | same | same |
+| Disclosed MCP CVEs with rule coverage | n/a | majority covered | same | same |
 | GitHub Action usage | 0 | 20 | 250 | 3,000 |
 | Published MCP Security Index grades | 0 | 1,000 servers | 5,000 | all 10,000+ |
 | Coordinated CVE disclosures | 0 | 1 | 5 | 20 |
@@ -146,4 +146,4 @@ Your honest answer to "why not Snyk Agent Scan?":
 
 ## 6. The CEO-readable one-pager
 
-> *AgentAuditKit* scans your AI-agent pipeline for 100+ security and compliance issues — from tool-poisoning and prompt-injection to insecure MCP configs and missing OAuth 2.1 enforcement. It produces SARIF for GitHub Security, an OWASP MCP Top 10 scorecard, and auditor-ready compliance evidence mapped to EU AI Act Article 15, SOC 2, ISO 27001 / 42001, HIPAA, NIST AI RMF, Singapore Agentic AI Governance, and India DPDP. We publish the MCP Security Index, grading the top 10,000 public MCP servers weekly, and we ship rule coverage for every disclosed MCP CVE within 48 hours. Used by engineering teams that need to show an auditor that their agents are safe — before the EU AI Act high-risk obligations apply on August 2, 2026.
+> *AgentAuditKit* scans your AI-agent pipeline for 100+ security and compliance issues — from tool-poisoning and prompt-injection to insecure MCP configs and missing OAuth 2.1 enforcement. It produces SARIF for GitHub Security, an OWASP MCP Top 10 scorecard, and auditor-ready compliance evidence mapped to EU AI Act Article 15, SOC 2, ISO 27001 / 42001, HIPAA, NIST AI RMF, Singapore Agentic AI Governance, and India DPDP. We publish the MCP Security Index, grading the top 10,000 public MCP servers weekly, and we ship rule coverage for disclosed MCP CVEs. Used by engineering teams that need to show an auditor that their agents are safe — before the EU AI Act high-risk obligations apply on August 2, 2026.

--- a/docs/launch/hn.md
+++ b/docs/launch/hn.md
@@ -40,7 +40,7 @@
 - **"How is this different from Snyk Agent Scan?"**
   → No auth, no cloud, compliance-evidence output, India DPDP +
   Singapore framework + EU AI Act Article 55. Deterministic, so CI
-  runs are reproducible. public CVE-to-rule ledger we maintain.
+  runs are reproducible. public CVE-response ledger we maintain.
 - **"Does it use an LLM?"**
   → No. The moat is deterministic rules. We keep an optional
   `--llm-scan` flag for semantic tool-description checks, but the core

--- a/docs/launch/reddit.md
+++ b/docs/launch/reddit.md
@@ -31,13 +31,13 @@ the #1 channel for this repo.
 > - Scanner: https://github.com/sattyamjjain/agent-audit-kit
 > - Leaderboard: https://mcp-security-index.com/
 > - Disclosure policy: https://github.com/sattyamjjain/agent-audit-kit/blob/main/docs/disclosure-policy.md
-> - CVE-to-rule ledger (48h SLA): https://github.com/sattyamjjain/agent-audit-kit/blob/main/CHANGELOG.cves.md
+> - CVE-response ledger: https://github.com/sattyamjjain/agent-audit-kit/blob/main/CHANGELOG.cves.md
 
 **Expected questions & answers**
 
 - "What makes this better than Snyk MCP-scan / `snyk/agent-scan`?"
   → No account required, air-gap friendly, compliance-evidence output,
-  public CVE-to-rule ledger, Sigstore-signed rule bundles.
+  public CVE-response ledger, Sigstore-signed rule bundles.
 - "Is the 82% stat your number or someone else's?"
   → Not ours. A 2,614-server survey, cited in the scanner's README.
   Our scan found similar proportions on the 500 we picked.

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -54,10 +54,11 @@ Post same Tuesday as HN, ~1h after HN submission.
 
 ---
 
-**5/ Public CVE-to-rule ledger**
+**5/ Public CVE-response ledger**
 
-> We publicly commit: every disclosed MCP CVE gets rule coverage
-> within 48h of NVD disclosure. Tracked in CHANGELOG.cves.md.
+> Newly disclosed MCP CVEs are triaged and turned into rules as they
+> land (surfaced by an NVD watcher). Every one we cover is logged with
+> its rule ID and ship date in CHANGELOG.cves.md.
 >
 > Sigstore-signed rule bundles, so enterprise users can pin + verify
 > without a vendor account.


### PR DESCRIPTION
## Summary
Retires the public **"48h CVE-to-rule SLA"** — an unbounded clock a solo maintainer can't reliably carry — and reframes the README to lead with the two defensible wedges. **Docs only, no detection logic, no version bump.**

## Changed
- **README**: removed the `48h CVE-to-rule SLA` badge and the "AAK Response SLA: within 48 hours" bullet. Added a lead block naming the two wedges — **fully offline / deterministic scanning** and **auditor-ready compliance-evidence packs**. Replaced the SLA bullet with a no-deadline capability line (CVEs triaged into rules as disclosed, via the NVD watcher + `CHANGELOG.cves.md`). Comparison row → "Public CVE-response ledger".
- **ROADMAP_2026.md**: reframed the "velocity commitment / AAK Response SLA" item, the publish-SLA bullet, the metrics-table row, and the boilerplate description — all to capability language with no clock.
- **docs/launch/{hn,reddit,x-thread}.md**: dropped the current-tense "within 48h" / "48h SLA" promise from the live launch copy.
- **CHANGELOG** `[Unreleased]` entry.

`rg "48h|SLA|CVE-to-rule|time-to-rule"` over README.md + ROADMAP_2026.md → **zero hits**.

## Deliberately NOT touched (machinery / history / different promise)
- The NVD watcher (`.github/workflows/cve-watcher.yml`) and the **`sla-48h` automation label** — a release-gate dependency; renaming it would break the release pipeline.
- `CHANGELOG.cves.md` (factual ledger), version-stamped snapshots (`release-notes-v0.3.0.md`, `github-verified-creator-application.md`).
- `docs/disclosure-policy.md`'s "within 48 hours" — that's the *coordinated-disclosure notification* window, a different (reasonable) promise.
- `docs/metrics.md` (internal latency targets), `docs/comparisons.md` (secondary), `docs/RELEASING.md` (release tooling) — flagged for a follow-up if you want them swept too.

## Test plan
`pytest` **1225 passed**; `ruff check .` clean; `mypy agent_audit_kit` clean (139 files); sync `--check` gates clean; version unchanged (0.3.41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)