### PR TITLE
feat: MCP prevalence scan (664 configs) + score calibration (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — MCP prevalence scan (664 configs) + score calibration (issue #23)
+
+Empirical sequel to the State-of-MCP-Security harness. Widened the corpus by
+sweeping five MCP-config filename queries in `benchmarks/crawler.py` (was a
+single `.mcp.json` query capped at GitHub Code Search's 1,000-result ceiling ≈
+571 distinct) → **664 distinct public configs**. Re-ran the #373 harness (reuses
+`engine.run_scan` + `scoring.compute_score`; extended to emit `owasp_mcp_hit_rate`
+and top-10). New report `research/state-of-mcp-2026/PREVALENCE.md`: the score
+distribution (A 30% / B 36% / C 13% / D 7% / F 13%; **median grade B, top 10%
+A** — the empirical anchor #23 asked for), 26.1% critical, 24.2% no-auth,
+OWASP-MCP hit rate (MCP07 99.4%), top-10 findings, methodology, honest
+limitations, and manual distribution drafts. `REPORT.md` now redirects to
+PREVALENCE.md (canonical); README + `docs/DISTRIBUTION-CHECKLIST.md` updated to
+664. Aggregate-only, no per-server list published and no CVEs filed (90-day
+coordinated-disclosure policy). No package code touched — version stays 0.3.42.
+
 ### Changed — finish the State of MCP Security 2026 report (launch-ready)
 
 Promoted the data-report harness (shipped in #373) into a finished, launch-ready

--- a/README.md
+++ b/README.md
@@ -383,19 +383,20 @@ Public leaderboard of MCP servers we scan weekly:
 
 ## State of MCP Security 2026
 
-A reproducible data report: we scanned **571 distinct public MCP server configs**
-and found **1 in 4 ships a critical-severity flaw** (only ~29% earn an "A"). It
+A reproducible data report: we scanned **664 distinct public MCP server configs**
+and found **1 in 4 ships a critical-severity flaw** — the **median config scores
+a B, the top 10% an A**, and **24.2% declare a remote server with no auth**. It
 exists because of AAK's two defensible wedges — the scan is **offline and
 deterministic** (no code or configs leave the machine; same input, same result),
 and it yields **auditor-ready compliance evidence**, which is what makes a report
-reproducible and an audit defensible. Full methodology, grade distribution, top
-misconfigurations, external anchors (MCP Registry 9,652 servers; Knostic 1,862
-exposed / 119-of-119 unauthenticated; the 2,614-server 82%-path-traversal
-survey), and honesty caveats are in
-**[`research/state-of-mcp-2026/REPORT.md`](research/state-of-mcp-2026/REPORT.md)**
+reproducible and an audit defensible. Full distribution, score calibration,
+OWASP-MCP-Top-10 hit rate, top-10 findings, external anchors (MCP Registry 9,652
+servers; Knostic 1,862 exposed / 119-of-119 unauthenticated; the 2,614-server
+82%-path-traversal survey), and honest limitations are in
+**[`research/state-of-mcp-2026/PREVALENCE.md`](research/state-of-mcp-2026/PREVALENCE.md)**
 (raw aggregate: [`results.json`](research/state-of-mcp-2026/results.json)).
 
-Mapped to the OWASP MCP Top 10, **99.3% of configs trip MCP07 (authorization /
+Mapped to the OWASP MCP Top 10, **99.4% of configs trip MCP07 (authorization /
 excessive permissions)**. Scan your own in 30s, fully offline:
 
 ```bash

--- a/benchmarks/crawler.py
+++ b/benchmarks/crawler.py
@@ -34,7 +34,19 @@ logger = logging.getLogger(__name__)
 
 GITHUB_SEARCH_URL = "https://api.github.com/search/code"
 GITHUB_API_VERSION = "2022-11-28"
+# Primary query (kept for back-compat / single-query callers).
 SEARCH_QUERY = "mcpServers filename:.mcp.json"
+# Each GitHub Code Search query is capped at 1,000 results, so a single
+# filename query plateaus (~571 distinct configs for `.mcp.json`). To widen the
+# corpus we sweep the other common MCP-config filenames and dedupe by
+# repo+path. Every query is public-metadata only (no exploitation).
+SEARCH_QUERIES = [
+    "mcpServers filename:.mcp.json",
+    "mcpServers filename:mcp.json",
+    "mcpServers filename:claude_desktop_config.json",
+    "mcpServers filename:cline_mcp_settings.json",
+    "mcpServers filename:mcp_settings.json",
+]
 PER_PAGE = 100  # max allowed by GitHub
 RATE_LIMIT_PAUSE_S = 10  # seconds to wait when rate-limited
 DATA_DIR = Path(__file__).resolve().parent / "data"
@@ -136,27 +148,46 @@ def search_mcp_configs(limit: int = 100) -> list[dict[str, Any]]:
         List of search result items from the GitHub Code Search API.
     """
     items: list[dict[str, Any]] = []
-    page = 1
-    per_page = min(limit, PER_PAGE)
+    seen: set[tuple[str, str]] = set()
+    per_page = PER_PAGE
 
-    while len(items) < limit:
-        url = (
-            f"{GITHUB_SEARCH_URL}"
-            f"?q={urllib.request.quote(SEARCH_QUERY)}"
-            f"&per_page={per_page}&page={page}"
-        )
-        logger.info("Searching page %d (collected %d/%d)...", page, len(items), limit)
-        data = _api_get(url)
+    for query in SEARCH_QUERIES:
+        page = 1
+        while len(items) < limit:
+            url = (
+                f"{GITHUB_SEARCH_URL}"
+                f"?q={urllib.request.quote(query)}"
+                f"&per_page={per_page}&page={page}"
+            )
+            logger.info(
+                "Searching %r page %d (collected %d/%d distinct)...",
+                query, page, len(items), limit,
+            )
+            try:
+                data = _api_get(url)
+            except RuntimeError:
+                # GitHub caps Code Search at 1,000 results / rate-limits hard;
+                # a failed page just ends this query, not the whole sweep.
+                logger.warning("Query %r ended early at page %d", query, page)
+                break
 
-        page_items = data.get("items", [])
-        if not page_items:
+            page_items = data.get("items", [])
+            if not page_items:
+                break
+
+            for it in page_items:
+                repo = it.get("repository", {}).get("full_name", "")
+                path = it.get("path", "")
+                key = (repo, path)
+                if key in seen:
+                    continue
+                seen.add(key)
+                items.append(it)
+
+            page += 1
+            time.sleep(2)  # respect rate limits between pages
+        if len(items) >= limit:
             break
-
-        items.extend(page_items)
-        page += 1
-
-        # Respect rate limits between pages
-        time.sleep(2)
 
     return items[:limit]
 

--- a/docs/DISTRIBUTION-CHECKLIST.md
+++ b/docs/DISTRIBUTION-CHECKLIST.md
@@ -1,16 +1,16 @@
 # Distribution Checklist — State of MCP Security 2026
 
 Manual launch checklist + **ready-to-post copy** for the data report
-([`research/state-of-mcp-2026/REPORT.md`](../research/state-of-mcp-2026/REPORT.md)).
+([`research/state-of-mcp-2026/PREVALENCE.md`](../research/state-of-mcp-2026/PREVALENCE.md)).
 **Nothing here auto-posts.** Copy, sanity-check the links, post one surface at a
 time, reply to comments.
 
 **Canonical numbers (from `results.json` — do not round up):**
-571 distinct configs · 25.7% with a critical finding · 28.9% grade A ·
-top misconfig = `npx`/`uvx` fetch-and-execute (43.4%) · 23.8% no-auth remote ·
-99.3% trip OWASP MCP07 (authorization). Static, offline, deterministic.
+664 distinct configs · 26.1% with a critical finding · median grade B (top 10% A) ·
+top misconfig = `npx`/`uvx` fetch-and-execute (43.7%) · 24.2% no-auth remote ·
+99.4% trip OWASP MCP07 (authorization). Static, offline, deterministic.
 
-Report link: `https://github.com/sattyamjjain/agent-audit-kit/blob/main/research/state-of-mcp-2026/REPORT.md`
+Report link: `https://github.com/sattyamjjain/agent-audit-kit/blob/main/research/state-of-mcp-2026/PREVALENCE.md`
 
 ---
 
@@ -18,24 +18,24 @@ Report link: `https://github.com/sattyamjjain/agent-audit-kit/blob/main/research
 
 **Title:**
 ```
-Show HN: I scanned 571 public MCP server configs — 1 in 4 has a critical flaw
+Show HN: I scanned 664 public MCP server configs — 1 in 4 has a critical flaw
 ```
 
 **First comment (post immediately, as author):**
 ```
 I run an open-source static scanner for MCP/agent configs (agent-audit-kit,
-MIT). I took 571 distinct public .mcp.json files and scanned each one offline
+MIT). I took 664 distinct public .mcp.json files and scanned each one offline
 and deterministically — no cloud, no LLM, same input gives the same result.
 
-Findings: 25.7% have at least one critical issue, and only 29% grade an A. The
-two big ones are boring and fixable — 43% launch their server with npx/uvx and
+Findings: 26.1% have at least one critical issue; the median config grades a B. The
+two big ones are boring and fixable — 44% launch their server with npx/uvx and
 no pinned version (so it runs whatever the registry serves that second), and 24%
 declare a remote server with no auth. That last one lines up with Knostic's
 separate finding that 119 of 119 exposed servers they probed allowed
 unauthenticated tool-listing.
 
 I tried to keep it honest: the sample skews to public repos, static analysis
-over- and under-counts, and I say "571 configs", not "the MCP ecosystem". Full
+over- and under-counts, and I say "664 configs", not "the MCP ecosystem". Full
 method + the exact command to reproduce it is in the report.
 
 Not trying to replace runtime tools like Snyk agent-scan — this is the
@@ -54,24 +54,24 @@ Repo: https://github.com/sattyamjjain/agent-audit-kit
 
 **Title:**
 ```
-The State of MCP Security 2026: 571 public MCP configs scanned (data + reproducible method)
+The State of MCP Security 2026: 664 public MCP configs scanned (data + reproducible method)
 ```
 
 **Body:**
 ```
 MCP servers are proliferating (the official registry listed 9,652 as of
-2026-05-24) and the config hygiene is rough. I scanned 571 distinct public
+2026-05-24) and the config hygiene is rough. I scanned 664 distinct public
 .mcp.json files with an offline, deterministic static analyzer and aggregated
 the results.
 
-Headline: 25.7% have a critical finding; 28.9% grade A. Mapped to the OWASP MCP
-Top 10, 99.3% trip MCP07 (authorization / excessive permissions). Most common
+Headline: 26.1% have a critical finding; median grade B. Mapped to the OWASP MCP
+Top 10, 99.4% trip MCP07 (authorization / excessive permissions). Most common
 issues: npx/uvx fetch-and-execute at launch (43.4%), no-auth remote server
-(23.8%), secret inlined in the config env block (11%).
+(24.2%), secret inlined in the config env block (11%).
 
 Method and raw aggregate (results.json) are committed; there's an exact
 reproduce command. The scanner is open source (agent-audit-kit, MIT); I've kept
-the caveats in the report (sample skew, static over/under-count, N=571 is a
+the caveats in the report (sample skew, static over/under-count, N=664 is a
 sample).
 
 Report + data + method: <report link>
@@ -90,11 +90,11 @@ real-world data). Open a Discussion first, not a cold PR.
 **One-paragraph note:**
 ```
 Sharing real-world prevalence data that may be useful evidence for the MCP Top
-10. I statically scanned 571 distinct public MCP server configs (offline,
+10. I statically scanned 664 distinct public MCP server configs (offline,
 deterministic; method + raw results committed and reproducible). Mapped to the
-current list: 99.3% of configs trip MCP07 (authorization/excessive perms),
+current list: 99.4% of configs trip MCP07 (authorization/excessive perms),
 43.4% trip the supply-chain/untrusted-execution risk (npx/uvx unpinned launch),
-and 23.8% declare a remote server with no authentication — which corroborates
+and 24.2% declare a remote server with no authentication — which corroborates
 Knostic's 119-of-119 unauthenticated-tool-listing finding from the deployment
 side. Happy to contribute the dataset or a category-by-category breakdown.
 Report: <report link>

--- a/research/state-of-mcp-2026/PREVALENCE.md
+++ b/research/state-of-mcp-2026/PREVALENCE.md
@@ -1,0 +1,204 @@
+# State of MCP Security 2026 — Prevalence & Score Calibration
+
+## We scanned 664 distinct public MCP server configs with an offline static scanner. 1 in 4 ships a critical-severity flaw, the median config scores a **B**, and the top 10% score an **A**.
+
+> **Reproducible data report** (empirical sequel to the [State-of-MCP-Security
+> harness](REPORT.md), issue #23). Every "measured" number below comes from
+> running [AgentAuditKit](https://github.com/sattyamjjain/agent-audit-kit)
+> (v0.3.42, 225 rules, fully offline, MIT) over a content-deduplicated corpus of
+> public MCP configs. Raw aggregate: [`results.json`](results.json). External
+> figures are attributed to their sources, not measured by us.
+>
+> **On the corpus size.** The target was ~1,000. GitHub Code Search hard-caps a
+> single query at 1,000 results, and the primary `.mcp.json` query dedupes to
+> ~571 distinct configs. Sweeping four more MCP-config filenames
+> (`mcp.json`, `claude_desktop_config.json`, `cline_mcp_settings.json`,
+> `mcp_settings.json`) widened it to **664 distinct configs** before returns
+> plateaued. We report the real N — 664 — not the round target.
+
+---
+
+## Three headline numbers
+
+1. **26.1% (173/664) of public MCP configs contain a critical-severity finding.**
+2. **The median public MCP config scores a B; the top 10% score an A.**
+   (This is the empirical score-calibration anchor issue #23 asked for. The
+   roadmap *guessed* "median C-, top 10% B+" — the real distribution skews
+   higher, because the single most common finding is a *medium* advisory, not a
+   critical.)
+3. **24.2% (161/664) declare a remote server with no authentication** — the
+   no-auth exposure rate, corroborating Knostic's 119-of-119 unauthenticated
+   tool-listing finding from the deployment side.
+
+---
+
+## Score distribution (A–F) — the calibration
+
+| Grade | Configs | Share | Cumulative |
+|:-----:|--------:|------:|-----------:|
+| **A** | 199 | 30.0% | 30.0% |
+| **B** | 242 | 36.4% | 66.4% |
+| **C** | 89 | 13.4% | 79.8% |
+| **D** | 49 | 7.4% | 87.2% |
+| **F** | 85 | 12.8% | 100% |
+
+- **Median grade: B** (the 332nd config falls inside the B band).
+- **Top 10% (best ~66 configs): all grade A.**
+- **~1 in 5 (20.2%) land at D or F.**
+
+The grade is AAK's penalty-based score (start at 100; deduct 20/CRITICAL,
+10/HIGH, 5/MEDIUM, 2/LOW), identical to `aak score`. **Calibration takeaway for
+#23:** the current penalties already produce a sane spread (a clear A/B mode with
+a real D/F tail) — the median lands at B, not the "C-" the roadmap assumed, so
+the hand-picked penalties are, if anything, slightly *lenient* on the common
+medium-severity advisory findings. No penalty re-weighting is done in this report
+(that's a follow-up); this run gives it the empirical floor it lacked.
+
+---
+
+## Severity + category prevalence
+
+**All findings:** 295 critical · 316 high · 2,604 medium · 640 low.
+**Per-config:** 26.1% have ≥1 critical; 24.5% have ≥1 high.
+
+| AAK category | Configs with ≥1 finding | Share |
+|---|--:|--:|
+| MCP configuration | 660 | 99.4% |
+| Secret exposure | 70 | 10.5% |
+| Transport security | 20 | 3.0% |
+| Tool poisoning / agent-config / legal | 1 each | ~0.2% |
+
+### OWASP MCP Top 10 — configs tripping each risk
+
+| OWASP MCP | Configs | Share |
+|---|--:|--:|
+| **MCP07:2025** — Insufficient Authorization / Excessive Permissions | 660 | 99.4% |
+| **MCP10:2025** — Supply-chain / untrusted package execution | 290 | 43.7% |
+| **MCP03:2025** — Tool/launch integrity | 290 | 43.7% |
+| **MCP04:2025** — Command injection surface | 205 | 30.9% |
+| **MCP01:2025** — Token / secret mismanagement | 71 | 10.7% |
+| **MCP09:2025** — Transport security | 44 | 6.6% |
+
+---
+
+## Top 10 most-common findings (advisory-posture rules excluded)
+
+| # | Rule | Severity | Configs | Share |
+|--:|---|:---:|--:|--:|
+| 1 | `AAK-MCP-005` — `npx`/`uvx` fetch-and-execute remote packages | MEDIUM | 290 | 43.7% |
+| 2 | `AAK-MCP-006` — command uses a relative path | MEDIUM | 175 | 26.4% |
+| 3 | `AAK-MCP-001` — remote MCP server without authentication | **CRITICAL** | 161 | 24.2% |
+| 4 | `AAK-SECRET-007` — secret in MCP server env block | MEDIUM | 70 | 10.5% |
+| 5 | `AAK-MCP-003` — env exposes secrets to the tool process | HIGH | 70 | 10.5% |
+| 6 | `AAK-MCP-STDIO-LAUNCHER-INJECT-001` — stdio server launches a shell interpreter with an exec flag / interpolated argv | HIGH | 49 | 7.4% |
+| 7 | `AAK-MCP-009` — server URL points at localhost / internal network | HIGH | 44 | 6.6% |
+| 8 | `AAK-TRANSPORT-003` — deprecated SSE transport | MEDIUM | 16 | 2.4% |
+| 9 | `AAK-MCP-004` — excessive number of MCP servers declared | HIGH | 12 | 1.8% |
+| 10 | `AAK-MCP-002` — command runs with shell expansion | **CRITICAL** | 9 | 1.4% |
+
+Two advisory-posture rules are **excluded** so the story isn't inflated (tracked
+in `results.json` under `excluded_advisory_rules`): `AAK-MCP-ATTEST-001`
+(deny-by-default attestation — fires on ~every server) and `AAK-MCP-007` (no
+version pin in `args`, LOW). The two fixes that matter: **pin what you launch**
+(43.7% fetch-and-run unpinned) and **authenticate mutating remote servers**
+(24.2% have no auth).
+
+---
+
+## Methodology
+
+- **Corpus.** MCP config files discovered via GitHub Code Search across five
+  filename queries (`.mcp.json`, `mcp.json`, `claude_desktop_config.json`,
+  `cline_mcp_settings.json`, `mcp_settings.json`), deduplicated by repo+path at
+  crawl time and again by file **content** at scan time — 748 downloaded files →
+  **664 distinct** (83 byte-identical duplicates + 1 unparseable removed).
+- **Scanner.** AgentAuditKit **v0.3.42, 225 rules**, no cloud/LLM/telemetry. Each
+  config scanned in isolation via the same `run_scan` + `compute_score` the CLI
+  and MCP Security Index use. Deterministic: same corpus → identical
+  `results.json`.
+- **Public metadata only.** We scan committed configuration files. No live
+  server probing, no exploitation, no credential use. Rate-limited crawl,
+  respects GitHub API limits.
+
+### Reproducibility
+
+- **Ruleset:** the exact 225 rules are the committed, Sigstore-signable
+  [`rules.json`](../../rules.json) bundle at this repo's HEAD.
+- **Corpus:** regenerate with the committed crawler + the same five queries (the
+  command below). We deliberately do **not** publish a per-server list mapping
+  repos to grades/findings — that would de-anonymize specific servers, against
+  the repo's 90-day coordinated-disclosure policy. The report is aggregate-only.
+
+```bash
+git clone https://github.com/sattyamjjain/agent-audit-kit && cd agent-audit-kit
+pip install -e .
+export GITHUB_TOKEN=$(gh auth token)
+python benchmarks/crawler.py --limit 1200 --output benchmarks/results.json   # 5-query sweep
+python research/state-of-mcp-2026/run_report.py \
+    --corpus benchmarks/data --out research/state-of-mcp-2026/results.json
+```
+
+Scan your own in 30s, fully offline: `pip install agent-audit-kit && agent-audit-kit scan .`
+
+---
+
+## Limitations (read before quoting)
+
+1. **Public-metadata static scan, not runtime.** A matched pattern is not proof
+   of exploitability in context; a clean scan is not proof of safety.
+2. **N of unreachable servers.** Downloads fail for private/deleted repos and
+   rate-limited fetches; those are dropped, so 664 is "distinct public configs we
+   could fetch and parse," not "all MCP servers."
+3. **Sample skews to discoverable public repos** (Code Search ranks by relevance
+   + stars). Not a uniform random sample of the ~9,652 registered servers.
+4. **External figures are as-reported** by the cited third parties (MCP Registry
+   9,652 servers 2026-05-24; Knostic 1,862 exposed / 119-of-119 unauthenticated;
+   the 2,614-server 82%-path-traversal survey). Only the 664-config scan is ours.
+5. **No CVEs/advisories were filed for this report.** A static match on a
+   committed config is not live-exploitation proof, and disclosing a specific
+   server is a deliberate, per-maintainer coordinated-disclosure decision — not
+   something to automate off an aggregate scan. Genuine exposures surface through
+   the [MCP Security Index](https://sattyamjjain.github.io/agent-audit-kit/) under
+   the 90-day policy.
+
+---
+
+## Distribution (drafts — post manually, nothing here auto-posts)
+
+Replace `<report link>` with the permalink before posting. Quote 664, never 1,000.
+
+**Show HN** (Tue/Wed ~8–9am ET):
+```
+Show HN: I scanned 664 public MCP server configs — 1 in 4 has a critical flaw
+```
+> First comment: I run an open-source, offline static scanner for MCP/agent
+> configs (agent-audit-kit, MIT). I scanned 664 distinct public .mcp.json files
+> deterministically — no cloud, no LLM. 26% have a critical issue; the median
+> config grades a B, the top 10% an A. The two big ones are boring and fixable:
+> 44% launch with npx/uvx and no pinned version, and 24% declare a remote server
+> with no auth (matches Knostic's separate 119-of-119 unauthenticated finding).
+> Honest caveats: sample skews to public repos, static analysis over/under-counts,
+> and I say "664 configs", not "the MCP ecosystem". Method + reproduce command in
+> the report. Not a runtime tool — this is the static/CI/offline angle.
+> Report: <report link> · Repo: github.com/sattyamjjain/agent-audit-kit
+
+**r/netsec** (research framing; tool name in body, not title):
+```
+The State of MCP Security 2026: 664 public MCP configs scanned (data + reproducible method)
+```
+> Scanned 664 distinct public MCP configs with an offline deterministic static
+> analyzer. 26% critical; median grade B. Mapped to OWASP MCP Top 10: 99% trip
+> MCP07 (authorization), 44% the supply-chain risk (npx/uvx unpinned launch), 24%
+> no-auth remote. Raw results.json + exact reproduce command committed. Scanner is
+> MIT (agent-audit-kit). Caveats in the report (sample skew, static
+> over/under-count, N=664 is a sample). <report link>
+
+**OWASP GenAI / MCP Top 10 working group** (`github.com/OWASP/www-project-mcp-top-10`, Phase-3 beta — open a Discussion, contribute data not a tool plug):
+> Sharing real-world prevalence data as possible evidence for the MCP Top 10. I
+> statically scanned 664 distinct public MCP configs (offline, deterministic,
+> reproducible; raw results committed). Mapped to the current list: 99.4% trip
+> MCP07 (authorization/excessive perms), 43.7% the supply-chain/untrusted-execution
+> risk (npx/uvx unpinned launch), and 24.2% declare a remote server with no auth —
+> corroborating Knostic's 119-of-119 unauthenticated-tool-listing finding from the
+> deployment side. Happy to contribute the dataset or a category-by-category
+> breakdown. <report link>

--- a/research/state-of-mcp-2026/REPORT.md
+++ b/research/state-of-mcp-2026/REPORT.md
@@ -1,219 +1,36 @@
 # The State of MCP Security 2026
 
-## We scanned 571 public MCP server configs with an offline static scanner. 1 in 4 ships a critical-severity flaw, and only ~29% earn an "A".
+> **Moved.** The canonical, current data report is **[`PREVALENCE.md`](PREVALENCE.md)**
+> — an expanded, content-deduplicated scan of **664 distinct public MCP server
+> configs** (v0.3.42, 225 rules, fully offline), with the score-calibration
+> distribution (issue #23), the OWASP-MCP-Top-10 hit rate, the top-10 findings,
+> methodology, honest limitations, and the exact reproduce command. Raw
+> aggregate: [`results.json`](results.json).
 
-> **Reproducible data report.** Every number under "What we measured" comes from
-> running [AgentAuditKit](https://github.com/sattyamjjain/agent-audit-kit)
-> (v0.3.42, 225 rules, fully offline, MIT) over a content-deduplicated corpus of
-> public MCP configs. The raw aggregate is committed alongside this file as
-> [`results.json`](results.json); the command to regenerate it is in
-> *How we scan*. External figures (next section) are attributed to their
-> sources, not measured by us.
+## The one-line version
 
----
+We scanned **664 distinct public MCP configs** offline and deterministically.
+**26.1% ship a critical-severity flaw**, the **median config scores a B** and the
+**top 10% score an A**, and **24.2% declare a remote server with no
+authentication**. Full report → **[`PREVALENCE.md`](PREVALENCE.md)**.
 
-## Executive summary
+## Why offline + deterministic matters
 
-- We statically scanned **571 distinct public MCP server configuration files**.
-  **147 (25.7%) contain at least one critical-severity finding**; only **165
-  (28.9%) earn an "A"** and **115 (20.1%) land at D or F**.
-- The single most common problem is **fetch-and-execute at launch**: **43.4% of
-  configs** start their server with `npx`/`uvx`, running whatever the registry
-  serves that moment (no pinned version, no hash).
-- The most common *critical* problem is **missing authentication on a remote
-  server** — **23.8% of configs** — which matches, from the deployment side,
-  Knostic's finding that **119 of 119** exposed servers they probed allowed
-  unauthenticated tool-listing.
-- Mapped to the OWASP MCP Top 10, **99.3% of configs** trip **MCP07:2025
-  (Insufficient Authorization / Excessive Permissions)** — this is an
-  authorization-and-launch-hygiene story, not exotic tool-poisoning.
-- It's fixable with a linter in CI, not a new exploit: **pin what you launch**
-  and **require a credential on anything mutating**.
+Two properties hosted scanners can't match, and exactly what makes this report
+trustworthy:
 
----
+1. **Offline & deterministic** — zero network calls, no LLM; the same corpus
+   yields the same `results.json`, byte-for-byte. A report you can re-run and
+   check, not a vibe.
+2. **Compliance-evidence, not just findings** — the same scan emits SARIF plus
+   auditor-ready PDF evidence mapped to 13 frameworks.
 
-## Why this matters now (verified external anchors)
-
-The Model Context Protocol went from proposal to cross-vendor default in ~18
-months, and the exposed surface is already large and under-secured:
-
-- **The official MCP Registry listed 9,652 servers as of 2026-05-24** — the
-  ecosystem is now thousands of independently-published servers, not a handful.
-  *(Source: official MCP Registry export, 2026-05-24.)*
-- **Knostic found 1,862 MCP servers exposed on the public internet, and 119 of
-  119 they probed allowed unauthenticated tool-listing** — every exposed server
-  they tested would hand its tool catalog to an anonymous caller.
-  *(Source: Knostic research.)*
-- **A 2,614-server survey found 82% had path-traversal issues.**
-  *(Source: the 2,614-server MCP survey.)*
-
-Those say the *population* is big and the *auth/path* hygiene is poor. This
-report adds the missing piece: **what the configuration files people actually
-commit look like, measured deterministically.**
-
----
-
-## What we measured
-
-- **Corpus.** 631 publicly-committed MCP config files discovered via GitHub Code
-  Search (seeded to overlap the MCP Registry export + mcp.so top-N), then
-  content-deduplicated — **59 byte-identical duplicates and 1 unparseable file
-  removed, leaving 571 distinct configs.**
-- **Scanner.** AgentAuditKit **v0.3.42, 225 rules** — no cloud, no telemetry, no
-  LLM. Each config is scanned in isolation through the same `run_scan` +
-  `compute_score` the CLI and the public MCP Security Index use. Deterministic:
-  the same corpus produces the same `results.json`, byte-for-byte.
-
-### Headline
-
-- **147 of 571 (25.7%) have ≥1 CRITICAL finding.**
-- **143 of 571 (25.0%) have ≥1 HIGH finding.**
-- All findings: **259 critical · 280 high · 2,256 medium · 586 low.**
-
-### Grade distribution (A–F)
-
-| Grade | Configs | Share |
-|:-----:|--------:|------:|
-| **A** | 165 | 28.9% |
-| **B** | 213 | 37.3% |
-| **C** | 78 | 13.7% |
-| **D** | 45 | 7.9% |
-| **F** | 70 | 12.3% |
-
-**~1 in 5 configs (20.1%) land at D or F.** The grade is AAK's penalty-based
-score (start at 100, deduct per finding severity), identical to `aak score`.
-
-### OWASP MCP Top 10 — configs tripping each risk
-
-| OWASP MCP | Configs | Share |
-|---|--:|--:|
-| **MCP07:2025** — Insufficient Authorization / Excessive Permissions | 567 | 99.3% |
-| **MCP10:2025** — Supply-chain / untrusted package execution | 248 | 43.4% |
-| **MCP03:2025** — Tool/launch integrity | 248 | 43.4% |
-| **MCP04:2025** — Command injection surface | 174 | 30.5% |
-| **MCP01:2025** — Token / secret mismanagement | 64 | 11.2% |
-| **MCP09:2025** — Transport security | 38 | 6.7% |
-
-### Top 5 misconfigurations (advisory-posture rules excluded)
-
-| Rule | Severity | Configs | Share |
-|---|:---:|--:|--:|
-| `AAK-MCP-005` — server uses `npx`/`uvx` to fetch-and-execute remote packages | MEDIUM | 248 | 43.4% |
-| `AAK-MCP-006` — server command uses a relative path | MEDIUM | 149 | 26.1% |
-| `AAK-MCP-001` — remote MCP server without authentication | **CRITICAL** | 136 | 23.8% |
-| `AAK-MCP-003` — server environment exposes secrets to the tool process | HIGH | 63 | 11.0% |
-| `AAK-SECRET-007` — secret in MCP server environment block | MEDIUM | 63 | 11.0% |
-
-Two advisory-posture rules are **excluded** from this table so the story isn't
-inflated (tracked in `results.json` under `excluded_advisory_rules`):
-`AAK-MCP-ATTEST-001` (deny-by-default attestation — fires on nearly every server
-because attestation isn't an ecosystem norm yet) and `AAK-MCP-007` (no version
-pin in `args`, LOW — advisory hygiene).
-
----
-
-## Case studies (CVE-class, anonymized)
-
-The snippets below are **illustrative, anonymized reconstructions** of the most
-common patterns — not any specific scanned repo (per our 90-day
-coordinated-disclosure policy, only aggregates are published). Each maps a top
-finding to the disclosed CVE class it mirrors.
-
-### 1. Unauthenticated remote server (`AAK-MCP-001`, 23.8% · CRITICAL)
-CVE class: **Azure-MCP no-auth (CVE-2026-32211), GitLab/Nocturne/AgenticMail
-no-auth cluster (CVE-2026-44895/44830/50287).**
-
-```jsonc
-{ "mcpServers": { "gateway": {
-    "url": "http://0.0.0.0:8080/mcp"    // network-bound, no Authorization header
-} } }
-```
-A mutation-capable RPC endpoint reachable by anyone on the network. This is the
-config-side mirror of Knostic's 119-of-119 unauthenticated tool-listing.
-**Fix:** require a bearer/mTLS credential; bind `127.0.0.1` behind an
-authenticating proxy.
-
-### 2. Fetch-and-execute at launch (`AAK-MCP-005`, 43.4% · supply chain)
-CVE class: **untrusted-package / rug-pull execution (MCP10:2025); the OX MCP
-STDIO command-injection cluster.**
-
-```jsonc
-{ "mcpServers": { "tools": {
-    "command": "npx", "args": ["-y", "some-mcp-server@latest"]   // unpinned, fetched every start
-} } }
-```
-`@latest` (or no version) means the server runs whatever the registry serves at
-launch — the contents can change between two starts without the config changing.
-**Fix:** pin an exact version or a hash; vendor the package.
-
-### 3. Secret in the environment block (`AAK-MCP-003` HIGH + `AAK-SECRET-007`, 11% each)
-CVE class: **credential exposure / token mismanagement (MCP01:2025); the
-splunk-mcp token-cleartext class (CVE-2026-20205).**
-
-```jsonc
-{ "mcpServers": { "svc": {
-    "command": "svc-mcp",
-    "env": { "API_TOKEN": "sk-live-REDACTED..." }   // long-lived secret in committed config
-} } }
-```
-A real credential in a file that lands in git history and every clone.
-**Fix:** reference an env var or secret manager; never inline the value.
-
----
-
-## How we scan (offline, reproducible)
-
-AgentAuditKit exists because of two properties hosted scanners can't match, and
-they're exactly what makes this report trustworthy:
-
-1. **Offline & deterministic.** Zero network calls, no LLM in the loop. Your
-   code, configs, and secrets never leave the machine, and the same input always
-   yields the same finding. A report you can re-run and check, not a vibe.
-2. **Compliance-evidence, not just findings.** The same scan emits SARIF for the
-   GitHub Security tab plus auditor-ready PDF evidence mapped to 13 frameworks
-   (EU AI Act, SOC 2, ISO 27001/42001, HIPAA, NIST AI RMF, and regional regimes)
-   — what you hand an auditor, not just a list.
-
-### Reproduce this yourself
-
-```bash
-# Scan your own MCP/agent configs in 30s, fully offline:
-pip install agent-audit-kit
-agent-audit-kit scan .
-
-# Regenerate this exact report:
-git clone https://github.com/sattyamjjain/agent-audit-kit && cd agent-audit-kit
-pip install -e .
-export GITHUB_TOKEN=$(gh auth token)                                   # higher search rate limit
-python benchmarks/crawler.py --limit 500 --output benchmarks/results.json   # acquire corpus
-python research/state-of-mcp-2026/run_report.py \                      # scan + aggregate
-    --corpus benchmarks/data --out research/state-of-mcp-2026/results.json
-```
-
-The harness contains **no scanner** — it calls the same `run_scan` /
-`compute_score` the product ships. Output is deterministic for a fixed corpus.
-
----
-
-## Honesty caveats (read before quoting)
-
-1. **The sample skews to discoverable public repos** (Code Search ranks by
-   relevance + stars). It is "configs people publish," not a uniform random
-   sample of the ~9,652 registered servers.
-2. **Static analysis both over- and under-counts.** A matched pattern is not
-   proof of exploitability in context; a clean scan is not proof of safety.
-3. **N = 571 is a sample.** We say "571 configs," never "the MCP ecosystem."
-4. **External figures are as-reported** by the cited third parties (MCP Registry,
-   Knostic, the 2,614-server survey); only the 571-config scan is our own
-   measurement.
-5. **The harness reports prevalence of patterns AAK already has rules for** — it
-   cannot, by construction, surface a class for which no rule exists. Discovering
-   genuinely uncovered patterns is a manual follow-up; any that hold up get filed
-   as issues and turned into rules separately. No speculative findings here.
+Scan your own in 30s, fully offline: `pip install agent-audit-kit && agent-audit-kit scan .`
 
 ---
 
 *The earlier marketing draft at
-[`launch/state-of-mcp-security-2026.md`](../../launch/state-of-mcp-security-2026.md)
-is superseded; this file is the canonical, reproducible source of record.
-Launch-ready copy is in [`docs/DISTRIBUTION-CHECKLIST.md`](../../docs/DISTRIBUTION-CHECKLIST.md).*
+[`../../launch/state-of-mcp-security-2026.md`](../../launch/state-of-mcp-security-2026.md)
+is superseded. Launch-ready copy is in
+[`../../docs/DISTRIBUTION-CHECKLIST.md`](../../docs/DISTRIBUTION-CHECKLIST.md).
+The prior 571-config run of this report is in git history.*

--- a/research/state-of-mcp-2026/results.json
+++ b/research/state-of-mcp-2026/results.json
@@ -1,40 +1,40 @@
 {
   "tool": "agent-audit-kit",
   "corpus": "benchmarks/data",
-  "corpus_total_files": 631,
-  "distinct_configs_scanned": 571,
-  "duplicates_removed": 59,
+  "corpus_total_files": 748,
+  "distinct_configs_scanned": 664,
+  "duplicates_removed": 83,
   "unparseable_removed": 1,
   "grade_distribution": {
-    "A": 165,
-    "B": 213,
-    "C": 78,
-    "D": 45,
-    "F": 70
+    "A": 199,
+    "B": 242,
+    "C": 89,
+    "D": 49,
+    "F": 85
   },
-  "configs_with_critical": 147,
-  "configs_with_critical_pct": 25.7,
-  "configs_with_high": 143,
-  "configs_with_high_pct": 25.0,
+  "configs_with_critical": 173,
+  "configs_with_critical_pct": 26.1,
+  "configs_with_high": 163,
+  "configs_with_high_pct": 24.5,
   "severity_totals": {
-    "medium": 2256,
-    "low": 586,
-    "critical": 259,
-    "high": 280,
+    "medium": 2604,
+    "low": 640,
+    "critical": 295,
+    "high": 316,
     "info": 1
   },
   "category_hit_rate": {
     "mcp-config": {
-      "configs": 567,
-      "pct": 99.3
+      "configs": 660,
+      "pct": 99.4
     },
     "secret-exposure": {
-      "configs": 63,
-      "pct": 11.0
+      "configs": 70,
+      "pct": 10.5
     },
     "transport-security": {
-      "configs": 18,
-      "pct": 3.2
+      "configs": 20,
+      "pct": 3.0
     },
     "legal-compliance": {
       "configs": 1,
@@ -51,31 +51,31 @@
   },
   "owasp_mcp_hit_rate": {
     "MCP07:2025": {
-      "configs": 567,
-      "pct": 99.3
+      "configs": 660,
+      "pct": 99.4
     },
     "MCP10:2025": {
-      "configs": 248,
-      "pct": 43.4
+      "configs": 290,
+      "pct": 43.7
     },
     "MCP03:2025": {
-      "configs": 248,
-      "pct": 43.4
+      "configs": 290,
+      "pct": 43.7
     },
     "MCP04:2025": {
-      "configs": 174,
-      "pct": 30.5
+      "configs": 205,
+      "pct": 30.9
     },
     "MCP01:2025": {
-      "configs": 64,
-      "pct": 11.2
+      "configs": 71,
+      "pct": 10.7
     },
     "MCP09:2025": {
-      "configs": 38,
-      "pct": 6.7
+      "configs": 44,
+      "pct": 6.6
     },
     "MCP02:2025": {
-      "configs": 10,
+      "configs": 12,
       "pct": 1.8
     },
     "MCP06:2025": {
@@ -92,36 +92,71 @@
       "rule_id": "AAK-MCP-005",
       "title": "MCP server uses npx/uvx to fetch and execute remote packages",
       "severity": "medium",
-      "configs": 248,
-      "config_pct": 43.4
+      "configs": 290,
+      "config_pct": 43.7
     },
     {
       "rule_id": "AAK-MCP-006",
       "title": "MCP server command uses relative path",
       "severity": "medium",
-      "configs": 149,
-      "config_pct": 26.1
+      "configs": 175,
+      "config_pct": 26.4
     },
     {
       "rule_id": "AAK-MCP-001",
       "title": "Remote MCP server without authentication",
       "severity": "critical",
-      "configs": 136,
-      "config_pct": 23.8
+      "configs": 161,
+      "config_pct": 24.2
     },
     {
       "rule_id": "AAK-SECRET-007",
       "title": "Secret in MCP server environment block",
       "severity": "medium",
-      "configs": 63,
-      "config_pct": 11.0
+      "configs": 70,
+      "config_pct": 10.5
     },
     {
       "rule_id": "AAK-MCP-003",
       "title": "MCP server environment exposes secrets",
       "severity": "high",
-      "configs": 63,
-      "config_pct": 11.0
+      "configs": 70,
+      "config_pct": 10.5
+    },
+    {
+      "rule_id": "AAK-MCP-STDIO-LAUNCHER-INJECT-001",
+      "title": "MCP stdio server launches a shell-style interpreter with an exec flag or interpolated args",
+      "severity": "high",
+      "configs": 49,
+      "config_pct": 7.4
+    },
+    {
+      "rule_id": "AAK-MCP-009",
+      "title": "MCP server URL points to localhost/internal network",
+      "severity": "high",
+      "configs": 44,
+      "config_pct": 6.6
+    },
+    {
+      "rule_id": "AAK-TRANSPORT-003",
+      "title": "Deprecated SSE transport in use",
+      "severity": "medium",
+      "configs": 16,
+      "config_pct": 2.4
+    },
+    {
+      "rule_id": "AAK-MCP-004",
+      "title": "Excessive number of MCP servers declared",
+      "severity": "high",
+      "configs": 12,
+      "config_pct": 1.8
+    },
+    {
+      "rule_id": "AAK-MCP-002",
+      "title": "MCP server command runs with shell expansion",
+      "severity": "critical",
+      "configs": 9,
+      "config_pct": 1.4
     }
   ],
   "excluded_advisory_rules": [

--- a/research/state-of-mcp-2026/run_report.py
+++ b/research/state-of-mcp-2026/run_report.py
@@ -149,7 +149,7 @@ def aggregate(corpus: Path) -> dict[str, Any]:
         }
         for rid, n in rule_configs.most_common()
         if rid not in _ADVISORY_RULES
-    ][:5]
+    ][:10]
 
     return {
         "tool": "agent-audit-kit",


### PR DESCRIPTION
Executes issue #23 — scan a corpus of public MCP servers and publish the vulnerability-prevalence + score distribution. **Reuses the existing scanner** (`agent_audit_kit.engine.run_scan`), the #373 harness, and `scoring.compute_score` — no new scanner.

## Honest N: 664, not 1,000
The target was ~1,000. GitHub Code Search hard-caps a single query at 1,000 results, and the primary `.mcp.json` query dedupes to ~571 distinct. I extended `benchmarks/crawler.py` to sweep **five** MCP-config filename queries (a real reproducibility win), widening the corpus to **664 distinct configs** before returns plateaued (748 files → 664 after content-dedup). **I report the real N, 664 — not a fabricated round number**, and named the file `PREVALENCE.md` (not `PREVALENCE-1000.md`) so the filename doesn't over-claim.

## Existing API (reused)
- `agent_audit_kit.engine.run_scan(project_root) -> ScanResult` (engine.py) — the scan entrypoint.
- `agent_audit_kit.scoring.compute_score(result)` — the A–F grade the CLI/Index use.
- `research/state-of-mcp-2026/run_report.py::_iter_configs` — the #373 corpus loader.

## Results (v0.3.42, 225 rules, offline/deterministic)
- **26.1% (173/664) ship a critical flaw.**
- **Median config scores a B; top 10% score an A** — the empirical score-calibration anchor #23 asked for. (Roadmap *guessed* "median C-"; reality skews higher because the most common finding is a medium advisory.)
- **24.2% no-auth remote**; OWASP MCP07 trips on **99.4%**; top misconfig = npx/uvx fetch-and-execute (**43.7%**).
- Full distribution + top-10 + methodology + limitations + distribution drafts in **`research/state-of-mcp-2026/PREVALENCE.md`**; raw `results.json` committed.

## Scope / safety
- **REPORT.md → redirect** to PREVALENCE.md (canonical); README + `docs/DISTRIBUTION-CHECKLIST.md` updated to 664.
- **Aggregate-only.** No per-server list published (would de-anonymize vulnerable servers, against the 90-day disclosure policy). **No CVEs filed** — a static match on a committed config isn't live-exploitation proof, and disclosing a specific server is a per-maintainer coordinated decision, not something to automate.
- **No package code touched** (only `benchmarks/` + `research/`) → version stays **0.3.42** (already on HEAD, unpublished). No release cut.

## Test plan
`pytest` **1226 passed**; `ruff check .` clean (incl. crawler + harness); `mypy` clean (140 files); `test_rule_count_is_canonical` green (225); sync `--check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)