### PR TITLE
fix(rules): AAK-FLOWISE-001 pin 3.1.2→3.1.3 for CVE-2026-58057 (closes #372)

### DIFF
--- a/CHANGELOG.cves.md
+++ b/CHANGELOG.cves.md
@@ -8,6 +8,12 @@ shipped-at timestamp. The GitHub Action `.github/workflows/cve-watcher.yml`
 diffs NVD's MCP keyword feed against this file and opens an
 `sla-48h`-labelled issue for anything new.
 
+## Shipped in v0.3.46 (2026-07-06)
+
+| Incident / Anchor | Reference | AAK rule(s) | Shipped | Latency |
+|---|---|---|---|---|
+| CVE-2026-58057 (Flowise < 3.1.3 — case-sensitive NODE_OPTIONS denylist bypass → `node_options` on Windows → `NODE_OPTIONS --require` RCE) | [NVD CVE-2026-58057](https://nvd.nist.gov/vuln/detail/CVE-2026-58057) (CVSS 5.0, published 2026-06-28) | **AAK-FLOWISE-001** (pin floor bumped 3.1.2 → 3.1.3; 3.1.2 configs now flag) | 2026-07-06 | version-pin extension |
+
 ## Shipped in v0.3.22 (2026-05-20)
 
 | Incident / Anchor | Reference | AAK rule(s) | Shipped | Latency |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security — Flowise CVE-2026-58057 (closes #372)
+
+Bumped `AAK-FLOWISE-001`'s pin floor **3.1.2 → 3.1.3** and added
+[CVE-2026-58057](https://nvd.nist.gov/vuln/detail/CVE-2026-58057) (Flowise
+before 3.1.3 validates Custom-MCP stdio env vars against a *case-sensitive*
+denylist, so on Windows `node_options` bypasses the `NODE_OPTIONS` entry and
+reaches `NODE_OPTIONS --require` RCE). Flowise 3.1.2 configs now flag; test +
+ledger updated. Clears the last open `sla-48h` gate item.
+
 ### Added — bench: determinism head-to-head
 
 New `benchmarks/determinism/` proves AAK yields a **byte-identical finding set

--- a/agent_audit_kit/rules/builtin.py
+++ b/agent_audit_kit/rules/builtin.py
@@ -2991,18 +2991,23 @@ _r(
     "(< 3.0.6, CVSS 9.8) is an unsandboxed RCE in the same feature; "
     "CVE-2026-56274 (< 3.1.2, CVSS 9.9) adds OS command injection via "
     "incomplete command-flag validation plus a regex bypass in local "
-    "file-access restrictions. Pin floor is 3.1.2 (highest fixed version) "
-    "so 3.0.6–3.1.1 are still flagged. Same architectural class as Ox's "
-    "original STDIO disclosure (see AAK-STDIO-001).",
+    "file-access restrictions; CVE-2026-58057 (< 3.1.3, CVSS 5.0) validates "
+    "Custom-MCP stdio env vars against a *case-sensitive* denylist, so on "
+    "Windows (case-insensitive env names) `node_options` slips past the "
+    "NODE_OPTIONS entry and reaches `NODE_OPTIONS --require` code execution. "
+    "Pin floor is 3.1.3 (highest fixed version) so 3.0.6–3.1.2 are still "
+    "flagged. Same architectural class as Ox's original STDIO disclosure "
+    "(see AAK-STDIO-001).",
     Severity.CRITICAL,
     Category.SUPPLY_CHAIN,
-    "Upgrade flowise and flowise-components to 3.1.2 or later. Audit "
+    "Upgrade flowise and flowise-components to 3.1.3 or later. Audit "
     "every MCP adapter node in your flow configs; remove "
     "`customFunction`/`runCode` sinks unless they're validated against "
-    "a strict argv allowlist. See also AAK-STDIO-001 for the "
+    "a strict argv allowlist, and treat env-var denylists as "
+    "case-insensitive. See also AAK-STDIO-001 for the "
     "architectural-class detector.",
     sarif_name="FlowiseMcpAdapterRce",
-    cve_references=["CVE-2026-40933", "CVE-2025-71336", "CVE-2026-56274"],
+    cve_references=["CVE-2026-40933", "CVE-2025-71336", "CVE-2026-56274", "CVE-2026-58057"],
     owasp_mcp_references=["MCP01:2025"],
     owasp_agentic_references=["ASI02"],
     adversa_references=["ADV-RCE-04"],

--- a/agent_audit_kit/scanners/stdio_injection.py
+++ b/agent_audit_kit/scanners/stdio_injection.py
@@ -304,13 +304,15 @@ def scan(project_root: Path) -> tuple[list[Finding], set[str]]:
 
 # ---------------------------------------------------------------------------
 # AAK-FLOWISE-001 — Flowise Custom-MCP RCE cluster. CVE-2026-40933 (< 3.1.0,
-# CVSS 10.0), CVE-2025-71336 (< 3.0.6 unsandboxed RCE), and CVE-2026-56274
-# (< 3.1.2 OS command injection / regex bypass) — pin floor is the highest
-# fixed version so 3.1.0/3.1.1 are still flagged for CVE-2026-56274.
+# CVSS 10.0), CVE-2025-71336 (< 3.0.6 unsandboxed RCE), CVE-2026-56274
+# (< 3.1.2 OS command injection / regex bypass), and CVE-2026-58057 (< 3.1.3
+# case-sensitive NODE_OPTIONS denylist bypass → `node_options` on Windows →
+# NODE_OPTIONS --require RCE) — pin floor is the highest fixed version so
+# 3.1.0/3.1.1/3.1.2 are still flagged for the CVE they remain exposed to.
 # ---------------------------------------------------------------------------
 
 
-_FLOWISE_PATCHED_VERSION = (3, 1, 2)
+_FLOWISE_PATCHED_VERSION = (3, 1, 3)
 
 
 def _parse_semver(spec: str) -> tuple[int, int, int] | None:

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-07-06T07:42:17Z",
+  "last_updated": "2026-07-06T07:50:13Z",
   "aak_version": "0.3.46",
   "rule_count": 231,
   "coverage": [
@@ -213,7 +213,8 @@
           "cve_references": [
             "CVE-2025-71336",
             "CVE-2026-40933",
-            "CVE-2026-56274"
+            "CVE-2026-56274",
+            "CVE-2026-58057"
           ],
           "aicm_references": [
             "STA-08"

--- a/rules.json
+++ b/rules.json
@@ -984,9 +984,10 @@
       "cve_references": [
         "CVE-2026-40933",
         "CVE-2025-71336",
-        "CVE-2026-56274"
+        "CVE-2026-56274",
+        "CVE-2026-58057"
       ],
-      "description": "Package manifest depends on `flowise` or `flowise-components` at version < 3.1.2, and/or a Flowise flow config (`.flowise/*.json`, `flows/*.json`) declares an MCP adapter node with `customFunction` or `runCode` sinks. The Custom-MCP feature is a recurring RCE class: CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) lets an authenticated attacker combine allowlisted commands like `npx` with execution flags such as `-c` for arbitrary OS command execution; CVE-2025-71336 (< 3.0.6, CVSS 9.8) is an unsandboxed RCE in the same feature; CVE-2026-56274 (< 3.1.2, CVSS 9.9) adds OS command injection via incomplete command-flag validation plus a regex bypass in local file-access restrictions. Pin floor is 3.1.2 (highest fixed version) so 3.0.6\u20133.1.1 are still flagged. Same architectural class as Ox's original STDIO disclosure (see AAK-STDIO-001).",
+      "description": "Package manifest depends on `flowise` or `flowise-components` at version < 3.1.2, and/or a Flowise flow config (`.flowise/*.json`, `flows/*.json`) declares an MCP adapter node with `customFunction` or `runCode` sinks. The Custom-MCP feature is a recurring RCE class: CVE-2026-40933 (GHSA-c9gw-hvqq-f33r, CVSS 10.0) lets an authenticated attacker combine allowlisted commands like `npx` with execution flags such as `-c` for arbitrary OS command execution; CVE-2025-71336 (< 3.0.6, CVSS 9.8) is an unsandboxed RCE in the same feature; CVE-2026-56274 (< 3.1.2, CVSS 9.9) adds OS command injection via incomplete command-flag validation plus a regex bypass in local file-access restrictions; CVE-2026-58057 (< 3.1.3, CVSS 5.0) validates Custom-MCP stdio env vars against a *case-sensitive* denylist, so on Windows (case-insensitive env names) `node_options` slips past the NODE_OPTIONS entry and reaches `NODE_OPTIONS --require` code execution. Pin floor is 3.1.3 (highest fixed version) so 3.0.6\u20133.1.2 are still flagged. Same architectural class as Ox's original STDIO disclosure (see AAK-STDIO-001).",
       "incident_references": [],
       "owasp_agentic_references": [
         "ASI02"
@@ -994,7 +995,7 @@
       "owasp_mcp_references": [
         "MCP01:2025"
       ],
-      "remediation": "Upgrade flowise and flowise-components to 3.1.2 or later. Audit every MCP adapter node in your flow configs; remove `customFunction`/`runCode` sinks unless they're validated against a strict argv allowlist. See also AAK-STDIO-001 for the architectural-class detector.",
+      "remediation": "Upgrade flowise and flowise-components to 3.1.3 or later. Audit every MCP adapter node in your flow configs; remove `customFunction`/`runCode` sinks unless they're validated against a strict argv allowlist, and treat env-var denylists as case-insensitive. See also AAK-STDIO-001 for the architectural-class detector.",
       "rule_id": "AAK-FLOWISE-001",
       "sarif_name": "FlowiseMcpAdapterRce",
       "severity": "critical",

--- a/tests/test_flowise.py
+++ b/tests/test_flowise.py
@@ -28,11 +28,24 @@ def test_flowise_patched_pin_is_quiet(tmp_path: Path) -> None:
     (tmp_path / "package.json").write_text(
         json.dumps({
             "name": "agent-app",
-            "dependencies": {"flowise": "3.1.2"},
+            "dependencies": {"flowise": "3.1.3"},
         })
     )
     findings, _ = stdio_injection.scan(tmp_path)
     assert not any(f.rule_id == "AAK-FLOWISE-001" for f in findings)
+
+
+def test_flowise_3_1_2_still_flagged_for_cve_2026_58057(tmp_path: Path) -> None:
+    """CVE-2026-58057 (NODE_OPTIONS denylist bypass) is fixed in 3.1.3, so 3.1.2
+    must still flag."""
+    (tmp_path / "package.json").write_text(
+        json.dumps({
+            "name": "agent-app",
+            "dependencies": {"flowise": "3.1.2"},
+        })
+    )
+    findings, _ = stdio_injection.scan(tmp_path)
+    assert any(f.rule_id == "AAK-FLOWISE-001" for f in findings)
 
 
 def test_flowise_3_1_1_still_flagged_for_cve_2026_56274(tmp_path: Path) -> None:
@@ -89,6 +102,7 @@ def test_flowise_rule_metadata_verified() -> None:
     assert "CVE-2026-40933" in rule.cve_references
     assert "CVE-2025-71336" in rule.cve_references
     assert "CVE-2026-56274" in rule.cve_references
+    assert "CVE-2026-58057" in rule.cve_references
     assert rule.auto_fixable is True
 
 


### PR DESCRIPTION
Clears the last open `sla-48h` gate item so the stacked 0.3.42–0.3.46 work can finally publish.

[CVE-2026-58057](https://nvd.nist.gov/vuln/detail/CVE-2026-58057) (CVSS 5.0): Flowise before 3.1.3 validates Custom-MCP stdio env vars against a **case-sensitive** denylist, so on Windows `node_options` bypasses the `NODE_OPTIONS` entry and reaches `NODE_OPTIONS --require` RCE.

- `_FLOWISE_PATCHED_VERSION` **(3,1,2) → (3,1,3)** in `stdio_injection.py`; added `CVE-2026-58057` to `AAK-FLOWISE-001`. Flowise **3.1.2 now flags** (was clean), 3.1.3 clean.
- Test (`test_flowise_3_1_2_still_flagged_for_cve_2026_58057`) + metadata assert + `CHANGELOG.cves.md` ledger row + `rules.json` regenerated. Rule count unchanged (231).

**Test plan:** `pytest` **1256 passed**; ruff + mypy clean; count guard green.

Closes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)