### PR TITLE
chore(rules): CVE-backlog coverage — extend Flowise/LiteLLM/Doris pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — CVE-backlog coverage: extend existing pins (Flowise/LiteLLM/Doris)
+
+Worked the open `sla-48h` backlog. The genuinely AAK-actionable items map to
+packages AAK already pins, so the existing rules were extended rather than
+duplicated:
+
+- **Flowise** (`AAK-FLOWISE-001`): pin floor bumped **3.1.0 → 3.1.2** so
+  3.0.6–3.1.1 are still flagged; added CVE-2025-71336 (< 3.0.6 unsandboxed RCE)
+  and CVE-2026-56274 (< 3.1.2 OS command injection / regex bypass) to the
+  Custom-MCP RCE cluster.
+- **LiteLLM** (`AAK-LITELLM-CVE-2026-30623-PIN-001`): added CVE-2026-12773
+  (MCP-proxy improper auth), CVE-2026-12774 + CVE-2026-12798 (MCP SSRF) — all
+  already flagged by the existing `< 1.83.7` floor.
+- **Apache Doris** (`AAK-DORIS-001`): added sibling CVE-2025-66336 (metadata-path
+  SQL injection), covered by the existing `< 0.6.1` floor.
+
+The remaining backlog issues were vulnerabilities **inside third-party products
+AAK does not scan** (desktop apps, web platforms, plugins, the Linux kernel) or
+patterns **already detected** by generalised rules (no-auth HTTP transport,
+DNS-rebind, hook auto-exec, SSRF, tool-gate authz) — dispositioned and closed
+with per-issue reasons, no fabricated rules. Rule count unchanged (225).
+
 ### Changed — retire public 48h CVE-to-rule SLA (unbounded solo liability); lead with offline + compliance-evidence wedges
 
 Removed the public "48h CVE-to-rule SLA" promise — a clock a solo maintainer

--- a/agent_audit_kit/rules/builtin.py
+++ b/agent_audit_kit/rules/builtin.py
@@ -2978,24 +2978,29 @@ _r(
 
 _r(
     "AAK-FLOWISE-001",
-    "Flowise < 3.1.0 MCP adapter authenticated RCE",
+    "Flowise < 3.1.2 MCP adapter authenticated RCE",
     "Package manifest depends on `flowise` or `flowise-components` at "
-    "version < 3.1.0, and/or a Flowise flow config (`.flowise/*.json`, "
+    "version < 3.1.2, and/or a Flowise flow config (`.flowise/*.json`, "
     "`flows/*.json`) declares an MCP adapter node with `customFunction` "
-    "or `runCode` sinks. CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) "
-    "lets an authenticated attacker combine allowlisted commands like "
-    "`npx` with execution flags such as `-c` to achieve arbitrary OS "
-    "command execution. Same architectural class as Ox's original STDIO "
-    "disclosure (see AAK-STDIO-001).",
+    "or `runCode` sinks. The Custom-MCP feature is a recurring RCE class: "
+    "CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) lets an authenticated "
+    "attacker combine allowlisted commands like `npx` with execution flags "
+    "such as `-c` for arbitrary OS command execution; CVE-2025-71336 "
+    "(< 3.0.6, CVSS 9.8) is an unsandboxed RCE in the same feature; "
+    "CVE-2026-56274 (< 3.1.2, CVSS 9.9) adds OS command injection via "
+    "incomplete command-flag validation plus a regex bypass in local "
+    "file-access restrictions. Pin floor is 3.1.2 (highest fixed version) "
+    "so 3.0.6–3.1.1 are still flagged. Same architectural class as Ox's "
+    "original STDIO disclosure (see AAK-STDIO-001).",
     Severity.CRITICAL,
     Category.SUPPLY_CHAIN,
-    "Upgrade flowise and flowise-components to 3.1.0 or later. Audit "
+    "Upgrade flowise and flowise-components to 3.1.2 or later. Audit "
     "every MCP adapter node in your flow configs; remove "
     "`customFunction`/`runCode` sinks unless they're validated against "
     "a strict argv allowlist. See also AAK-STDIO-001 for the "
     "architectural-class detector.",
     sarif_name="FlowiseMcpAdapterRce",
-    cve_references=["CVE-2026-40933"],
+    cve_references=["CVE-2026-40933", "CVE-2025-71336", "CVE-2026-56274"],
     owasp_mcp_references=["MCP01:2025"],
     owasp_agentic_references=["ASI02"],
     adversa_references=["ADV-RCE-04"],
@@ -3095,14 +3100,17 @@ _r(
     "CVE-2025-66335 is a query-context neutralization bypass in the MCP "
     "adapter's tool layer — crafted tool arguments are concatenated into "
     "Doris SQL without a parameterized boundary, letting an LLM-driven "
-    "tool call reach into arbitrary reads/writes. Fixed in 0.6.1.",
+    "tool call reach into arbitrary reads/writes. CVE-2025-66336 is a "
+    "sibling SQL injection in a metadata query path (a user-controlled "
+    "database name interpolated without the caller's authz context), same "
+    "< 0.6.1 fixed line. Fixed in 0.6.1.",
     Severity.HIGH,
     Category.SUPPLY_CHAIN,
     "Upgrade `apache-doris-mcp-server` to 0.6.1 or newer. Audit every "
     "tool the adapter exposes to confirm arguments flow through a "
     "parameterized query builder, never string concatenation.",
     sarif_name="DorisMcpSqlInjection",
-    cve_references=["CVE-2025-66335"],
+    cve_references=["CVE-2025-66335", "CVE-2025-66336"],
     owasp_mcp_references=["MCP04:2025"],
     owasp_agentic_references=["ASI02"],
     adversa_references=["ADV-INJECT-02"],
@@ -4623,6 +4631,11 @@ _r(
     "covers the source-side architectural shape; this pin-only rule "
     "complements it by surfacing a discrete finding for consumers "
     "who run pin-check mode and need an actionable manifest fix. "
+    "The <1.83.7 floor also flags the LiteLLM MCP-proxy CVE cluster, all "
+    "in versions below the floor: CVE-2026-12773 (improper authentication "
+    "in the MCP proxy `UserAPIKeyAuth`, <=1.59.8), CVE-2026-12774 (SSRF in "
+    "MCP server connection testing, <=1.82.2), and CVE-2026-12798 (SSRF in "
+    "the MCP OpenAPI spec loader, <=1.82.2). "
     "Wired into `aak fix --cve` so the auto-fixer can rewrite "
     "requirements*.txt entries to `litellm>=1.83.7`.",
     Severity.HIGH,
@@ -4632,7 +4645,9 @@ _r(
     "edits should go through the project's normal dependency-update "
     "workflow.",
     sarif_name="LitellmCveStaleVersion",
-    cve_references=["CVE-2026-30623"],
+    cve_references=[
+        "CVE-2026-30623", "CVE-2026-12773", "CVE-2026-12774", "CVE-2026-12798",
+    ],
     owasp_mcp_references=["MCP01:2025", "MCP05:2025"],
     owasp_agentic_references=["ASI02", "ASI10"],
     incident_references=["BERRIAI-LITELLM-2026-04-30"],

--- a/agent_audit_kit/scanners/stdio_injection.py
+++ b/agent_audit_kit/scanners/stdio_injection.py
@@ -303,11 +303,14 @@ def scan(project_root: Path) -> tuple[list[Finding], set[str]]:
 
 
 # ---------------------------------------------------------------------------
-# AAK-FLOWISE-001 — CVE-2026-40933 (Flowise < 3.1.0, CVSS 10.0).
+# AAK-FLOWISE-001 — Flowise Custom-MCP RCE cluster. CVE-2026-40933 (< 3.1.0,
+# CVSS 10.0), CVE-2025-71336 (< 3.0.6 unsandboxed RCE), and CVE-2026-56274
+# (< 3.1.2 OS command injection / regex bypass) — pin floor is the highest
+# fixed version so 3.1.0/3.1.1 are still flagged for CVE-2026-56274.
 # ---------------------------------------------------------------------------
 
 
-_FLOWISE_PATCHED_VERSION = (3, 1, 0)
+_FLOWISE_PATCHED_VERSION = (3, 1, 2)
 
 
 def _parse_semver(spec: str) -> tuple[int, int, int] | None:

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-06-23T10:18:20Z",
+  "last_updated": "2026-06-27T10:05:37Z",
   "aak_version": "0.3.41",
   "rule_count": 225,
   "coverage": [
@@ -177,7 +177,8 @@
           "id": "AAK-DORIS-001",
           "severity": "high",
           "cve_references": [
-            "CVE-2025-66335"
+            "CVE-2025-66335",
+            "CVE-2025-66336"
           ],
           "aicm_references": [
             "AIS-07",
@@ -199,7 +200,9 @@
           "id": "AAK-FLOWISE-001",
           "severity": "critical",
           "cve_references": [
-            "CVE-2026-40933"
+            "CVE-2025-71336",
+            "CVE-2026-40933",
+            "CVE-2026-56274"
           ],
           "aicm_references": [
             "STA-08"
@@ -240,6 +243,9 @@
           "id": "AAK-LITELLM-CVE-2026-30623-PIN-001",
           "severity": "high",
           "cve_references": [
+            "CVE-2026-12773",
+            "CVE-2026-12774",
+            "CVE-2026-12798",
             "CVE-2026-30623"
           ],
           "aicm_references": [
@@ -2127,6 +2133,9 @@
           "id": "AAK-LITELLM-CVE-2026-30623-PIN-001",
           "severity": "high",
           "cve_references": [
+            "CVE-2026-12773",
+            "CVE-2026-12774",
+            "CVE-2026-12798",
             "CVE-2026-30623"
           ],
           "aicm_references": [

--- a/rules.json
+++ b/rules.json
@@ -910,9 +910,10 @@
       "auto_fixable": false,
       "category": "supply-chain",
       "cve_references": [
-        "CVE-2025-66335"
+        "CVE-2025-66335",
+        "CVE-2025-66336"
       ],
-      "description": "Project depends on `apache-doris-mcp-server` at a version < 0.6.1. CVE-2025-66335 is a query-context neutralization bypass in the MCP adapter's tool layer \u2014 crafted tool arguments are concatenated into Doris SQL without a parameterized boundary, letting an LLM-driven tool call reach into arbitrary reads/writes. Fixed in 0.6.1.",
+      "description": "Project depends on `apache-doris-mcp-server` at a version < 0.6.1. CVE-2025-66335 is a query-context neutralization bypass in the MCP adapter's tool layer \u2014 crafted tool arguments are concatenated into Doris SQL without a parameterized boundary, letting an LLM-driven tool call reach into arbitrary reads/writes. CVE-2025-66336 is a sibling SQL injection in a metadata query path (a user-controlled database name interpolated without the caller's authz context), same < 0.6.1 fixed line. Fixed in 0.6.1.",
       "incident_references": [],
       "owasp_agentic_references": [
         "ASI02"
@@ -981,9 +982,11 @@
       "auto_fixable": true,
       "category": "supply-chain",
       "cve_references": [
-        "CVE-2026-40933"
+        "CVE-2026-40933",
+        "CVE-2025-71336",
+        "CVE-2026-56274"
       ],
-      "description": "Package manifest depends on `flowise` or `flowise-components` at version < 3.1.0, and/or a Flowise flow config (`.flowise/*.json`, `flows/*.json`) declares an MCP adapter node with `customFunction` or `runCode` sinks. CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) lets an authenticated attacker combine allowlisted commands like `npx` with execution flags such as `-c` to achieve arbitrary OS command execution. Same architectural class as Ox's original STDIO disclosure (see AAK-STDIO-001).",
+      "description": "Package manifest depends on `flowise` or `flowise-components` at version < 3.1.2, and/or a Flowise flow config (`.flowise/*.json`, `flows/*.json`) declares an MCP adapter node with `customFunction` or `runCode` sinks. The Custom-MCP feature is a recurring RCE class: CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) lets an authenticated attacker combine allowlisted commands like `npx` with execution flags such as `-c` for arbitrary OS command execution; CVE-2025-71336 (< 3.0.6, CVSS 9.8) is an unsandboxed RCE in the same feature; CVE-2026-56274 (< 3.1.2, CVSS 9.9) adds OS command injection via incomplete command-flag validation plus a regex bypass in local file-access restrictions. Pin floor is 3.1.2 (highest fixed version) so 3.0.6\u20133.1.1 are still flagged. Same architectural class as Ox's original STDIO disclosure (see AAK-STDIO-001).",
       "incident_references": [],
       "owasp_agentic_references": [
         "ASI02"
@@ -991,11 +994,11 @@
       "owasp_mcp_references": [
         "MCP01:2025"
       ],
-      "remediation": "Upgrade flowise and flowise-components to 3.1.0 or later. Audit every MCP adapter node in your flow configs; remove `customFunction`/`runCode` sinks unless they're validated against a strict argv allowlist. See also AAK-STDIO-001 for the architectural-class detector.",
+      "remediation": "Upgrade flowise and flowise-components to 3.1.2 or later. Audit every MCP adapter node in your flow configs; remove `customFunction`/`runCode` sinks unless they're validated against a strict argv allowlist. See also AAK-STDIO-001 for the architectural-class detector.",
       "rule_id": "AAK-FLOWISE-001",
       "sarif_name": "FlowiseMcpAdapterRce",
       "severity": "critical",
-      "title": "Flowise < 3.1.0 MCP adapter authenticated RCE"
+      "title": "Flowise < 3.1.2 MCP adapter authenticated RCE"
     },
     {
       "adversa_references": [
@@ -1812,9 +1815,12 @@
       "auto_fixable": true,
       "category": "supply-chain",
       "cve_references": [
-        "CVE-2026-30623"
+        "CVE-2026-30623",
+        "CVE-2026-12773",
+        "CVE-2026-12774",
+        "CVE-2026-12798"
       ],
-      "description": "A Python manifest (`requirements*.txt`, `pyproject.toml`, `Pipfile*`, `poetry.lock`, `uv.lock`) pins `litellm` at a version below 1.83.7. BerriAI/litellm shipped the CVE-2026-30623 fix in v1.83.7 on 2026-04-30. AAK-MCP-STDIO-CMD-INJ-001 already covers the source-side architectural shape; this pin-only rule complements it by surfacing a discrete finding for consumers who run pin-check mode and need an actionable manifest fix. Wired into `aak fix --cve` so the auto-fixer can rewrite requirements*.txt entries to `litellm>=1.83.7`.",
+      "description": "A Python manifest (`requirements*.txt`, `pyproject.toml`, `Pipfile*`, `poetry.lock`, `uv.lock`) pins `litellm` at a version below 1.83.7. BerriAI/litellm shipped the CVE-2026-30623 fix in v1.83.7 on 2026-04-30. AAK-MCP-STDIO-CMD-INJ-001 already covers the source-side architectural shape; this pin-only rule complements it by surfacing a discrete finding for consumers who run pin-check mode and need an actionable manifest fix. The <1.83.7 floor also flags the LiteLLM MCP-proxy CVE cluster, all in versions below the floor: CVE-2026-12773 (improper authentication in the MCP proxy `UserAPIKeyAuth`, <=1.59.8), CVE-2026-12774 (SSRF in MCP server connection testing, <=1.82.2), and CVE-2026-12798 (SSRF in the MCP OpenAPI spec loader, <=1.82.2). Wired into `aak fix --cve` so the auto-fixer can rewrite requirements*.txt entries to `litellm>=1.83.7`.",
       "incident_references": [
         "BERRIAI-LITELLM-2026-04-30"
       ],

--- a/tests/test_flowise.py
+++ b/tests/test_flowise.py
@@ -28,11 +28,23 @@ def test_flowise_patched_pin_is_quiet(tmp_path: Path) -> None:
     (tmp_path / "package.json").write_text(
         json.dumps({
             "name": "agent-app",
-            "dependencies": {"flowise": "3.1.0"},
+            "dependencies": {"flowise": "3.1.2"},
         })
     )
     findings, _ = stdio_injection.scan(tmp_path)
     assert not any(f.rule_id == "AAK-FLOWISE-001" for f in findings)
+
+
+def test_flowise_3_1_1_still_flagged_for_cve_2026_56274(tmp_path: Path) -> None:
+    """CVE-2026-56274 is fixed in 3.1.2, so 3.1.0/3.1.1 must still flag."""
+    (tmp_path / "package.json").write_text(
+        json.dumps({
+            "name": "agent-app",
+            "dependencies": {"flowise": "3.1.1"},
+        })
+    )
+    findings, _ = stdio_injection.scan(tmp_path)
+    assert any(f.rule_id == "AAK-FLOWISE-001" for f in findings)
 
 
 def test_flowise_components_package_also_matches(tmp_path: Path) -> None:
@@ -75,6 +87,8 @@ def test_flowise_rule_metadata_verified() -> None:
     rule = RULES["AAK-FLOWISE-001"]
     assert rule.severity.value == "critical"
     assert "CVE-2026-40933" in rule.cve_references
+    assert "CVE-2025-71336" in rule.cve_references
+    assert "CVE-2026-56274" in rule.cve_references
     assert rule.auto_fixable is True
 
 


### PR DESCRIPTION
Clears the AAK-actionable part of the open `sla-48h` backlog by **extending existing pin rules** (no duplicates, no fabricated rules).

- **Flowise** `AAK-FLOWISE-001`: floor **3.1.0 → 3.1.2** (so 3.0.6–3.1.1 still flag); +CVE-2025-71336 (<3.0.6 unsandboxed RCE), +CVE-2026-56274 (<3.1.2 OS cmd injection/regex bypass). New test pins 3.1.1-still-flagged / 3.1.2-clean.
- **LiteLLM** `AAK-LITELLM-...-PIN-001`: +CVE-2026-12773 / -12774 / -12798 (MCP-proxy auth + SSRF) — already flagged by the `<1.83.7` floor.
- **Apache Doris** `AAK-DORIS-001`: +CVE-2025-66336 (sibling metadata-path SQLi) — covered by `<0.6.1`.

The rest of the backlog is vulns **inside third-party products AAK doesn't scan** (desktop apps, web platforms, plugins, Linux kernel) or patterns **already detected** (no-auth HTTP transport, DNS-rebind, hook auto-exec, SSRF, tool-gate authz) — closed with per-issue dispositions.

**Test plan:** pytest **1226 passed**; ruff/mypy clean; sync `--check` clean. Rule count unchanged (225); no version bump (folds into pending v0.3.41).