### PR TITLE
fix(rules): correct SEP citations on AAK-MCP-STATELESS-* pack (0.3.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — correct SEP citations on the AAK-MCP-STATELESS-* pack
+
+Citation-accuracy pass on the shipped stateless-migration rules (no detection
+change, rule count stays 231). The `Mcp-Session-Id` / protocol-session removal
+was mis-attributed to SEP-1442; it is actually **SEP-2567** ("Sessionless MCP
+via Explicit State Handles"), with SEP-1442 / **SEP-2575** making the init
+handshake optional so stateless is the default. The `tasks/list` removal cited
+a **non-existent SEP-1359**; corrected to the experimental Tasks primitive
+(**SEP-1686**) moving out of core into the Extensions framework (redesigned as
+**SEP-2663**). Updated `AAK-MCP-STATELESS-001`/`-002` descriptions, the
+`mcp_stateless_migration` scanner docstring + engine label, and `rules.json`.
+Verified against modelcontextprotocol.io + the MCP GitHub SEPs. Version
+**0.3.46 → 0.3.47**.
+
 ### Security — Flowise CVE-2026-58057 (closes #372)
 
 Bumped `AAK-FLOWISE-001`'s pin floor **3.1.2 → 3.1.3** and added

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.46
+      - uses: sattyamjjain/agent-audit-kit@v0.3.47
         with:
           fail-on: high
 ```
@@ -86,7 +86,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.46
+    rev: v0.3.47
     hooks:
       - id: agent-audit-kit
 ```

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,6 +1,6 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.46"
+__version__ = "0.3.47"
 RULE_COUNT = 231
 SCANNER_COUNT = 81

--- a/agent_audit_kit/engine.py
+++ b/agent_audit_kit/engine.py
@@ -84,7 +84,7 @@ _OPTIONAL_SCANNERS: list[tuple[str, str, list[str]]] = [
     ("skill_lifecycle_attribution", "Skill lifecycle outcome-attribution (SkillsVote, arXiv:2605.18401)", []),
     ("agent_harness_shared_state", "Multi-agent shared-state lock (Code-as-Harness, arXiv:2605.18747)", []),
     ("mcp_sampling_capability", "MCP `sampling` capability consent guard (MCP07:2025)", []),
-    ("mcp_stateless_migration", "MCP 2026-07-28 stateless-migration smells (SEP-1442/1359)", []),
+    ("mcp_stateless_migration", "MCP 2026-07-28 stateless-migration smells (SEP-2567/1442/2575)", []),
     ("eu_ai_act_art15_locale", "EU AI Act Art. 15 multilingual-eval coverage (advisory)", []),
     ("mcp_tunnel", "MCP Tunnels gateway config + credential exposure (Anthropic 2026-05-19 research preview)", []),
     ("sandbox_self_disable", "Tool-schema sandbox self-disable parameter (CVE-2026-42074)", []),

--- a/agent_audit_kit/rules/builtin.py
+++ b/agent_audit_kit/rules/builtin.py
@@ -525,22 +525,27 @@ _r(
 # ---------------------------------------------------------------------------
 # AAK-MCP-STATELESS-001..004 — 2026-07-28 stateless-MCP migration
 #
-# The MCP 2026-07-28 spec release candidate (locked 2026-05-21) makes the
-# protocol stateless by default: the `Mcp-Session-Id` header and the
-# protocol-level session are removed (SEP-1442), and the experimental
-# `tasks/list` method is removed because it can't be scoped safely without
-# sessions (SEP-1359). Server/client code that assumes the pre-RC stateful
-# protocol — relies on `Mcp-Session-Id`, dispatches `tasks/list`, requires
-# sticky routing or a shared session store, or skips client-side caching of
-# `tools/list` while holding per-session server state — will silently break
-# after 2026-07-28 once the final spec lands. These four rules surface the
-# migration surface so it can be fixed before the cutover.
+# The MCP 2026-07-28 spec release candidate makes the protocol stateless by
+# default: the `Mcp-Session-Id` header and the protocol-level session are
+# removed and replaced with explicit, server-minted state handles (SEP-2567),
+# while making the mandatory initialization handshake optional so stateless is
+# the default (SEP-1442 / SEP-2575). The experimental Tasks primitive (SEP-1686)
+# — including `tasks/list` — is moved out of the core spec into the Extensions
+# framework (redesigned as SEP-2663), so core `tasks/list` is removed. Server/
+# client code that assumes the pre-RC stateful protocol — relies on
+# `Mcp-Session-Id`, dispatches `tasks/list`, requires sticky routing or a shared
+# session store, or skips client-side caching of `tools/list` while holding
+# per-session server state — will silently break after 2026-07-28 once the final
+# spec lands. These four rules surface the migration surface so it can be fixed
+# before the cutover.
 #
 # Sources:
 #   https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
-#   https://blog.modelcontextprotocol.io/posts/2025-12-19-mcp-transport-future/
+#   https://modelcontextprotocol.io/seps/2567-sessionless-mcp
 #   https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442
-#   https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1359
+#   https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575
+#   https://modelcontextprotocol.io/community/seps/1686-tasks
+#   https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663
 # ---------------------------------------------------------------------------
 
 _r(
@@ -548,8 +553,10 @@ _r(
     "Reliance on `Mcp-Session-Id` header / protocol-level session id",
     "Server or client code reads, writes, asserts, or constants the "
     "`Mcp-Session-Id` header. The MCP 2026-07-28 spec release candidate "
-    "(SEP-1442) makes the protocol stateless and removes the "
-    "`Mcp-Session-Id` header along with the protocol-level session. After "
+    "removes the `Mcp-Session-Id` header and the protocol-level session, "
+    "replacing them with explicit server-minted state handles (SEP-2567); "
+    "SEP-1442 / SEP-2575 make the initialization handshake optional so "
+    "stateless is the default. After "
     "the final spec lands on 2026-07-28, code that depends on this header "
     "(or on the session it represented) will silently break: any MCP "
     "request can land on any server instance, and sticky routing / shared "
@@ -572,10 +579,11 @@ _r(
     "Use of removed `tasks/list` method",
     "Server or client code dispatches, handles, or names the `tasks/list` "
     "JSON-RPC method. The MCP 2026-07-28 spec release candidate removes "
-    "`tasks/list` outright because it cannot be scoped safely without the "
-    "protocol-level session. Tasks moves out of the core specification into "
-    "the new Extensions framework; the stateful list surface has no "
-    "stateless successor.",
+    "`tasks/list` from the core because it cannot be scoped safely without "
+    "the protocol-level session: the experimental Tasks primitive (SEP-1686) "
+    "moves out of the core specification into the Extensions framework "
+    "(redesigned as SEP-2663), and the stateful list surface has no "
+    "stateless successor in core.",
     Severity.HIGH,
     Category.MCP_CONFIG,
     "Stop calling and handling `tasks/list`. If your application needs an "

--- a/agent_audit_kit/scanners/mcp_stateless_migration.py
+++ b/agent_audit_kit/scanners/mcp_stateless_migration.py
@@ -3,11 +3,13 @@
 The MCP 2026-07-28 spec release candidate (locked 2026-05-21) makes the
 protocol stateless by default:
 
-* SEP-1442: the protocol-level session and `Mcp-Session-Id` header are
-  removed; any MCP request can land on any server instance.
-* SEP-1359: the `tasks/list` method is removed because it can't be scoped
-  safely without sessions; Tasks moves out of the core specification into
-  the Extensions framework.
+* SEP-2567: the protocol-level session and `Mcp-Session-Id` header are
+  removed and replaced with explicit server-minted state handles, so any
+  MCP request can land on any server instance. SEP-1442 / SEP-2575 make the
+  initialization handshake optional so stateless is the default.
+* The experimental Tasks primitive (SEP-1686), including `tasks/list`, moves
+  out of the core specification into the Extensions framework (redesigned as
+  SEP-2663), so core `tasks/list` is removed.
 
 Server / client code that assumes the pre-RC stateful protocol will
 silently break once the final spec lands on 2026-07-28. This scanner

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.46
+      - uses: sattyamjjain/agent-audit-kit@v0.3.47
         with:
           severity: low
           fail-on: high
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.46
+    rev: v0.3.47
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.46
+    rev: v0.3.47
     hooks:
       - id: agent-audit-kit
 ```
@@ -59,7 +59,7 @@ repos:
 ## GitHub Action
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.46
+- uses: sattyamjjain/agent-audit-kit@v0.3.47
   with:
     severity: low
     fail-on: high

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -92,7 +92,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.46
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.47
 >
 > MIT. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.46
+- uses: sattyamjjain/agent-audit-kit@v0.3.47
   with:
     preset: mcp-ox-2026-04
 ```

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-07-06T07:50:13Z",
-  "aak_version": "0.3.46",
+  "last_updated": "2026-07-07T17:38:27Z",
+  "aak_version": "0.3.47",
   "rule_count": 231,
   "coverage": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.46"
+version = "0.3.47"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rules.json
+++ b/rules.json
@@ -3014,7 +3014,7 @@
       "auto_fixable": false,
       "category": "mcp-config",
       "cve_references": [],
-      "description": "Server or client code reads, writes, asserts, or constants the `Mcp-Session-Id` header. The MCP 2026-07-28 spec release candidate (SEP-1442) makes the protocol stateless and removes the `Mcp-Session-Id` header along with the protocol-level session. After the final spec lands on 2026-07-28, code that depends on this header (or on the session it represented) will silently break: any MCP request can land on any server instance, and sticky routing / shared session stores at the protocol layer are no longer guaranteed.",
+      "description": "Server or client code reads, writes, asserts, or constants the `Mcp-Session-Id` header. The MCP 2026-07-28 spec release candidate removes the `Mcp-Session-Id` header and the protocol-level session, replacing them with explicit server-minted state handles (SEP-2567); SEP-1442 / SEP-2575 make the initialization handshake optional so stateless is the default. After the final spec lands on 2026-07-28, code that depends on this header (or on the session it represented) will silently break: any MCP request can land on any server instance, and sticky routing / shared session stores at the protocol layer are no longer guaranteed.",
       "incident_references": [],
       "owasp_agentic_references": [
         "ASI03"
@@ -3037,7 +3037,7 @@
       "auto_fixable": false,
       "category": "mcp-config",
       "cve_references": [],
-      "description": "Server or client code dispatches, handles, or names the `tasks/list` JSON-RPC method. The MCP 2026-07-28 spec release candidate removes `tasks/list` outright because it cannot be scoped safely without the protocol-level session. Tasks moves out of the core specification into the new Extensions framework; the stateful list surface has no stateless successor.",
+      "description": "Server or client code dispatches, handles, or names the `tasks/list` JSON-RPC method. The MCP 2026-07-28 spec release candidate removes `tasks/list` from the core because it cannot be scoped safely without the protocol-level session: the experimental Tasks primitive (SEP-1686) moves out of the core specification into the Extensions framework (redesigned as SEP-2663), and the stateful list surface has no stateless successor in core.",
       "incident_references": [],
       "owasp_agentic_references": [],
       "owasp_mcp_references": [

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.46"
+    assert __version__ == "0.3.47"


### PR DESCRIPTION
**Not a new pack — a credibility fix on the existing one.** `AAK-MCP-STATELESS-001..004` already ship (v0.3.25); this corrects wrong SEP citations in them. No detection change, rule count stays **231**.

Web-verified against modelcontextprotocol.io + the MCP GitHub SEPs:

| Was | Should be | Why |
|---|---|---|
| `Mcp-Session-Id` removal → SEP-1442 | **SEP-2567** ("Sessionless MCP via Explicit State Handles") | 2567 removes the session + header; 1442 / **2575** just make the handshake optional |
| `tasks/list` removal → **SEP-1359** | **SEP-1686 → SEP-2663** | SEP-1359 does not exist; Tasks (1686) moved to the Extensions framework (redesigned as 2663) |

Changed: `AAK-MCP-STATELESS-001/-002` descriptions + section comment/sources, `mcp_stateless_migration.py` docstring, engine label, `rules.json`. The bogus **SEP-1359 is gone** repo-wide.

## Test plan
`pytest` **1256 passed** (incl. the 16 stateless tests); `ruff` + `mypy` clean; count guard green at 231.

## Note
Your brief asked to *add* this pack as new — it already existed, so I did the verification-gated citation refresh instead (option 2). Your instinct on SEP-2567/2575 was correct; the shipped SEP-1442 was incomplete and SEP-1359 was fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)