### PR TITLE
feat: State of MCP Security 2026 data-report harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — State-of-MCP-Security-2026 research harness + report
+
+New `research/state-of-mcp-2026/` directory: a reproducible data-report harness
+(`run_report.py`) that scans a corpus of public MCP configs and aggregates a
+grade distribution (A–F), per-category hit rates, and the top misconfigurations.
+It contains **no scanner** — it reuses `agent_audit_kit.engine.run_scan` and
+`agent_audit_kit.scoring.compute_score` (the same scan + grade the CLI / MCP
+Security Index use), and delegates corpus acquisition to the existing
+`benchmarks/crawler.py`. Ships the raw aggregate (`results.json`) and the
+human-readable writeup (`REPORT.md`). Headline from the committed run: 571
+distinct configs, 25.7% with a critical finding, ~29% grade A. README gains a
+"State of MCP Security 2026" section with the reproduce command. Docs/research
+only — no package code, no version bump.
+
 ### Changed — CVE-backlog coverage: extend existing pins (Flowise/LiteLLM/Doris)
 
 Worked the open `sla-48h` backlog. The genuinely AAK-actionable items map to

--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ Public leaderboard of MCP servers we scan weekly:
 - **90-day coordinated disclosure** before anything lands on a public card — see [`docs/disclosure-policy.md`](docs/disclosure-policy.md)
 - Maintainer-fix earlier gets published the day the fix lands, with credit
 
+## State of MCP Security 2026
+
+A reproducible, offline data report: we scanned **571 distinct public MCP server
+configs** and found **1 in 4 ships a critical-severity flaw** (only ~29% earn an
+"A"). Full methodology, grade distribution, top misconfigurations, external
+anchors (MCP Registry 9,652 servers; Knostic 1,862 exposed / 119-of-119
+unauthenticated; the 2,614-server 82%-path-traversal survey), and honesty
+caveats are in **[`research/state-of-mcp-2026/REPORT.md`](research/state-of-mcp-2026/REPORT.md)**
+(raw aggregate: [`results.json`](research/state-of-mcp-2026/results.json)).
+
+The harness contains no scanner — it reuses `agent_audit_kit.engine.run_scan` +
+`scoring.compute_score`. Reproduce:
+
+```bash
+export GITHUB_TOKEN=$(gh auth token)
+python benchmarks/crawler.py --limit 500 --output benchmarks/results.json
+python research/state-of-mcp-2026/run_report.py --corpus benchmarks/data \
+    --out research/state-of-mcp-2026/results.json
+```
+
 ## CVE Response
 
 AgentAuditKit tracks newly disclosed MCP CVEs and ships rule coverage on a best-effort basis, recorded in a public ledger ([`CHANGELOG.cves.md`](CHANGELOG.cves.md)). A [GitHub Action](.github/workflows/cve-watcher.yml) watches NVD's MCP keyword feed every 6 hours and files a tracking issue for each new disclosure.

--- a/research/state-of-mcp-2026/REPORT.md
+++ b/research/state-of-mcp-2026/REPORT.md
@@ -1,0 +1,161 @@
+# The State of MCP Security 2026
+
+## We scanned 571 public MCP server configs with an offline static scanner. 1 in 4 ships a critical-severity flaw, and only ~29% earn an "A".
+
+> **Reproducible data report.** Every number under "What we measured" comes from
+> running [AgentAuditKit](https://github.com/sattyamjjain/agent-audit-kit)
+> (v0.3.41, 225 rules, fully offline, MIT) over a content-deduplicated corpus of
+> public MCP configs. The raw aggregate is committed alongside this file as
+> [`results.json`](results.json); the exact command to regenerate it is in
+> *Reproduce this*. External figures (next section) are attributed to their
+> sources, not measured by us.
+
+---
+
+## Why this matters now (verified external anchors)
+
+The Model Context Protocol went from proposal to cross-vendor default in ~18
+months, and the exposed surface is already large and under-secured:
+
+- **The official MCP Registry listed 9,652 servers as of 2026-05-24** — the
+  ecosystem is now thousands of independently-published servers, not a handful.
+  *(Source: official MCP Registry export, 2026-05-24.)*
+- **Knostic found 1,862 MCP servers exposed on the public internet, and 119 of
+  119 they probed allowed unauthenticated tool-listing** — i.e. every exposed
+  server they tested would hand its tool catalog to an anonymous caller.
+  *(Source: Knostic research.)*
+- **A 2,614-server survey found 82% had path-traversal issues.** *(Source: the
+  2,614-server MCP survey.)*
+
+These say the *population* is big and the *authentication/path* hygiene is poor.
+This report adds the missing piece: **what the configuration files people
+actually commit look like, measured deterministically.**
+
+### Where AgentAuditKit fits (two defensible wedges)
+
+1. **Offline & deterministic.** Every figure here was produced with zero network
+   calls and no LLM — the same corpus yields the same findings, byte-for-byte.
+   That is what makes a *report* reproducible and an *audit* defensible.
+2. **Compliance-evidence, not just findings.** The same scan emits SARIF for the
+   GitHub Security tab plus auditor-ready PDF evidence mapped to 13 frameworks
+   (EU AI Act, SOC 2, ISO 27001/42001, HIPAA, NIST AI RMF, and regional regimes).
+
+---
+
+## What we measured
+
+- **Corpus:** 631 publicly-committed MCP config files discovered via GitHub Code
+  Search (seeded to overlap the MCP Registry export + mcp.so top-N), then
+  content-deduplicated — **59 byte-identical duplicates and 1 unparseable file
+  removed, leaving 571 distinct configs.**
+- **Tool:** AgentAuditKit v0.3.41 — 225 deterministic rules, no cloud, no
+  telemetry. Each config scanned in isolation via the same `run_scan` +
+  `compute_score` the CLI and the MCP Security Index use.
+
+### Headline
+
+- **147 of 571 configs (25.7%) contain at least one CRITICAL-severity finding.**
+- **143 of 571 (25.0%) contain at least one HIGH-severity finding.**
+- Across all configs: **259 critical · 280 high · 2,256 medium · 586 low**
+  findings.
+
+### Grade distribution (A–F)
+
+| Grade | Configs | Share |
+|:-----:|--------:|------:|
+| **A** | 165 | 28.9% |
+| **B** | 213 | 37.3% |
+| **C** | 78 | 13.7% |
+| **D** | 45 | 7.9% |
+| **F** | 70 | 12.3% |
+
+**~1 in 5 configs (20.1%) land at D or F.** The grade is AAK's penalty-based
+score (start at 100, deduct per finding severity), identical to `aak score`.
+
+### Where the findings cluster (per-category hit rate)
+
+| Category | Configs with ≥1 finding | Share |
+|---|--:|--:|
+| MCP configuration | 567 | 99.3% |
+| Secret exposure | 63 | 11.0% |
+| Transport security | 18 | 3.2% |
+| Tool poisoning / agent-config / legal | 1 each | ~0.2% |
+
+The story is overwhelmingly a **configuration** story: launch/transport/auth
+hygiene in the `.mcp.json` itself, not exotic tool-poisoning.
+
+### Top 5 misconfigurations (advisory-posture rules excluded)
+
+| Rule | Severity | Configs | Share |
+|---|:---:|--:|--:|
+| `AAK-MCP-005` — server uses `npx`/`uvx` to fetch-and-execute remote packages | MEDIUM | 248 | 43.4% |
+| `AAK-MCP-006` — server command uses a relative path | MEDIUM | 149 | 26.1% |
+| `AAK-MCP-001` — remote MCP server without authentication | **CRITICAL** | 136 | 23.8% |
+| `AAK-MCP-003` — server environment exposes secrets to the tool process | HIGH | 63 | 11.0% |
+| `AAK-SECRET-007` — secret in MCP server environment block | MEDIUM | 63 | 11.0% |
+
+The two things worth fixing **today**: (1) **pin what you launch** — 43% of
+configs `npx`/`uvx` fetch-and-run whatever the registry serves that moment; (2)
+**authenticate mutating remote servers** — ~1 in 4 declares a remote server with
+no auth, which aligns with Knostic's 119-of-119 unauthenticated finding from the
+*deployment* side.
+
+### What we deliberately did NOT count
+
+To avoid inflating the story, two advisory-posture rules are **excluded** from
+the "top misconfigurations" table (they are tracked in `results.json` under
+`excluded_advisory_rules`):
+
+- `AAK-MCP-ATTEST-001` (deny-by-default attestation) — fires on nearly every
+  server because attestation isn't an ecosystem norm yet; a roadmap signal, not
+  an exploit.
+- `AAK-MCP-007` (no version pin in `args`, LOW) — advisory hygiene.
+
+---
+
+## Honesty caveats (read before quoting)
+
+1. **The sample skews to discoverable public repos** (Code Search ranks by
+   relevance + stars). It is "configs people publish," not a uniform random
+   sample of the ~9,652 registered servers.
+2. **Static analysis both over- and under-counts.** A matched pattern is not
+   proof of exploitability in context; a clean scan is not proof of safety.
+3. **N = 571 is a sample.** We say "571 configs," never "the MCP ecosystem."
+4. **External figures are as-reported** by the cited third parties (MCP Registry,
+   Knostic, the 2,614-server survey); only the 571-config scan is our own
+   measurement.
+
+---
+
+## Reproduce this
+
+```bash
+git clone https://github.com/sattyamjjain/agent-audit-kit && cd agent-audit-kit
+pip install -e .
+
+# 1. Acquire the corpus (reuses the existing crawler)
+export GITHUB_TOKEN=$(gh auth token)
+python benchmarks/crawler.py --limit 500 --output benchmarks/results.json
+
+# 2. Scan + aggregate (reuses agent_audit_kit.engine.run_scan + scoring.compute_score)
+python research/state-of-mcp-2026/run_report.py \
+    --corpus benchmarks/data \
+    --out research/state-of-mcp-2026/results.json
+```
+
+The harness contains **no scanner** — it calls the same `run_scan` /
+`compute_score` the product ships. Output is deterministic for a fixed corpus.
+
+## Methodology note: novel-pattern discovery
+
+This harness reports the **prevalence of patterns AAK already has rules for** —
+it cannot, by construction, surface a misconfiguration class for which no rule
+exists. Discovering genuinely *uncovered* patterns is a manual corpus-inspection
+follow-up; any that hold up will be filed as `cve-response`/finding issues and
+turned into rules separately. No speculative findings were filed for this report.
+
+---
+
+*Marketing/launch copy for this report lives in
+[`launch/state-of-mcp-security-2026.md`](../../launch/state-of-mcp-security-2026.md);
+this file is the rigorous, reproducible source of record.*

--- a/research/state-of-mcp-2026/results.json
+++ b/research/state-of-mcp-2026/results.json
@@ -1,0 +1,93 @@
+{
+  "tool": "agent-audit-kit",
+  "corpus": "benchmarks/data",
+  "corpus_total_files": 631,
+  "distinct_configs_scanned": 571,
+  "duplicates_removed": 59,
+  "unparseable_removed": 1,
+  "grade_distribution": {
+    "A": 165,
+    "B": 213,
+    "C": 78,
+    "D": 45,
+    "F": 70
+  },
+  "configs_with_critical": 147,
+  "configs_with_critical_pct": 25.7,
+  "configs_with_high": 143,
+  "configs_with_high_pct": 25.0,
+  "severity_totals": {
+    "medium": 2256,
+    "low": 586,
+    "critical": 259,
+    "high": 280,
+    "info": 1
+  },
+  "category_hit_rate": {
+    "mcp-config": {
+      "configs": 567,
+      "pct": 99.3
+    },
+    "secret-exposure": {
+      "configs": 63,
+      "pct": 11.0
+    },
+    "transport-security": {
+      "configs": 18,
+      "pct": 3.2
+    },
+    "legal-compliance": {
+      "configs": 1,
+      "pct": 0.2
+    },
+    "agent-config": {
+      "configs": 1,
+      "pct": 0.2
+    },
+    "tool-poisoning": {
+      "configs": 1,
+      "pct": 0.2
+    }
+  },
+  "top_misconfigurations": [
+    {
+      "rule_id": "AAK-MCP-005",
+      "title": "MCP server uses npx/uvx to fetch and execute remote packages",
+      "severity": "medium",
+      "configs": 248,
+      "config_pct": 43.4
+    },
+    {
+      "rule_id": "AAK-MCP-006",
+      "title": "MCP server command uses relative path",
+      "severity": "medium",
+      "configs": 149,
+      "config_pct": 26.1
+    },
+    {
+      "rule_id": "AAK-MCP-001",
+      "title": "Remote MCP server without authentication",
+      "severity": "critical",
+      "configs": 136,
+      "config_pct": 23.8
+    },
+    {
+      "rule_id": "AAK-MCP-003",
+      "title": "MCP server environment exposes secrets",
+      "severity": "high",
+      "configs": 63,
+      "config_pct": 11.0
+    },
+    {
+      "rule_id": "AAK-SECRET-007",
+      "title": "Secret in MCP server environment block",
+      "severity": "medium",
+      "configs": 63,
+      "config_pct": 11.0
+    }
+  ],
+  "excluded_advisory_rules": [
+    "AAK-MCP-007",
+    "AAK-MCP-ATTEST-001"
+  ]
+}

--- a/research/state-of-mcp-2026/run_report.py
+++ b/research/state-of-mcp-2026/run_report.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""State of MCP Security 2026 — reproducible research harness.
+
+Scans a corpus of public MCP server configs with AgentAuditKit and aggregates
+the findings into a grade distribution (A–F), per-rule-category hit rates, and
+the top-N most-common misconfigurations.
+
+This harness does NOT contain a scanner. It REUSES:
+  - ``agent_audit_kit.engine.run_scan``      — the scan entrypoint (engine.py)
+  - ``agent_audit_kit.scoring.compute_score`` — the same penalty-based A–F
+                                                grade the MCP Security Index /
+                                                ``aak score`` uses (scoring/__init__.py)
+  - ``agent_audit_kit.rules.builtin.RULES``   — rule titles for the top-N table
+
+Corpus acquisition is delegated to the existing crawler,
+``benchmarks/crawler.py`` (GitHub Code Search → downloaded ``.mcp.json`` files),
+seeded to match the official MCP Registry export + mcp.so top-N. Point
+``--corpus`` at its output directory (default ``benchmarks/data``).
+
+Reproduce:
+    export GITHUB_TOKEN=$(gh auth token)
+    python benchmarks/crawler.py --limit 500 --output benchmarks/results.json
+    python research/state-of-mcp-2026/run_report.py \
+        --corpus benchmarks/data \
+        --out research/state-of-mcp-2026/results.json
+
+Output is deterministic for a fixed corpus (offline, no network, no LLM).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import tempfile
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from agent_audit_kit.engine import run_scan
+from agent_audit_kit.rules.builtin import RULES
+from agent_audit_kit.scoring import compute_score
+
+# Findings AAK reports that are advisory *posture* signals, not exploitable
+# misconfigurations. Excluded from the "top misconfigurations" headline so the
+# story isn't inflated (documented in REPORT.md).
+_ADVISORY_RULES = frozenset({"AAK-MCP-ATTEST-001", "AAK-MCP-007"})
+
+
+def _iter_configs(corpus: Path) -> list[Path]:
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for pattern in ("*.json",):
+        for p in sorted(corpus.rglob(pattern)):
+            if p.is_file() and p not in seen:
+                seen.add(p)
+                out.append(p)
+    return out
+
+
+def _content_key(path: Path) -> str | None:
+    """Stable sha256 of the normalised JSON so byte-identical configs that
+    differ only in formatting dedupe to one sample."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except (ValueError, OSError):
+        return None
+    blob = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _scan_one(path: Path) -> Any:
+    """Scan a single config in isolation by copying it into a temp project root
+    and reusing engine.run_scan + scoring.compute_score."""
+    tmp = Path(tempfile.mkdtemp(prefix="aak-somcp-"))
+    try:
+        shutil.copy(path, tmp / path.name)
+        result = run_scan(tmp)
+        compute_score(result)
+        return result
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def aggregate(corpus: Path) -> dict[str, Any]:
+    configs = _iter_configs(corpus)
+    seen_keys: set[str] = set()
+
+    total = 0
+    duplicates = 0
+    unparseable = 0
+    grades: Counter[str] = Counter()
+    severities: Counter[str] = Counter()
+    category_configs: Counter[str] = Counter()  # configs with >=1 finding in cat
+    rule_configs: Counter[str] = Counter()       # configs with >=1 finding of rule
+    has_critical = 0
+    has_high = 0
+
+    for path in configs:
+        key = _content_key(path)
+        if key is None:
+            unparseable += 1
+            continue
+        if key in seen_keys:
+            duplicates += 1
+            continue
+        seen_keys.add(key)
+
+        result = _scan_one(path)
+        total += 1
+        grades[result.grade or "?"] += 1
+
+        cats_here: set[str] = set()
+        rules_here: set[str] = set()
+        sev_here: set[str] = set()
+        for f in result.findings:
+            sev = f.severity.value
+            severities[sev] += 1
+            sev_here.add(sev)
+            cats_here.add(f.category.value)
+            rules_here.add(f.rule_id)
+        for c in cats_here:
+            category_configs[c] += 1
+        for r in rules_here:
+            rule_configs[r] += 1
+        if "critical" in sev_here:
+            has_critical += 1
+        if "high" in sev_here:
+            has_high += 1
+
+    def _pct(n: int) -> float:
+        return round(100.0 * n / total, 1) if total else 0.0
+
+    top_misconfig = [
+        {
+            "rule_id": rid,
+            "title": RULES[rid].title if rid in RULES else rid,
+            "severity": RULES[rid].severity.value if rid in RULES else "?",
+            "configs": n,
+            "config_pct": _pct(n),
+        }
+        for rid, n in rule_configs.most_common()
+        if rid not in _ADVISORY_RULES
+    ][:5]
+
+    return {
+        "tool": "agent-audit-kit",
+        "corpus": str(corpus),
+        "corpus_total_files": len(configs),
+        "distinct_configs_scanned": total,
+        "duplicates_removed": duplicates,
+        "unparseable_removed": unparseable,
+        "grade_distribution": dict(sorted(grades.items())),
+        "configs_with_critical": has_critical,
+        "configs_with_critical_pct": _pct(has_critical),
+        "configs_with_high": has_high,
+        "configs_with_high_pct": _pct(has_high),
+        "severity_totals": dict(severities),
+        "category_hit_rate": {
+            cat: {"configs": n, "pct": _pct(n)}
+            for cat, n in category_configs.most_common()
+        },
+        "top_misconfigurations": top_misconfig,
+        "excluded_advisory_rules": sorted(_ADVISORY_RULES),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--corpus", default="benchmarks/data",
+        help="Directory of downloaded MCP configs (default: benchmarks/data).",
+    )
+    parser.add_argument(
+        "--out", default="research/state-of-mcp-2026/results.json",
+        help="Where to write the aggregate results JSON.",
+    )
+    args = parser.parse_args()
+
+    corpus = Path(args.corpus)
+    if not corpus.is_dir():
+        raise SystemExit(
+            f"Corpus dir {corpus} not found. Populate it first:\n"
+            "  export GITHUB_TOKEN=$(gh auth token)\n"
+            "  python benchmarks/crawler.py --limit 500 --output benchmarks/results.json"
+        )
+
+    data = aggregate(corpus)
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    g = data["grade_distribution"]
+    print(
+        f"scanned {data['distinct_configs_scanned']} distinct configs "
+        f"({data['duplicates_removed']} dup, {data['unparseable_removed']} unparseable removed)\n"
+        f"grades: {g}\n"
+        f"critical: {data['configs_with_critical']} ({data['configs_with_critical_pct']}%) "
+        f"| high: {data['configs_with_high']} ({data['configs_with_high_pct']}%)\n"
+        f"wrote {out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds `research/state-of-mcp-2026/` — a reproducible, offline data report.

## Anti-duplicate (reuses existing scan + grade code)
The harness (`run_report.py`) contains **no scanner**. It reuses:
- `agent_audit_kit.engine.run_scan` — the scan entrypoint (`engine.py`)
- `agent_audit_kit.scoring.compute_score` — the same A–F grade as `aak score` / the MCP Security Index (`scoring/__init__.py`)
- `benchmarks/crawler.py` — existing corpus acquisition (cited; not duplicated)

## Deliverables
- **`results.json`** — raw aggregate (committed): grade distribution, severity totals, per-category hit rate, top-5 misconfigurations.
- **`REPORT.md`** — writeup leading with verified external anchors (MCP Registry **9,652** servers 2026-05-24; Knostic **1,862** exposed / **119-of-119** unauthenticated tool-listing; **2,614-server** survey **82%** path-traversal), the two wedges (offline/deterministic + compliance-evidence), methodology, honesty caveats, and an exact reproduce command.

## Headline (from the committed run, v0.3.41 / 225 rules)
**571 distinct configs · 25.7% ship a critical · ~29% grade A · top misconfig = npx/uvx fetch-and-execute (43%).** (Numbers differ from the earlier `launch/` draft because the rule set grew 221→225; this report is grounded in the fresh scan.)

## Scope decisions
- **No version bump** — research/docs only, no package code (matches the prior data-report precedent).
- **No finding issues filed** — the harness reports prevalence of *existing-rule* patterns by construction; nothing genuinely uncovered was auto-surfaced, so no speculative `cve-response` issues (documented in REPORT.md). Manual novel-pattern discovery is a noted follow-up.
- Stays static-SAST + offline + compliance-evidence — no runtime pivot, no cloud, no paywall.

## Test plan
`ruff check .` clean (incl. harness); `mypy` clean (140 files, incl. harness); sync `--check` clean; `pytest` **1226 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)