### PR TITLE
docs: finish State of MCP Security 2026 report (launch-ready) + v0.3.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — finish the State of MCP Security 2026 report (launch-ready)
+
+Promoted the data-report harness (shipped in #373) into a finished, launch-ready
+report. `research/state-of-mcp-2026/REPORT.md` gains an executive summary, an
+OWASP-MCP-Top-10 hit-rate table, three anonymized CVE-class case studies, a
+"how we scan (offline, reproducible)" section leading with the two wedges, and a
+`pip install` self-scan block so the report doubles as a distribution funnel.
+Every figure is sourced to `results.json` — the harness was re-run against the
+current corpus (571 distinct configs; 25.7% critical; 28.9% grade A; 99.3% trip
+OWASP MCP07). The harness now also aggregates `owasp_mcp_hit_rate` (no scanner
+change — it reads `owasp_mcp_references` off the existing rules). Filled
+`docs/DISTRIBUTION-CHECKLIST.md` with ready-to-post copy (Show HN, r/netsec,
+OWASP working-group note, awesome-mcp-security) — operator-posted, nothing
+auto-posts. Version **0.3.41 → 0.3.42**. No scanner rules added; rule count
+stays 225.
+
 ### Changed — docs: align public rule-count to canonical 225; promote State-of-MCP-Security-2026 report
 
 Killed the last public rule-count drift: the GitHub repo "About" description and

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.41
+      - uses: sattyamjjain/agent-audit-kit@v0.3.42
         with:
           fail-on: high
 ```
@@ -86,7 +86,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.41
+    rev: v0.3.42
     hooks:
       - id: agent-audit-kit
 ```
@@ -395,8 +395,15 @@ survey), and honesty caveats are in
 **[`research/state-of-mcp-2026/REPORT.md`](research/state-of-mcp-2026/REPORT.md)**
 (raw aggregate: [`results.json`](research/state-of-mcp-2026/results.json)).
 
+Mapped to the OWASP MCP Top 10, **99.3% of configs trip MCP07 (authorization /
+excessive permissions)**. Scan your own in 30s, fully offline:
+
+```bash
+pip install agent-audit-kit && agent-audit-kit scan .
+```
+
 The harness contains no scanner — it reuses `agent_audit_kit.engine.run_scan` +
-`scoring.compute_score`. Reproduce:
+`scoring.compute_score`. Regenerate the report:
 
 ```bash
 export GITHUB_TOKEN=$(gh auth token)
@@ -404,6 +411,8 @@ python benchmarks/crawler.py --limit 500 --output benchmarks/results.json
 python research/state-of-mcp-2026/run_report.py --corpus benchmarks/data \
     --out research/state-of-mcp-2026/results.json
 ```
+
+Launch-ready copy for the report is in [`docs/DISTRIBUTION-CHECKLIST.md`](docs/DISTRIBUTION-CHECKLIST.md).
 
 ## CVE Response
 

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,6 +1,6 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.41"
+__version__ = "0.3.42"
 RULE_COUNT = 225
 SCANNER_COUNT = 79

--- a/docs/DISTRIBUTION-CHECKLIST.md
+++ b/docs/DISTRIBUTION-CHECKLIST.md
@@ -1,65 +1,133 @@
 # Distribution Checklist — State of MCP Security 2026
 
-A manual launch checklist for the data report
+Manual launch checklist + **ready-to-post copy** for the data report
 ([`research/state-of-mcp-2026/REPORT.md`](../research/state-of-mcp-2026/REPORT.md)).
-**Nothing here is automated** — every item is a human action. Post deliberately,
-one surface at a time, and respond to replies.
+**Nothing here auto-posts.** Copy, sanity-check the links, post one surface at a
+time, reply to comments.
 
-Canonical numbers to quote (from `results.json`, do not round up):
-**571 distinct configs · 25.7% with a critical finding · ~29% grade A ·
-top misconfig = `npx`/`uvx` fetch-and-execute (43%) · 24% no-auth remote.**
-Static, offline, deterministic — reproduce command is in the report.
+**Canonical numbers (from `results.json` — do not round up):**
+571 distinct configs · 25.7% with a critical finding · 28.9% grade A ·
+top misconfig = `npx`/`uvx` fetch-and-execute (43.4%) · 23.8% no-auth remote ·
+99.3% trip OWASP MCP07 (authorization). Static, offline, deterministic.
+
+Report link: `https://github.com/sattyamjjain/agent-audit-kit/blob/main/research/state-of-mcp-2026/REPORT.md`
 
 ---
 
-## Surfaces (in suggested order)
+## 1. Show HN — post Tue or Wed, ~8–9am ET
 
-### 1. Show HN — Tue/Wed ~8–9am ET
-- [ ] Title (research-framed, not a tool pitch):
-      **"I scanned 571 public MCP servers — here's what's exposed"**
-- [ ] First comment (post as author, immediately): one paragraph — method
-      (offline deterministic scan), the headline stat, the honest caveats
-      (sample skews to public repos; static over/under-counts), and a link to
-      the reproduce command. Say plainly it's not a replacement for runtime
-      tools (Snyk `agent-scan`) — this is the static/CI/offline angle.
-- [ ] Do NOT gate the dataset behind email. Do NOT say "the MCP ecosystem" —
-      say "571 configs". Reply to every comment for the first ~3 hours.
+**Title:**
+```
+Show HN: I scanned 571 public MCP server configs — 1 in 4 has a critical flaw
+```
 
-### 2. r/netsec — research framing ONLY
-- [ ] Title: **"The State of MCP Security 2026: 571 public MCP configs scanned
-      (data + reproducible methodology)"**
-- [ ] Lead with dataset + method + the reproducible harness link; put the tool
-      name in the body, not the title (r/netsec removes product posts — this
-      passes as original research because it is). Link `REPORT.md` + `results.json`.
+**First comment (post immediately, as author):**
+```
+I run an open-source static scanner for MCP/agent configs (agent-audit-kit,
+MIT). I took 571 distinct public .mcp.json files and scanned each one offline
+and deterministically — no cloud, no LLM, same input gives the same result.
 
-### 3. awesome-mcp-security PR
-- [ ] Confirm AAK isn't already listed; add one factual line under the
-      tools/SAST section, following that repo's `CONTRIBUTING.md` (dated
-      template, alphabetical/new-on-top as required).
-- [ ] Line: *"agent-audit-kit — offline SAST scanner for MCP/agent pipelines;
-      OWASP Agentic + MCP Top-10; SARIF + compliance reports."*
-      (Note: an entry already exists in `Puliczek/awesome-mcp-security` PR — check status before re-submitting.)
+Findings: 25.7% have at least one critical issue, and only 29% grade an A. The
+two big ones are boring and fixable — 43% launch their server with npx/uvx and
+no pinned version (so it runs whatever the registry serves that second), and 24%
+declare a remote server with no auth. That last one lines up with Knostic's
+separate finding that 119 of 119 exposed servers they probed allowed
+unauthenticated tool-listing.
 
-### 4. OWASP GenAI / MCP Top 10 working group
-- [ ] `github.com/OWASP/www-project-mcp-top-10` (Phase-3 beta — accepts
-      real-world data). Open a Discussion first, not a cold PR.
-- [ ] Offer the dataset as evidence for the **unauthenticated-transport** and
-      **supply-chain / fetch-and-execute** categories (strongest, externally
-      corroborated by Knostic 119-of-119 + this report's 24% no-auth / 43% npx).
+I tried to keep it honest: the sample skews to public repos, static analysis
+over- and under-counts, and I say "571 configs", not "the MCP ecosystem". Full
+method + the exact command to reproduce it is in the report.
+
+Not trying to replace runtime tools like Snyk agent-scan — this is the
+static/CI/offline angle. You can scan your own in 30s: pip install
+agent-audit-kit && agent-audit-kit scan .
+
+Report: <report link>
+Repo: https://github.com/sattyamjjain/agent-audit-kit
+```
+
+- [ ] Posted Tue/Wed AM. Do NOT gate the data behind email. Reply for ~3h.
+
+---
+
+## 2. r/netsec — research framing, tool name in body not title
+
+**Title:**
+```
+The State of MCP Security 2026: 571 public MCP configs scanned (data + reproducible method)
+```
+
+**Body:**
+```
+MCP servers are proliferating (the official registry listed 9,652 as of
+2026-05-24) and the config hygiene is rough. I scanned 571 distinct public
+.mcp.json files with an offline, deterministic static analyzer and aggregated
+the results.
+
+Headline: 25.7% have a critical finding; 28.9% grade A. Mapped to the OWASP MCP
+Top 10, 99.3% trip MCP07 (authorization / excessive permissions). Most common
+issues: npx/uvx fetch-and-execute at launch (43.4%), no-auth remote server
+(23.8%), secret inlined in the config env block (11%).
+
+Method and raw aggregate (results.json) are committed; there's an exact
+reproduce command. The scanner is open source (agent-audit-kit, MIT); I've kept
+the caveats in the report (sample skew, static over/under-count, N=571 is a
+sample).
+
+Report + data + method: <report link>
+```
+
+- [ ] r/netsec removes product posts — this passes as original research because
+      it is. Link `REPORT.md` + `results.json`; keep the tool name out of the title.
+
+---
+
+## 3. OWASP GenAI / MCP Top 10 working group
+
+Target: `github.com/OWASP/www-project-mcp-top-10` (Phase-3 beta, accepts
+real-world data). Open a Discussion first, not a cold PR.
+
+**One-paragraph note:**
+```
+Sharing real-world prevalence data that may be useful evidence for the MCP Top
+10. I statically scanned 571 distinct public MCP server configs (offline,
+deterministic; method + raw results committed and reproducible). Mapped to the
+current list: 99.3% of configs trip MCP07 (authorization/excessive perms),
+43.4% trip the supply-chain/untrusted-execution risk (npx/uvx unpinned launch),
+and 23.8% declare a remote server with no authentication — which corroborates
+Knostic's 119-of-119 unauthenticated-tool-listing finding from the deployment
+side. Happy to contribute the dataset or a category-by-category breakdown.
+Report: <report link>
+```
+
 - [ ] Contribute *data*, not a tool plug. Permalink to the merged report commit.
 
-### 5. Cross-references
-- [ ] Once Show HN + r/netsec are live, cross-reference them for credibility.
-- [ ] Drop the report link in any MCP registry / directory listing that allows
-      a "security" note (PulseMCP, Glama) — passive, not spammy.
+---
+
+## 4. awesome-mcp-security PR
+
+- [ ] `Puliczek/awesome-mcp-security` already has an agent-audit-kit entry (PR
+      submitted earlier). **Check its status first** — if merged, do nothing; if
+      open, nudge; only submit elsewhere if genuinely absent.
+- [ ] If adding to another list, one factual line, follow that repo's
+      CONTRIBUTING (dated template / alphabetical / new-on-top as required):
+      *"agent-audit-kit — offline SAST scanner for MCP/agent pipelines; OWASP
+      Agentic + MCP Top-10; SARIF + compliance reports."*
+
+---
+
+## 5. Cross-references (after 1 & 2 are live)
+- [ ] Cross-link Show HN ↔ r/netsec for credibility.
+- [ ] Drop the report link where a "security" note is welcome (PulseMCP, Glama)
+      — passive, not spammy.
 
 ---
 
 ## Guardrails
-- One launch problem-essay drafted separately; keep claims to what `results.json`
-  supports. External figures stay attributed to their sources (MCP Registry,
-  Knostic, the 2,614-server survey).
-- No paywall, no email gate, no cloud upload of anyone's configs — the whole
-  pitch is offline/deterministic; don't undercut it.
+- Every number must trace to `results.json`. External figures stay attributed
+  (MCP Registry, Knostic, the 2,614-server survey).
+- No paywall, no email gate, no cloud upload of anyone's configs — the pitch is
+  offline/deterministic; don't undercut it.
 - If a maintainer whose config is graded asks for a fix window, honor the 90-day
   coordinated-disclosure policy (`docs/disclosure-policy.md`).
+- Replace `<report link>` with the real URL before posting.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.41
+      - uses: sattyamjjain/agent-audit-kit@v0.3.42
         with:
           severity: low
           fail-on: high
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.41
+    rev: v0.3.42
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.41
+    rev: v0.3.42
     hooks:
       - id: agent-audit-kit
 ```
@@ -59,7 +59,7 @@ repos:
 ## GitHub Action
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.41
+- uses: sattyamjjain/agent-audit-kit@v0.3.42
   with:
     severity: low
     fail-on: high

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -92,7 +92,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.41
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.42
 >
 > MIT. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.41
+- uses: sattyamjjain/agent-audit-kit@v0.3.42
   with:
     preset: mcp-ox-2026-04
 ```

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-06-27T10:05:37Z",
-  "aak_version": "0.3.41",
+  "last_updated": "2026-07-01T17:46:03Z",
+  "aak_version": "0.3.42",
   "rule_count": 225,
   "coverage": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.41"
+version = "0.3.42"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/research/state-of-mcp-2026/REPORT.md
+++ b/research/state-of-mcp-2026/REPORT.md
@@ -4,11 +4,31 @@
 
 > **Reproducible data report.** Every number under "What we measured" comes from
 > running [AgentAuditKit](https://github.com/sattyamjjain/agent-audit-kit)
-> (v0.3.41, 225 rules, fully offline, MIT) over a content-deduplicated corpus of
+> (v0.3.42, 225 rules, fully offline, MIT) over a content-deduplicated corpus of
 > public MCP configs. The raw aggregate is committed alongside this file as
-> [`results.json`](results.json); the exact command to regenerate it is in
-> *Reproduce this*. External figures (next section) are attributed to their
+> [`results.json`](results.json); the command to regenerate it is in
+> *How we scan*. External figures (next section) are attributed to their
 > sources, not measured by us.
+
+---
+
+## Executive summary
+
+- We statically scanned **571 distinct public MCP server configuration files**.
+  **147 (25.7%) contain at least one critical-severity finding**; only **165
+  (28.9%) earn an "A"** and **115 (20.1%) land at D or F**.
+- The single most common problem is **fetch-and-execute at launch**: **43.4% of
+  configs** start their server with `npx`/`uvx`, running whatever the registry
+  serves that moment (no pinned version, no hash).
+- The most common *critical* problem is **missing authentication on a remote
+  server** — **23.8% of configs** — which matches, from the deployment side,
+  Knostic's finding that **119 of 119** exposed servers they probed allowed
+  unauthenticated tool-listing.
+- Mapped to the OWASP MCP Top 10, **99.3% of configs** trip **MCP07:2025
+  (Insufficient Authorization / Excessive Permissions)** — this is an
+  authorization-and-launch-hygiene story, not exotic tool-poisoning.
+- It's fixable with a linter in CI, not a new exploit: **pin what you launch**
+  and **require a credential on anything mutating**.
 
 ---
 
@@ -21,43 +41,34 @@ months, and the exposed surface is already large and under-secured:
   ecosystem is now thousands of independently-published servers, not a handful.
   *(Source: official MCP Registry export, 2026-05-24.)*
 - **Knostic found 1,862 MCP servers exposed on the public internet, and 119 of
-  119 they probed allowed unauthenticated tool-listing** — i.e. every exposed
-  server they tested would hand its tool catalog to an anonymous caller.
+  119 they probed allowed unauthenticated tool-listing** — every exposed server
+  they tested would hand its tool catalog to an anonymous caller.
   *(Source: Knostic research.)*
-- **A 2,614-server survey found 82% had path-traversal issues.** *(Source: the
-  2,614-server MCP survey.)*
+- **A 2,614-server survey found 82% had path-traversal issues.**
+  *(Source: the 2,614-server MCP survey.)*
 
-These say the *population* is big and the *authentication/path* hygiene is poor.
-This report adds the missing piece: **what the configuration files people
-actually commit look like, measured deterministically.**
-
-### Where AgentAuditKit fits (two defensible wedges)
-
-1. **Offline & deterministic.** Every figure here was produced with zero network
-   calls and no LLM — the same corpus yields the same findings, byte-for-byte.
-   That is what makes a *report* reproducible and an *audit* defensible.
-2. **Compliance-evidence, not just findings.** The same scan emits SARIF for the
-   GitHub Security tab plus auditor-ready PDF evidence mapped to 13 frameworks
-   (EU AI Act, SOC 2, ISO 27001/42001, HIPAA, NIST AI RMF, and regional regimes).
+Those say the *population* is big and the *auth/path* hygiene is poor. This
+report adds the missing piece: **what the configuration files people actually
+commit look like, measured deterministically.**
 
 ---
 
 ## What we measured
 
-- **Corpus:** 631 publicly-committed MCP config files discovered via GitHub Code
+- **Corpus.** 631 publicly-committed MCP config files discovered via GitHub Code
   Search (seeded to overlap the MCP Registry export + mcp.so top-N), then
   content-deduplicated — **59 byte-identical duplicates and 1 unparseable file
   removed, leaving 571 distinct configs.**
-- **Tool:** AgentAuditKit v0.3.41 — 225 deterministic rules, no cloud, no
-  telemetry. Each config scanned in isolation via the same `run_scan` +
-  `compute_score` the CLI and the MCP Security Index use.
+- **Scanner.** AgentAuditKit **v0.3.42, 225 rules** — no cloud, no telemetry, no
+  LLM. Each config is scanned in isolation through the same `run_scan` +
+  `compute_score` the CLI and the public MCP Security Index use. Deterministic:
+  the same corpus produces the same `results.json`, byte-for-byte.
 
 ### Headline
 
-- **147 of 571 configs (25.7%) contain at least one CRITICAL-severity finding.**
-- **143 of 571 (25.0%) contain at least one HIGH-severity finding.**
-- Across all configs: **259 critical · 280 high · 2,256 medium · 586 low**
-  findings.
+- **147 of 571 (25.7%) have ≥1 CRITICAL finding.**
+- **143 of 571 (25.0%) have ≥1 HIGH finding.**
+- All findings: **259 critical · 280 high · 2,256 medium · 586 low.**
 
 ### Grade distribution (A–F)
 
@@ -72,17 +83,16 @@ actually commit look like, measured deterministically.**
 **~1 in 5 configs (20.1%) land at D or F.** The grade is AAK's penalty-based
 score (start at 100, deduct per finding severity), identical to `aak score`.
 
-### Where the findings cluster (per-category hit rate)
+### OWASP MCP Top 10 — configs tripping each risk
 
-| Category | Configs with ≥1 finding | Share |
+| OWASP MCP | Configs | Share |
 |---|--:|--:|
-| MCP configuration | 567 | 99.3% |
-| Secret exposure | 63 | 11.0% |
-| Transport security | 18 | 3.2% |
-| Tool poisoning / agent-config / legal | 1 each | ~0.2% |
-
-The story is overwhelmingly a **configuration** story: launch/transport/auth
-hygiene in the `.mcp.json` itself, not exotic tool-poisoning.
+| **MCP07:2025** — Insufficient Authorization / Excessive Permissions | 567 | 99.3% |
+| **MCP10:2025** — Supply-chain / untrusted package execution | 248 | 43.4% |
+| **MCP03:2025** — Tool/launch integrity | 248 | 43.4% |
+| **MCP04:2025** — Command injection surface | 174 | 30.5% |
+| **MCP01:2025** — Token / secret mismanagement | 64 | 11.2% |
+| **MCP09:2025** — Transport security | 38 | 6.7% |
 
 ### Top 5 misconfigurations (advisory-posture rules excluded)
 
@@ -94,22 +104,94 @@ hygiene in the `.mcp.json` itself, not exotic tool-poisoning.
 | `AAK-MCP-003` — server environment exposes secrets to the tool process | HIGH | 63 | 11.0% |
 | `AAK-SECRET-007` — secret in MCP server environment block | MEDIUM | 63 | 11.0% |
 
-The two things worth fixing **today**: (1) **pin what you launch** — 43% of
-configs `npx`/`uvx` fetch-and-run whatever the registry serves that moment; (2)
-**authenticate mutating remote servers** — ~1 in 4 declares a remote server with
-no auth, which aligns with Knostic's 119-of-119 unauthenticated finding from the
-*deployment* side.
+Two advisory-posture rules are **excluded** from this table so the story isn't
+inflated (tracked in `results.json` under `excluded_advisory_rules`):
+`AAK-MCP-ATTEST-001` (deny-by-default attestation — fires on nearly every server
+because attestation isn't an ecosystem norm yet) and `AAK-MCP-007` (no version
+pin in `args`, LOW — advisory hygiene).
 
-### What we deliberately did NOT count
+---
 
-To avoid inflating the story, two advisory-posture rules are **excluded** from
-the "top misconfigurations" table (they are tracked in `results.json` under
-`excluded_advisory_rules`):
+## Case studies (CVE-class, anonymized)
 
-- `AAK-MCP-ATTEST-001` (deny-by-default attestation) — fires on nearly every
-  server because attestation isn't an ecosystem norm yet; a roadmap signal, not
-  an exploit.
-- `AAK-MCP-007` (no version pin in `args`, LOW) — advisory hygiene.
+The snippets below are **illustrative, anonymized reconstructions** of the most
+common patterns — not any specific scanned repo (per our 90-day
+coordinated-disclosure policy, only aggregates are published). Each maps a top
+finding to the disclosed CVE class it mirrors.
+
+### 1. Unauthenticated remote server (`AAK-MCP-001`, 23.8% · CRITICAL)
+CVE class: **Azure-MCP no-auth (CVE-2026-32211), GitLab/Nocturne/AgenticMail
+no-auth cluster (CVE-2026-44895/44830/50287).**
+
+```jsonc
+{ "mcpServers": { "gateway": {
+    "url": "http://0.0.0.0:8080/mcp"    // network-bound, no Authorization header
+} } }
+```
+A mutation-capable RPC endpoint reachable by anyone on the network. This is the
+config-side mirror of Knostic's 119-of-119 unauthenticated tool-listing.
+**Fix:** require a bearer/mTLS credential; bind `127.0.0.1` behind an
+authenticating proxy.
+
+### 2. Fetch-and-execute at launch (`AAK-MCP-005`, 43.4% · supply chain)
+CVE class: **untrusted-package / rug-pull execution (MCP10:2025); the OX MCP
+STDIO command-injection cluster.**
+
+```jsonc
+{ "mcpServers": { "tools": {
+    "command": "npx", "args": ["-y", "some-mcp-server@latest"]   // unpinned, fetched every start
+} } }
+```
+`@latest` (or no version) means the server runs whatever the registry serves at
+launch — the contents can change between two starts without the config changing.
+**Fix:** pin an exact version or a hash; vendor the package.
+
+### 3. Secret in the environment block (`AAK-MCP-003` HIGH + `AAK-SECRET-007`, 11% each)
+CVE class: **credential exposure / token mismanagement (MCP01:2025); the
+splunk-mcp token-cleartext class (CVE-2026-20205).**
+
+```jsonc
+{ "mcpServers": { "svc": {
+    "command": "svc-mcp",
+    "env": { "API_TOKEN": "sk-live-REDACTED..." }   // long-lived secret in committed config
+} } }
+```
+A real credential in a file that lands in git history and every clone.
+**Fix:** reference an env var or secret manager; never inline the value.
+
+---
+
+## How we scan (offline, reproducible)
+
+AgentAuditKit exists because of two properties hosted scanners can't match, and
+they're exactly what makes this report trustworthy:
+
+1. **Offline & deterministic.** Zero network calls, no LLM in the loop. Your
+   code, configs, and secrets never leave the machine, and the same input always
+   yields the same finding. A report you can re-run and check, not a vibe.
+2. **Compliance-evidence, not just findings.** The same scan emits SARIF for the
+   GitHub Security tab plus auditor-ready PDF evidence mapped to 13 frameworks
+   (EU AI Act, SOC 2, ISO 27001/42001, HIPAA, NIST AI RMF, and regional regimes)
+   — what you hand an auditor, not just a list.
+
+### Reproduce this yourself
+
+```bash
+# Scan your own MCP/agent configs in 30s, fully offline:
+pip install agent-audit-kit
+agent-audit-kit scan .
+
+# Regenerate this exact report:
+git clone https://github.com/sattyamjjain/agent-audit-kit && cd agent-audit-kit
+pip install -e .
+export GITHUB_TOKEN=$(gh auth token)                                   # higher search rate limit
+python benchmarks/crawler.py --limit 500 --output benchmarks/results.json   # acquire corpus
+python research/state-of-mcp-2026/run_report.py \                      # scan + aggregate
+    --corpus benchmarks/data --out research/state-of-mcp-2026/results.json
+```
+
+The harness contains **no scanner** — it calls the same `run_scan` /
+`compute_score` the product ships. Output is deterministic for a fixed corpus.
 
 ---
 
@@ -124,38 +206,14 @@ the "top misconfigurations" table (they are tracked in `results.json` under
 4. **External figures are as-reported** by the cited third parties (MCP Registry,
    Knostic, the 2,614-server survey); only the 571-config scan is our own
    measurement.
+5. **The harness reports prevalence of patterns AAK already has rules for** — it
+   cannot, by construction, surface a class for which no rule exists. Discovering
+   genuinely uncovered patterns is a manual follow-up; any that hold up get filed
+   as issues and turned into rules separately. No speculative findings here.
 
 ---
 
-## Reproduce this
-
-```bash
-git clone https://github.com/sattyamjjain/agent-audit-kit && cd agent-audit-kit
-pip install -e .
-
-# 1. Acquire the corpus (reuses the existing crawler)
-export GITHUB_TOKEN=$(gh auth token)
-python benchmarks/crawler.py --limit 500 --output benchmarks/results.json
-
-# 2. Scan + aggregate (reuses agent_audit_kit.engine.run_scan + scoring.compute_score)
-python research/state-of-mcp-2026/run_report.py \
-    --corpus benchmarks/data \
-    --out research/state-of-mcp-2026/results.json
-```
-
-The harness contains **no scanner** — it calls the same `run_scan` /
-`compute_score` the product ships. Output is deterministic for a fixed corpus.
-
-## Methodology note: novel-pattern discovery
-
-This harness reports the **prevalence of patterns AAK already has rules for** —
-it cannot, by construction, surface a misconfiguration class for which no rule
-exists. Discovering genuinely *uncovered* patterns is a manual corpus-inspection
-follow-up; any that hold up will be filed as `cve-response`/finding issues and
-turned into rules separately. No speculative findings were filed for this report.
-
----
-
-*Marketing/launch copy for this report lives in
-[`launch/state-of-mcp-security-2026.md`](../../launch/state-of-mcp-security-2026.md);
-this file is the rigorous, reproducible source of record.*
+*The earlier marketing draft at
+[`launch/state-of-mcp-security-2026.md`](../../launch/state-of-mcp-security-2026.md)
+is superseded; this file is the canonical, reproducible source of record.
+Launch-ready copy is in [`docs/DISTRIBUTION-CHECKLIST.md`](../../docs/DISTRIBUTION-CHECKLIST.md).*

--- a/research/state-of-mcp-2026/results.json
+++ b/research/state-of-mcp-2026/results.json
@@ -49,6 +49,44 @@
       "pct": 0.2
     }
   },
+  "owasp_mcp_hit_rate": {
+    "MCP07:2025": {
+      "configs": 567,
+      "pct": 99.3
+    },
+    "MCP10:2025": {
+      "configs": 248,
+      "pct": 43.4
+    },
+    "MCP03:2025": {
+      "configs": 248,
+      "pct": 43.4
+    },
+    "MCP04:2025": {
+      "configs": 174,
+      "pct": 30.5
+    },
+    "MCP01:2025": {
+      "configs": 64,
+      "pct": 11.2
+    },
+    "MCP09:2025": {
+      "configs": 38,
+      "pct": 6.7
+    },
+    "MCP02:2025": {
+      "configs": 10,
+      "pct": 1.8
+    },
+    "MCP06:2025": {
+      "configs": 1,
+      "pct": 0.2
+    },
+    "MCP05:2025": {
+      "configs": 1,
+      "pct": 0.2
+    }
+  },
   "top_misconfigurations": [
     {
       "rule_id": "AAK-MCP-005",
@@ -72,16 +110,16 @@
       "config_pct": 23.8
     },
     {
-      "rule_id": "AAK-MCP-003",
-      "title": "MCP server environment exposes secrets",
-      "severity": "high",
+      "rule_id": "AAK-SECRET-007",
+      "title": "Secret in MCP server environment block",
+      "severity": "medium",
       "configs": 63,
       "config_pct": 11.0
     },
     {
-      "rule_id": "AAK-SECRET-007",
-      "title": "Secret in MCP server environment block",
-      "severity": "medium",
+      "rule_id": "AAK-MCP-003",
+      "title": "MCP server environment exposes secrets",
+      "severity": "high",
       "configs": 63,
       "config_pct": 11.0
     }

--- a/research/state-of-mcp-2026/run_report.py
+++ b/research/state-of-mcp-2026/run_report.py
@@ -94,6 +94,7 @@ def aggregate(corpus: Path) -> dict[str, Any]:
     severities: Counter[str] = Counter()
     category_configs: Counter[str] = Counter()  # configs with >=1 finding in cat
     rule_configs: Counter[str] = Counter()       # configs with >=1 finding of rule
+    owasp_mcp_configs: Counter[str] = Counter()  # configs with >=1 finding mapped to MCPxx
     has_critical = 0
     has_high = 0
 
@@ -114,16 +115,22 @@ def aggregate(corpus: Path) -> dict[str, Any]:
         cats_here: set[str] = set()
         rules_here: set[str] = set()
         sev_here: set[str] = set()
+        owasp_here: set[str] = set()
         for f in result.findings:
             sev = f.severity.value
             severities[sev] += 1
             sev_here.add(sev)
             cats_here.add(f.category.value)
             rules_here.add(f.rule_id)
+            rule = RULES.get(f.rule_id)
+            if rule:
+                owasp_here.update(rule.owasp_mcp_references)
         for c in cats_here:
             category_configs[c] += 1
         for r in rules_here:
             rule_configs[r] += 1
+        for o in owasp_here:
+            owasp_mcp_configs[o] += 1
         if "critical" in sev_here:
             has_critical += 1
         if "high" in sev_here:
@@ -160,6 +167,10 @@ def aggregate(corpus: Path) -> dict[str, Any]:
         "category_hit_rate": {
             cat: {"configs": n, "pct": _pct(n)}
             for cat, n in category_configs.most_common()
+        },
+        "owasp_mcp_hit_rate": {
+            code: {"configs": n, "pct": _pct(n)}
+            for code, n in owasp_mcp_configs.most_common()
         },
         "top_misconfigurations": top_misconfig,
         "excluded_advisory_rules": sorted(_ADVISORY_RULES),

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.41"
+    assert __version__ == "0.3.42"


### PR DESCRIPTION
Promotes the #373 data-report harness into a **finished, launch-ready** report. No new scanner rules (rule count stays 225; `test_rule_count_is_canonical` green).

## Report (`research/state-of-mcp-2026/REPORT.md`)
Re-ran the harness on the current corpus — every figure sourced to `results.json`:
**571 distinct configs · 25.7% critical · 28.9% grade A · 99.3% trip OWASP MCP07 · top misconfig npx/uvx fetch-and-execute 43.4%.**
Added: executive summary · OWASP-MCP-Top-10 hit-rate table (new) · 3 anonymized CVE-class case studies (no-auth remote → CVE-2026-32211 class; npx/uvx → MCP10 supply-chain; secret-in-env → CVE-2026-20205 class) · a "How we scan (offline, reproducible)" section leading with the two wedges · a `pip install agent-audit-kit && agent-audit-kit scan .` block so the report doubles as a funnel.

## Harness
Now also aggregates **`owasp_mcp_hit_rate`** — **no scanner change**, it reads `owasp_mcp_references` off the existing rules. Still reuses `run_scan` + `compute_score`.

## Distribution (`docs/DISTRIBUTION-CHECKLIST.md`)
Filled with **ready-to-post copy**: Show HN title+body (Tue/Wed AM, GitHub link, no superlatives), r/netsec research-framed post, OWASP GenAI/MCP working-group paragraph, awesome-mcp-security note. Operator-posted — nothing auto-posts.

## Scope
Docs/research + version bump only. **v0.3.41 → 0.3.42** (README/docs pins auto-synced; coverage JSON version-stamped). CLI `--version` reads `__version__` (now 0.3.42).

## Test plan
`pytest` **1226 passed** (incl. version canary + `test_repo_metadata_sync`); `ruff` clean; `mypy` clean (140 files incl. harness); `test_rule_count_is_canonical` green (225); sync `--check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)