### PR TITLE
feat(research): State of MCP Security 2026 report — 2,303-config corpus + human PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — State of MCP Security 2026 data report (fresh 2,303-config corpus)
+
+Publish the credibility artifact — no new detection, nothing gated.
+
+- **Refreshed the corpus** via `fetch_registry.py` from the live MCP Registry:
+  **1,641 distinct latest-version servers @ 2026-07-26**, up 2.3× from 710 on
+  2026-07-19 (the registry has grown fast). Combined with the GitHub crawl, the
+  scanned corpus is now **2,303 distinct public MCP server configs** (up from
+  1,374). Snapshot date + N logged in the manifest for reproducibility.
+- **Re-ran the aggregation** (`run_report.py`, offline + deterministic) →
+  refreshed `results.json`. Headline: **52.3% (1,205/2,303) declare a remote
+  server with no authentication** (up from 35.1% as the registry skewed toward
+  no-auth remotes), 0% use RFC 9728 PRM discovery, 100% (421/421) of inline-auth
+  configs hardcode a static credential, 19.5% `npx`/`uvx`-fetch-execute unpinned
+  packages, 52.8% carry a critical finding.
+- **Rewrote `research/state-of-mcp-2026/REPORT.md`** — headline `% fail X` per
+  rule family, method, corpus size + date, reproduce CLI, the two defensible
+  wedges (offline/deterministic + NSA-CSI/OWASP-Agentic compliance crosswalk),
+  and the market backdrop (Shai-Hulud 2.0 npm worm, NSA MCP CSI). Explicitly not
+  claiming "first". Added a **human PDF** via `output/pdf_report.py`
+  (`emit_report_pdf`): `state-of-mcp-security-2026.pdf`.
+- README "State of MCP Security 2026" section refreshed with the live headline.
+- Counts stay canonical (**270 rules / 86 scanners**, one number everywhere,
+  guarded by `test_rule_count_is_canonical` / scanner-count) — the reported
+  drift did not exist.
+- Version 0.3.59 → 0.3.60.
+
 ### Added — coverage crosswalk asset (`--emit-coverage`) + State-of-MCP report seed
 
 Make the tool's coverage legible without adding any rules (still 270).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.59
+      - uses: sattyamjjain/agent-audit-kit@v0.3.60
         id: scan
         with:
           fail-on: high
@@ -95,7 +95,7 @@ agent-audit-kit scan .
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.59
+    rev: v0.3.60
     hooks:
       - id: agent-audit-kit
 ```
@@ -280,7 +280,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v4
-  - uses: sattyamjjain/agent-audit-kit@v0.3.59
+  - uses: sattyamjjain/agent-audit-kit@v0.3.60
     id: scan
     with:
       fail-on: high
@@ -463,20 +463,24 @@ Public leaderboard of MCP servers we scan weekly:
 - **90-day coordinated disclosure** before anything lands on a public card — see [`docs/disclosure-policy.md`](docs/disclosure-policy.md)
 - Maintainer-fix earlier gets published the day the fix lands, with credit
 
-## Research: State of MCP Server Authentication 2026
+## State of MCP Security 2026
 
-A reproducible data report over **1,374 distinct public MCP server configs** — 664
-GitHub-crawled plus **710 official MCP Registry latest-version servers**, deduped by
-content and scanned offline and deterministically (scan date 2026-07-19). Headline:
-**35.1% (482/1,374) declare a remote server with no authentication, 0% (0/1,374) use
-RFC 9728 Protected-Resource-Metadata discovery, and 100% (318/318) of inline-auth
-configs hardcode a static credential.** 36.0% carry a critical-severity finding; the
-median config scores a **B**, and **99.7% trip OWASP MCP07 (authorization)**. Full
-method, per-metric findings (each with n + denominator), the 2026-07-28 / 2027-07-28
-migration exposure with explicit coverage notes, disclosure posture, and limitations:
-**[`research/state-of-mcp-2026/REPORT.md`](research/state-of-mcp-2026/REPORT.md)** —
-raw aggregate [`results.json`](research/state-of-mcp-2026/results.json), corpus
-provenance [`registry-manifest.json`](research/state-of-mcp-2026/corpus/registry-manifest.json).
+A reproducible data report over **2,303 distinct public MCP server configs** — 664
+GitHub-crawled plus **1,641 official MCP Registry latest-version servers** (up 2.3×
+from 710 in July as the registry grew), deduped by content and scanned offline and
+deterministically (scan date **2026-07-26**). Headline: **52.3% (1,205/2,303) declare
+a remote server with no authentication, 0% use RFC 9728 Protected-Resource-Metadata
+discovery, 100% (421/421) of inline-auth configs hardcode a static credential, and
+19.5% `npx`/`uvx`-fetch-and-execute unpinned remote packages** (the Shai-Hulud
+supply-chain blast radius, one `.mcp.json` away). 52.8% carry a critical finding.
+
+Full method, per-metric findings (each with n + denominator), the two defensible
+wedges (offline/deterministic scanning + a NSA-MCP-CSI / OWASP-Agentic
+compliance-evidence crosswalk), market backdrop, and limitations:
+**[`research/state-of-mcp-2026/REPORT.md`](research/state-of-mcp-2026/REPORT.md)**
+(+ [PDF](research/state-of-mcp-2026/state-of-mcp-security-2026.pdf)) — raw aggregate
+[`results.json`](research/state-of-mcp-2026/results.json), corpus provenance
+[`registry-manifest.json`](research/state-of-mcp-2026/corpus/registry-manifest.json).
 
 The harness contains no scanner — it reuses `agent_audit_kit.engine.run_scan` +
 `scoring.compute_score`, so every number is reproducible offline and cannot drift

--- a/agent_audit_kit/__init__.py
+++ b/agent_audit_kit/__init__.py
@@ -1,6 +1,6 @@
 """AgentAuditKit — Security scanner for MCP-connected AI agent pipelines."""
 from __future__ import annotations
 
-__version__ = "0.3.59"
+__version__ = "0.3.60"
 RULE_COUNT = 270
 SCANNER_COUNT = 86

--- a/agent_audit_kit/output/pdf_report.py
+++ b/agent_audit_kit/output/pdf_report.py
@@ -317,3 +317,84 @@ def emit_pdf(result: ScanResult, framework: str, output_path: Path) -> tuple[boo
 
     doc.build(story)
     return True, f"wrote PDF report to {output_path}"
+
+
+def _report_text(results: dict) -> str:
+    """Plain-text fallback for the State-of-MCP aggregate report."""
+    lines = [
+        "The State of MCP Security, 2026 — AgentAuditKit",
+        f"Scan date: {results.get('scan_date', '?')}",
+        f"Corpus: {results['distinct_configs_scanned']:,} distinct public MCP server configs",
+        "",
+        "Top findings (% of corpus):",
+    ]
+    for t in results.get("top_misconfigurations", []):
+        lines.append(f"  {t['config_pct']:>5}%  {t['rule_id']} [{t['severity']}] — {t['title']}")
+    return "\n".join(lines) + "\n"
+
+
+def emit_report_pdf(results: dict, output_path: Path) -> tuple[bool, str]:
+    """Render the State-of-MCP aggregate (`results.json`) as a human PDF.
+
+    Reuses the same reportlab primitives as `emit_pdf`; falls back to a .txt when
+    reportlab is missing. This is the credibility artifact — the "% of public MCP
+    servers fail X" report — not a per-scan compliance pack.
+    """
+    try:
+        from reportlab.lib.pagesizes import letter
+        from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+        from reportlab.lib.units import inch
+        from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
+        from reportlab.lib import colors
+    except ImportError:
+        text_path = output_path.with_suffix(".txt")
+        text_path.write_text(_report_text(results), encoding="utf-8")
+        return False, f"reportlab not installed; wrote plain-text fallback to {text_path}."
+
+    doc = SimpleDocTemplate(str(output_path), pagesize=letter, title="State of MCP Security 2026")
+    styles = getSampleStyleSheet()
+    body = ParagraphStyle("aak-body", parent=styles["BodyText"], fontName="Helvetica", fontSize=9, leading=12)
+    n = results["distinct_configs_scanned"]
+    story = [
+        Paragraph("<b>The State of MCP Security, 2026</b>", styles["Title"]),
+        Paragraph(f"AgentAuditKit {__version__} — offline, deterministic", styles["Heading3"]),
+        Paragraph(
+            f"Scan date: {results.get('scan_date', '?')} &nbsp;·&nbsp; Corpus: {n:,} distinct "
+            f"public MCP server configs ({results.get('corpus_sources', {})})",
+            body,
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("<b>Headline findings — % of public MCP servers</b>", styles["Heading2"]),
+    ]
+    rows = [["Rule", "Severity", "% of corpus", "Configs", "Finding"]]
+    for t in results.get("top_misconfigurations", []):
+        rows.append([t["rule_id"], t["severity"].upper(), f"{t['config_pct']}%", str(t["configs"]), t["title"]])
+    tbl = Table(rows, colWidths=[1.7 * inch, 0.7 * inch, 0.8 * inch, 0.6 * inch, 2.7 * inch])
+    tbl.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.lightgrey),
+        ("GRID", (0, 0), (-1, -1), 0.25, colors.grey),
+        ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+        ("FONTSIZE", (0, 0), (-1, -1), 7),
+        ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.whitesmoke]),
+    ]))
+    story.append(tbl)
+    story.append(Spacer(1, 0.2 * inch))
+
+    ap = results.get("auth_profile_2026_07_28", {})
+    na = ap.get("no_authentication", {})
+    story.append(Paragraph("<b>Authentication posture (2026-07-28 profile)</b>", styles["Heading2"]))
+    story.append(Paragraph(
+        f"No authentication: {na.get('n')} of {n:,} ({na.get('pct')}%). "
+        f"RFC 9728 PRM discovery: {ap.get('rfc9728_prm_discovery', {}).get('n')} of {n:,}. "
+        f"Of inline-auth remotes, {ap.get('remote_auth_static_credential', {}).get('n')} of "
+        f"{ap.get('remote_auth_static_credential', {}).get('denominator')} hardcode a static credential.",
+        body,
+    ))
+    story.append(Spacer(1, 0.15 * inch))
+    story.append(Paragraph(
+        "Reproduce (offline, deterministic): <font face='Courier'>make report</font>. "
+        "Full narrative + method: research/state-of-mcp-2026/REPORT.md.",
+        body,
+    ))
+    doc.build(story)
+    return True, f"wrote State-of-MCP report PDF to {output_path}"

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: sattyamjjain/agent-audit-kit@v0.3.59
+      - uses: sattyamjjain/agent-audit-kit@v0.3.60
         with:
           severity: low
           fail-on: high
@@ -22,7 +22,7 @@ jobs:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.59
+    rev: v0.3.60
     hooks:
       - id: agent-audit-kit
       # Or strict mode:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sattyamjjain/agent-audit-kit
-    rev: v0.3.59
+    rev: v0.3.60
     hooks:
       - id: agent-audit-kit
 ```
@@ -59,7 +59,7 @@ repos:
 ## GitHub Action
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.59
+- uses: sattyamjjain/agent-audit-kit@v0.3.60
   with:
     severity: low
     fail-on: high

--- a/docs/launch/x-thread.md
+++ b/docs/launch/x-thread.md
@@ -92,7 +92,7 @@ Post same Tuesday as HN, ~1h after HN submission.
 > • Repo: github.com/sattyamjjain/agent-audit-kit
 > • Leaderboard: mcp-security-index.com
 > • VS Code Marketplace: agent-audit-kit
-> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.59
+> • GitHub Action: uses: sattyamjjain/agent-audit-kit@v0.3.60
 >
 > MIT. No strings.
 

--- a/docs/presets/mcp-ox-2026-04.md
+++ b/docs/presets/mcp-ox-2026-04.md
@@ -34,7 +34,7 @@ agent-audit-kit scan --preset mcp-ox-2026-04 .
 ## GitHub Action usage
 
 ```yaml
-- uses: sattyamjjain/agent-audit-kit@v0.3.59
+- uses: sattyamjjain/agent-audit-kit@v0.3.60
   with:
     preset: mcp-ox-2026-04
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-audit-kit"
-version = "0.3.59"
+version = "0.3.60"
 description = "Security scanner for MCP-connected AI agent pipelines"
 readme = "README.md"
 license = {text = "MIT"}

--- a/research/state-of-mcp-2026/REPORT.md
+++ b/research/state-of-mcp-2026/REPORT.md
@@ -1,45 +1,83 @@
-# The State of MCP Server Authentication, 2026
+# The State of MCP Security, 2026
 
-**Scan date:** 2026-07-19 · **Corpus:** 1,374 distinct public MCP server configs · **Tool:** AgentAuditKit (offline, deterministic)
+**Scan date:** 2026-07-26 · **Corpus:** 2,303 distinct public MCP server configs · **Tool:** AgentAuditKit (offline, deterministic)
 
-A static scan of 1,374 distinct public Model Context Protocol server
-configurations, measuring authentication posture and exposure to the two
-scheduled MCP protocol changes (2026-07-28 stateless transport, 2027-07-28
-feature removals). Every number below carries its numerator, denominator, and —
-where a metric is not computable for the whole corpus — its coverage.
+We statically scanned **2,303 distinct public Model Context Protocol server
+configurations** — the largest snapshot we know of — and measured what fraction
+fail each security rule family. The headline: **more than half of public MCP
+servers declare a remote endpoint with no authentication.** Every number below
+carries its numerator, denominator, and — where a metric is not computable for
+the whole corpus — its coverage.
+
+## Headline findings
+
+| Finding | Rule | Share of corpus |
+|---------|------|----------------:|
+| Remote MCP server with **no authentication** | `AAK-MCP-001` (critical) | **52.3%** — 1205 of 2,303 |
+| Carries at least one **critical** finding | — | 52.8% (1,217) |
+| Fetches & executes remote packages via `npx`/`uvx` (supply-chain surface) | `AAK-MCP-005` (medium) | 19.5% (450) |
+| OAuth surface with **no RFC 9728** Protected-Resource-Metadata discovery | `AAK-OAUTH-008` (low) | 18.3% (421) |
+| Command uses a **relative path** (PATH-hijack surface) | `AAK-MCP-006` (medium) | 7.8% (179) |
+| **Secret in the env block** (hardcoded credential) | `AAK-MCP-003` / `AAK-SECRET-007` | 3.0% (70) |
+| **stdio launcher injection** — shell interpreter with exec flag / interpolated args | `AAK-MCP-STDIO-LAUNCHER-INJECT-001` (high) | 2.1% (49) |
+| URL points to **localhost / internal** network (SSRF surface) | `AAK-MCP-009` (high) | 1.9% (44) |
+| Deprecated **SSE** transport (2026-07-28 stateless break) | `AAK-TRANSPORT-003` | 1.6% (36) |
+
+Auth posture, the 2026-07-28 profile:
+
+- **No authentication:** 1205 of 2,303 (**52.3%**).
+- **RFC 9728 PRM discovery:** 0 of 2,303 (**0.0%**) — not a single public server
+  serves the discovery document the ratified auth spec expects.
+- **Remote configs:** 1,648 of 2,303 (71.6%). Of the 421 that embed an inline
+  credential, **421 of 421 (100%)** hardcode a static secret rather than
+  reference an env var or use OAuth.
 
 ## Method
 
 ### Corpus construction
 
-The corpus is two provenance-tracked sources, deduplicated by configuration
-content (SHA-256 of the normalised JSON):
+Two provenance-tracked sources, deduplicated by configuration content (SHA-256
+of the normalised JSON):
 
-| Source | Candidates | Distinct after dedup |
-|--------|-----------:|---------------------:|
+| Source | Candidates | In corpus |
+|--------|-----------:|----------:|
 | GitHub-crawled `.mcp.json` files (`benchmarks/data/`) | 748 | 664 |
-| Official MCP Registry, latest-version servers (`registry.modelcontextprotocol.io`) | 710 | 710 |
-| **Combined** | **1,458** | **1,374** |
+| Official MCP Registry, latest-version servers (`registry.modelcontextprotocol.io`) | 1,641 | 1,639 |
+| **Combined** | **2,389** | **2,303** |
 
-83 byte-duplicate configs and 1 unparseable file were removed. Registry servers
-were fetched on 2026-07-19 via cursor pagination, filtered to
+85 byte-duplicate configs and 1 unparseable file were removed. Registry servers
+were fetched on **2026-07-26** via cursor pagination (40-page crawl), filtered to
 `isLatest = true` / `status = active`, and each converted to a scannable
-`.mcp.json`-shaped config. Provenance for every registry server — name, version,
-transport, auth mode, source URL, fetch date — is recorded in
-`corpus/registry-manifest.json`, so each number here is reproducible from the
-committed manifest without re-fetching.
+`.mcp.json`-shaped config. The registry has grown fast — this snapshot is
+**1,641 distinct latest-version registry servers**, up from 710 on 2026-07-19
+(2.3×). Provenance for every registry server — name, version, transport, auth
+mode, source URL, fetch date — is recorded in `corpus/registry-manifest.json`,
+so each number here is reproducible from the committed manifest without
+re-fetching.
 
 ### Scanning
 
 Each config is scanned in isolation with AgentAuditKit's engine and scored with
 the same penalty-based A–F grade the `aak score` command and the MCP Security
-Index use. The scan is offline (no network) and deterministic: the same corpus
-yields a byte-identical `results.json` on every run, across Python hash seeds.
+Index use. The scan is **offline** (zero network calls) and **deterministic**:
+the same corpus yields a byte-identical `results.json` on every run, across
+Python hash seeds — the property that makes a published number auditable.
+
+Note on what is and isn't config-detectable: rule families that live in a
+client `.mcp.json` — no-auth, launcher injection, relative-path commands, env
+secrets, `npx`/`uvx` fetch-execute, transport — fire here. Families that require
+**server source** (tool-poisoning `AAK-POISON-*`, taint `AAK-TAINT-*`, the
+`AAK-MCP-STDIO-CMD-INJ-*` source detectors) do not fire on a config-only corpus
+and are reported as ~0% by construction, not by absence of risk. The MCP CVE
+version-pins (`agent_audit_kit/scanners/mcp_cve_pins_2026_07.py`) fire only when
+a config pins a specific vulnerable version; registry configs overwhelmingly use
+unpinned `npx -y <pkg>` (counted under `AAK-MCP-005`), so pinned-CVE hits are
+rare on this corpus.
 
 ### Reproduce
 
 ```bash
-make report          # refreshes results.json from the committed manifest, offline
+make report          # refreshes results.json from the committed manifest, offline + deterministic
 # or, explicitly:
 python research/state-of-mcp-2026/run_report.py \
     --corpus benchmarks/data \
@@ -48,152 +86,81 @@ python research/state-of-mcp-2026/run_report.py \
 ```
 
 Refreshing the corpus itself (the one network step) is separate:
-`python research/state-of-mcp-2026/fetch_registry.py --target 700`.
+`python research/state-of-mcp-2026/fetch_registry.py --target 5000`.
 
-## Findings
+## Grade distribution (score calibration)
 
-### Grade distribution (score calibration)
+| Grade | Configs | Share |
+|:-----:|--------:|------:|
+| A | 632 | 27.4% |
+| B | 1,426 | 61.9% |
+| C | 111 | 4.8% |
+| D | 49 | 2.1% |
+| F | 85 | 3.7% |
 
-| Grade | Configs | Share | Cumulative |
-|:-----:|--------:|------:|-----------:|
-| A | 500 | 36.4% | 36.4% |
-| B | 643 | 46.8% | 83.2% |
-| C | 97 | 7.1% | 90.3% |
-| D | 49 | 3.6% | 93.9% |
-| F | 85 | 6.2% | 100% |
+n = 2,303. The median config scores **B**. **1,217 (52.8%)** carry at least one
+critical-severity finding — driven almost entirely by the no-auth remote server
+class. Most public configs are not catastrophic, but the single most common
+public posture is *a remote server anyone can call*.
 
-n = 1,374. The median config scores **B**; the top 36.4% score **A**. **494
-configs (36.0%)** carry at least one critical-severity finding and **164 (11.9%)**
-at least one high. Operationally: most public configs are not catastrophic, but a
-third contain something that, in a scanned deployment, would be a critical
-finding.
+## Why this matters now — and the two wedges
 
-### No authentication at all
+The market backdrop is a supply-chain and trust crisis, not a scanner gap:
 
-**482 of 1,374 configs (35.1%)** declare a remote MCP server reachable with no
-authentication (`AAK-MCP-001`). Of the 801 configs (58.3%) that declare any
-remote server, that is the single most common finding. Operationally: a client
-using one of these configs connects to a network-reachable MCP server that
-performs no access control at the transport layer.
+- **Shai-Hulud 2.0** — the self-propagating npm worm that republishes legitimate
+  packages with a malicious `preinstall` script and uses GitHub infrastructure as
+  C2 — compromised **25,000+ repositories across ~350 maintainers** (Zapier,
+  PostHog, Postman), with a *Mini Shai-Hulud* resurgence in May 2026 hitting 170+
+  npm packages ([Microsoft Security](https://www.microsoft.com/en-us/security/blog/2025/12/09/shai-hulud-2-0-guidance-for-detecting-investigating-and-defending-against-the-supply-chain-attack/)).
+  Our finding that **19.5% of public MCP servers `npx`/`uvx`-fetch-and-execute
+  unpinned remote packages** is that same blast radius, one `.mcp.json` away.
+- **NSA MCP hardening guidance** — the NSA AISC *MCP Security Design
+  Considerations* CSI (U/OO/6030316-26, 2026-05-20) put MCP posture on
+  government letterhead. It is prose, not a checklist — so the gap is *evidence*,
+  not awareness.
 
-### RFC 9728 Protected Resource Metadata discovery
+Against that backdrop, two things a free hosted scanner structurally can't match:
 
-**0 of 1,374 configs (0.0%)** reference RFC 9728 Protected Resource Metadata
-discovery (`/.well-known/oauth-protected-resource`, `authorization_servers`, or
-`resource_metadata`). This holds across the whole corpus, not only the 748-config
-baseline. Operationally: no public config in this sample uses the
-server-advertised discovery mechanism the ratified 2025-11-25 auth spec defines;
-authentication, where present, is arranged out of band.
+1. **Offline + deterministic scanning.** Zero network calls in the default scan
+   path; the same input always yields the same finding (no model in the loop), so
+   CI diffs, audit re-runs, and regression baselines stay byte-stable. This report
+   is itself the proof: every number regenerates identically from the committed
+   manifest.
+2. **A compliance-evidence crosswalk.** Every rule is mapped — rule by rule — to
+   the **NSA MCP Security CSI** control it evidences and its **OWASP Agentic
+   Top-10 (2026)** slot (also OWASP MCP Top-10 and EU AI Act), emitted as
+   machine-readable evidence: `agent-audit-kit --emit-coverage --format json`
+   (see [`docs/coverage.json`](../../docs/coverage.json) and
+   [`docs/crosswalk/nsa-csi-owasp-agentic.md`](../../docs/crosswalk/nsa-csi-owasp-agentic.md)).
+   That turns a finding into audit evidence an assessor can cite.
 
-### Remote auth that hardcodes a static credential
+We are **not** claiming to be first — public MCP-security surveys and vendor
+disclosures predate this. What is offline, deterministic, and standards-mapped is
+the combination.
 
-Of the configs that authenticate to a remote server by embedding a credential
-inline, **318 of 318 (100%)** do so with a static credential and no PRM discovery
-path (`AAK-OAUTH-008`). This matches the 36-of-36 baseline exactly at ~9× the
-scale. Operationally: every remote-auth config in the sample presents a
-pre-shared bearer/token header rather than obtaining an audience-bound token
-through discovery.
+## 2026-07-28 stateless-transport exposure
 
-### Transport distribution
-
-Across all declared server entries (a config may declare several):
-
-| Transport | Server entries |
-|-----------|---------------:|
-| stdio | 1,265 |
-| streamable-http | 900 |
-| sse | 41 |
-| unknown | 7 |
-
-stdio (local subprocess) remains the most common transport; streamable-HTTP is
-the dominant remote transport; deprecated SSE is a small residual.
-
-### Rule-family and OWASP-MCP distribution
-
-Configs with ≥1 finding, by AAK rule family and by OWASP MCP Top 10 slot:
-
-| AAK family | Configs | Share | | OWASP MCP | Configs | Share |
-|---|--:|--:|---|---|--:|--:|
-| `AAK-MCP-*` | 1,370 | 99.7% | | MCP07:2025 (authorization) | 1,370 | 99.7% |
-| `AAK-OAUTH-*` | 318 | 23.1% | | MCP01:2025 (token/secret) | 385 | 28.0% |
-| `AAK-SECRET-*` | 70 | 5.1% | | MCP03:2025 (tool/launch integrity) | 377 | 27.4% |
-| `AAK-TRANSPORT-*` | 26 | 1.9% | | MCP10:2025 (supply chain) | 377 | 27.4% |
-| | | | | MCP04:2025 (command injection) | 205 | 14.9% |
-| | | | | MCP09:2025 (transport) | 44 | 3.2% |
-
-### Top findings (advisory-posture rules excluded)
-
-| # | Rule | Severity | Configs | Share |
-|--:|---|:---:|--:|--:|
-| 1 | `AAK-MCP-001` — remote server without authentication | **CRITICAL** | 482 | 35.1% |
-| 2 | `AAK-MCP-005` — `npx`/`uvx` fetch-and-execute remote packages | MEDIUM | 377 | 27.4% |
-| 3 | `AAK-OAUTH-008` — no RFC 9728 PRM discovery | LOW | 318 | 23.1% |
-| 4 | `AAK-MCP-006` — command uses a relative path | MEDIUM | 175 | 12.7% |
-| 5 | `AAK-SECRET-007` — secret in server env block | MEDIUM | 70 | 5.1% |
-| 6 | `AAK-MCP-003` — env exposes secrets to the tool process | HIGH | 70 | 5.1% |
-| 7 | `AAK-MCP-STDIO-LAUNCHER-INJECT-001` — stdio server launches a shell interpreter | HIGH | 49 | 3.6% |
-| 8 | `AAK-MCP-009` — server URL points at localhost / internal network | HIGH | 44 | 3.2% |
-| 9 | `AAK-TRANSPORT-003` — deprecated SSE transport | MEDIUM | 21 | 1.5% |
-| 10 | `AAK-MCP-004` — excessive number of servers declared | HIGH | 12 | 0.9% |
-
-## Migration exposure
-
-### 2026-07-28 stateless transport revision
-
-The 2026-07-28 revision makes the protocol stateless: SEP-2575 makes the
-`initialize`/`initialized` handshake optional and SEP-2567 removes the
-`Mcp-Session-Id` header and the SSE session model.
-
-**Config-measurable proxy: 26 of 1,374 configs (1.9%)** declare a deprecated-SSE
-transport (`AAK-TRANSPORT-003`, or a `type: sse` entry), which is the surface
-being removed. **Coverage note:** the `initialize`-handshake and
-`Mcp-Session-Id` dependencies are runtime/server-code behaviours that a client
-`.mcp.json` config does not express — they are **not** computable from this
-corpus. The SSE-transport share is the only config-visible signal; the true
-protocol-level exposure requires scanning server source, which this report does
-not do.
-
-### 2027-07-28 feature-removal clock (Roots / Sampling / Logging / Dynamic Client Registration)
-
-**Config-measurable: 0 of 1,374 configs (0.0%).** These are runtime capabilities
-negotiated at connection time (or server-side auth features), not fields declared
-in a client `.mcp.json` config. **Coverage note:** this metric is therefore not
-measurable from the config corpus at all — a `0` here means "no config expresses
-it," not "no server uses it." Measuring real Roots/Sampling/Logging/DCR usage
-requires scanning server implementations; AAK ships the rules
-(`AAK-MCP-DEPRECATED-001..003`, `AAK-MCP-STATELESS-001..004`) for that, but the
-population on the 2027-07-28 removal clock cannot be quantified from
-configurations.
+The ratified 2026-07-28 spec removes the `initialize` handshake and the
+`Mcp-Session-Id` header (stateless core). The measurable proxy in a client config
+is deprecated **SSE** transport: **36 configs (1.6%)** still declare it and will
+break when the session model goes. streamable-HTTP dominates the fresh corpus
+(1,726 server entries) over stdio (1,347) and SSE (62).
 
 ## Responsible-disclosure posture
 
-This report publishes only aggregate statistics. No individual server is named,
-graded, or linked. Where AAK's public MCP Security Index does surface per-server
-findings, it follows a coordinated 90-day
-[disclosure policy](../../docs/disclosure-policy.md): affected maintainers are
-notified privately before anything is visible, with the rule ID, file/line
-pointer, remediation, and severity.
+Findings here are aggregate and de-identified; no server is named as vulnerable.
+The corpus is public registry metadata and public GitHub `.mcp.json` files. AAK's
+90-day [disclosure policy](../../docs/disclosure-policy.md) governs any per-server
+notification.
 
 ## Limitations
 
-- **Sample bias.** The corpus is public registry servers plus GitHub-crawled
-  configs. That is not the whole MCP population: private/internal servers,
-  unpublished configs, and enterprise deployments are absent, and registry
-  servers skew toward projects deliberately published for discovery. Percentages
-  describe *this sample*, not "all MCP servers."
-- **Config-level, not runtime.** The scan reads static configurations, not live
-  servers. It cannot confirm that a no-auth config points at a truly open server
-  (the operator may enforce auth elsewhere), nor measure runtime-negotiated
-  capabilities — hence the explicit coverage notes on the two migration metrics.
-- **Conversion fidelity.** Registry servers are converted to `.mcp.json` shape
-  from their `remotes`/`packages` metadata; a converted config reflects the
-  registry's declared transport and auth, which may differ from a server's actual
-  deployment.
-- **Point in time.** Numbers are as of the 2026-07-19 fetch. The registry holds
-  ~17k latest-version servers; this sample is 710 of them plus the 664 crawled
-  configs. Re-running `make report` on a refreshed manifest will move the numbers.
-
----
-
-*Raw aggregate: [`results.json`](results.json). Prior 664-config run:
-[`PREVALENCE.md`](PREVALENCE.md) (superseded by this expanded corpus).*
+- **Config-only for source-based families.** Tool-poisoning and taint need server
+  source; their ~0% here is a coverage boundary, not an all-clear (stated above).
+- **Registry snapshot is a 40-page crawl** (1,641 distinct latest); the registry
+  is larger and still growing, so the true corpus is a floor.
+- **Auth posture is inferred from declared config**, not a live probe — a server
+  could enforce auth the config doesn't declare (and vice-versa).
+- **"Benign" is not claimed.** This measures declared posture, not exploitability;
+  see the [benign-slice false-positive rate](../../benchmarks/false_positive/RESULTS.md)
+  for how precise the high-severity findings are.

--- a/research/state-of-mcp-2026/corpus/registry-manifest.json
+++ b/research/state-of-mcp-2026/corpus/registry-manifest.json
@@ -1,17 +1,17 @@
 {
   "source": "https://registry.modelcontextprotocol.io/v0/servers",
-  "fetched_at": "2026-07-19",
-  "distinct_latest_servers": 710,
+  "fetched_at": "2026-07-26",
+  "distinct_latest_servers": 1641,
   "servers": [
     {
       "name": "ac.inference.sh/mcp",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://sh.inference.ac",
       "registry_status": "active",
-      "published_at": "2026-04-13T17:33:26.613537Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-20T18:02:33.295284Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -29,7 +29,7 @@
       "source_url": "https://tandem.ac/mcp",
       "registry_status": "active",
       "published_at": "2026-04-22T21:06:34.500049Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "docs-mcp": {
@@ -47,7 +47,7 @@
       "source_url": "https://www.hood.ag/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T04:58:06.628668Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "name-service": {
@@ -65,7 +65,7 @@
       "source_url": "https://mcp.lona.agency/mcp",
       "registry_status": "active",
       "published_at": "2026-02-24T00:07:27.525636Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "trading": {
@@ -83,7 +83,7 @@
       "source_url": "https://agoclnqfyinwjxdmjnns.supabase.co/functions/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T05:01:17.106808Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -101,7 +101,7 @@
       "source_url": "https://mcp.aarna.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-10T11:09:59.15927Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "atars-mcp": {
@@ -119,7 +119,7 @@
       "source_url": "https://mcp.abmeter.ai",
       "registry_status": "active",
       "published_at": "2026-04-19T18:11:04.905549Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "abmeter": {
@@ -137,7 +137,7 @@
       "source_url": "https://api.adadvisor.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-28T13:09:52.236521Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -158,7 +158,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.adeu/adeu",
       "registry_status": "active",
       "published_at": "2026-05-16T13:54:48.18266Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "adeu": {
@@ -179,7 +179,7 @@
       "source_url": "https://mcp.adramp.ai",
       "registry_status": "active",
       "published_at": "2026-03-20T11:16:36.853329Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "google-ads": {
@@ -197,7 +197,7 @@
       "source_url": "https://api.adside.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-16T19:48:48.148514Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "adside": {
@@ -218,7 +218,7 @@
       "source_url": "https://mcp.adweave.ai/meta-ads-mcp",
       "registry_status": "active",
       "published_at": "2026-04-10T16:46:57.731179Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "meta-ads-mcp": {
@@ -233,13 +233,13 @@
     },
     {
       "name": "ai.aetherwealth/mcp",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.aetherwealth/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-17T08:51:15.143192Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-24T22:07:17.215889Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -260,7 +260,7 @@
       "source_url": "https://agentberg.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-18T01:49:38.050173Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "agentberg": {
@@ -278,7 +278,7 @@
       "source_url": "https://api.agentdm.ai/mcp/v1/grid",
       "registry_status": "active",
       "published_at": "2026-05-10T02:12:16.907792Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "agentdm": {
@@ -299,12 +299,30 @@
       "source_url": "https://api.agentic-news.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-06T18:34:53.583541Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
             "type": "http",
             "url": "https://api.agentic-news.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.agenticfabricationnetwork/ufp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agenticfabricationnetwork.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T06:26:25.029641Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ufp": {
+            "type": "http",
+            "url": "https://agenticfabricationnetwork.ai/mcp"
           }
         }
       }
@@ -317,7 +335,7 @@
       "source_url": "https://api.agenticshelf.ai/m/graffeo/mcp",
       "registry_status": "active",
       "published_at": "2026-05-14T20:40:06.442182Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "graffeo": {
@@ -335,7 +353,7 @@
       "source_url": "https://api.agenticshelf.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-06T16:24:16.952518Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -353,7 +371,7 @@
       "source_url": "https://api.agenticshelf.ai/m/puroair/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T16:47:32.556297Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "puroair": {
@@ -371,7 +389,7 @@
       "source_url": "https://mcp.agenticterminal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T15:17:01.794422Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "directory": {
@@ -389,7 +407,7 @@
       "source_url": "https://api.agentrapay.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-22T18:16:07.628131Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "agentra": {
@@ -407,7 +425,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agenttrust/mcp-server",
       "registry_status": "active",
       "published_at": "2026-03-06T11:23:10.721165Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -431,7 +449,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-agentops",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:14.904919Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-agentops": {
@@ -452,7 +470,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-bestiary",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:15.433564Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-bestiary": {
@@ -473,7 +491,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-browser-workflow",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:15.897391Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-browser-workflow": {
@@ -494,7 +512,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-compose",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:16.321193Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-compose": {
@@ -515,7 +533,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-edge-finance",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:17.095531Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-edge-finance": {
@@ -536,7 +554,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-edge-market",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:17.497855Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-edge-market": {
@@ -557,7 +575,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-locale",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:17.9033Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-locale": {
@@ -578,7 +596,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-matchpoint",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:18.280353Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-matchpoint": {
@@ -599,7 +617,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-mediakit",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:18.653557Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-mediakit": {
@@ -620,7 +638,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-model-router",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:19.082426Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-model-router": {
@@ -641,7 +659,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-prooflayer",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:19.560994Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-prooflayer": {
@@ -662,7 +680,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-retail",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:19.946363Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-retail": {
@@ -683,7 +701,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-rollforge",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:20.41779Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-rollforge": {
@@ -704,7 +722,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-statline",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:20.828032Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-statline": {
@@ -725,7 +743,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-synthforge",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:21.289726Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-synthforge": {
@@ -746,7 +764,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-web-probe",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:21.796993Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-web-probe": {
@@ -767,7 +785,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.agentutility/mcp-wordmint",
       "registry_status": "active",
       "published_at": "2026-07-14T21:10:22.302521Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-wordmint": {
@@ -781,6 +799,24 @@
       }
     },
     {
+      "name": "ai.ai-akari/agent-trust-receipt",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai-akari.ai/mcp-trust",
+      "registry_status": "active",
+      "published_at": "2026-07-24T19:48:47.852003Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-trust-receipt": {
+            "type": "http",
+            "url": "https://ai-akari.ai/mcp-trust"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.ai-akari/one-minute-akari",
       "version": "1.0.3",
       "transport": "streamable-http",
@@ -788,7 +824,7 @@
       "source_url": "https://ai-akari.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-18T04:01:27.700359Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "one-minute-akari": {
@@ -806,7 +842,7 @@
       "source_url": "https://www.ai-portal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T15:07:28.114017Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ai-portal": {
@@ -824,7 +860,7 @@
       "source_url": "https://aient.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T10:40:20.47951Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -842,7 +878,7 @@
       "source_url": "https://mcp.airshelf.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-16T09:32:12.311101Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "catalog": {
@@ -860,7 +896,7 @@
       "source_url": "https://api.aisecuritygateway.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T23:23:14.982464Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-gateway": {
@@ -881,7 +917,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.aliengiraffe/spotdb",
       "registry_status": "active",
       "published_at": "2025-10-09T17:05:17.793149Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "spotdb": {
@@ -907,7 +943,7 @@
       "source_url": "https://mcp.alphacreek.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T13:01:13.227147Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "alphacreek-mcp": {
@@ -928,7 +964,7 @@
       "source_url": "https://mcp.alpic.ai",
       "registry_status": "active",
       "published_at": "2026-02-18T15:32:32.672631Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "alpic-mcp": {
@@ -946,7 +982,7 @@
       "source_url": "https://test.alpic.ai/",
       "registry_status": "active",
       "published_at": "2025-09-10T13:57:43.256739Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "test-mcp-server": {
@@ -964,7 +1000,7 @@
       "source_url": "https://mcp.ambix.ai",
       "registry_status": "active",
       "published_at": "2026-06-18T11:40:33.32243Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ambix": {
@@ -976,13 +1012,13 @@
     },
     {
       "name": "ai.ankimcp/anki-mcp-server",
-      "version": "0.22.2",
+      "version": "0.22.5",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.ankimcp/anki-mcp-server",
       "registry_status": "active",
-      "published_at": "2026-07-04T17:34:42.675643Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-21T18:58:14.907015Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "anki-mcp-server": {
@@ -1003,7 +1039,7 @@
       "source_url": "https://mcp.anomalyarmor.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-18T00:51:37.350253Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "armor-mcp": {
@@ -1021,7 +1057,7 @@
       "source_url": "https://mcp.anzenna.ai/sse",
       "registry_status": "active",
       "published_at": "2026-02-21T23:53:55.798606Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "anzenna": {
@@ -1039,7 +1075,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.apithreshold/apithreshold",
       "registry_status": "active",
       "published_at": "2026-07-02T22:06:43.451983Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "apithreshold": {
@@ -1068,7 +1104,7 @@
       "source_url": "https://api-v2.appdeploy.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T12:28:46.556669Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "deploy-app": {
@@ -1086,7 +1122,7 @@
       "source_url": "https://arclan.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T16:59:50.65972Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "registry": {
@@ -1104,7 +1140,7 @@
       "source_url": "https://argushq.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T20:32:22.415073Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "enforcement-database": {
@@ -1122,7 +1158,7 @@
       "source_url": "https://mcp.arpi.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T04:42:03.74166Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arpi-mcp": {
@@ -1140,7 +1176,7 @@
       "source_url": "https://artidrop.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-17T04:01:26.724763Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "artidrop": {
@@ -1158,7 +1194,7 @@
       "source_url": "https://api.assetlog.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T06:44:06.803244Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "assetlog": {
@@ -1176,12 +1212,30 @@
       "source_url": "https://supershopping-mcp.atdev.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-29T05:36:58.413006Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "supershopping": {
             "type": "http",
             "url": "https://supershopping-mcp.atdev.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.atlasverified/atlas-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.atlasverified.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T23:43:13.692003Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "atlas-mcp": {
+            "type": "http",
+            "url": "https://api.atlasverified.ai/mcp"
           }
         }
       }
@@ -1194,12 +1248,33 @@
       "source_url": "https://api.augmentev.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-26T03:21:55.655559Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "paseo": {
             "type": "http",
             "url": "https://api.augmentev.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.augworlds/travel-world",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://travel.augworlds.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T22:17:22.125299Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "travel-world": {
+            "type": "http",
+            "url": "https://travel.augworlds.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -1212,7 +1287,7 @@
       "source_url": "https://mcp.auralogs.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T05:44:10.419193Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "auralogs": {
@@ -1233,7 +1308,7 @@
       "source_url": "https://auteng.ai/mcp/docs",
       "registry_status": "active",
       "published_at": "2026-02-06T20:56:39.150934Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "docs": {
@@ -1251,7 +1326,7 @@
       "source_url": "https://auteng.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-06T17:18:22.957864Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -1269,7 +1344,7 @@
       "source_url": "https://authoryze.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T01:01:52.175208Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "authoryze": {
@@ -1290,7 +1365,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.autoblocks/contextlayer-mcp",
       "registry_status": "active",
       "published_at": "2026-01-12T03:52:52.134106Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "contextlayer-mcp": {
@@ -1311,7 +1386,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.autoblocks/ctxl",
       "registry_status": "active",
       "published_at": "2026-01-12T03:52:12.746584Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ctxl": {
@@ -1332,7 +1407,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.autoblocks/ctxl-mcp",
       "registry_status": "active",
       "published_at": "2026-01-12T03:52:19.009876Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ctxl-mcp": {
@@ -1353,7 +1428,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.autonomad/computeback",
       "registry_status": "active",
       "published_at": "2026-05-11T23:17:51.160439Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "computeback": {
@@ -1380,7 +1455,7 @@
       "source_url": "https://mcp.autonomad.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-11T09:19:18.416611Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "travel": {
@@ -1398,7 +1473,7 @@
       "source_url": "https://{api_host}/mcp",
       "registry_status": "active",
       "published_at": "2026-05-18T01:09:10.259215Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -1416,7 +1491,7 @@
       "source_url": "https://api.auxen.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-18T23:32:19.610277Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "auxen": {
@@ -1434,7 +1509,7 @@
       "source_url": "https://aviado.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-30T13:03:52.011241Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "health": {
@@ -1452,7 +1527,7 @@
       "source_url": "https://mcp.neuroautomata.axonagentic.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-01T18:54:25.720204Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "neuroautomata": {
@@ -1470,7 +1545,7 @@
       "source_url": "https://backengine-prod.backengine.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T10:04:00.694928Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "backengine-mcp": {
@@ -1488,7 +1563,7 @@
       "source_url": "https://mcp-server-295985738387.europe-west1.run.app/mcp",
       "registry_status": "active",
       "published_at": "2026-04-28T09:24:20.898632Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "inferventis-mcp": {
@@ -1509,7 +1584,7 @@
       "source_url": "https://api.bareun.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-09T06:04:45.980117Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bareun": {
@@ -1530,7 +1605,7 @@
       "source_url": "https://api.baselight.app/mcp",
       "registry_status": "active",
       "published_at": "2026-04-30T15:33:16.859356Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "baselight": {
@@ -1551,12 +1626,30 @@
       "source_url": "https://mcp.basethread.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T17:57:42.454703Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "basethread": {
             "type": "http",
             "url": "https://mcp.basethread.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.bassethound/bassethound",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.bassethound.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T21:01:56.801935Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bassethound": {
+            "type": "http",
+            "url": "https://mcp.bassethound.ai/mcp"
           }
         }
       }
@@ -1569,7 +1662,7 @@
       "source_url": "https://beatbandit.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T15:54:48.389416Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "beatbandit": {
@@ -1587,7 +1680,7 @@
       "source_url": "https://b4-index.vercel.app/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T23:52:40.30259Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "b4-index": {
@@ -1608,7 +1701,7 @@
       "source_url": "https://betterpost.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T13:48:32.941236Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "server": {
@@ -1626,7 +1719,7 @@
       "source_url": "https://app.bezal.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-03-03T01:28:17.439049Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "local-commerce": {
@@ -1644,7 +1737,7 @@
       "source_url": "https://mcp.biddeed.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T13:00:32.732972Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "biddeed-mcp": {
@@ -1662,7 +1755,7 @@
       "source_url": "https://mcp.biel.ai/v2/{project_slug}/mcp",
       "registry_status": "active",
       "published_at": "2026-07-05T15:36:24.193043Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "biel-ai": {
@@ -1680,12 +1773,37 @@
       "source_url": "https://bittlebits.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-02T16:24:51.181889Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bittlebits": {
             "type": "http",
             "url": "https://bittlebits.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.bizmuse/bizmuse",
+      "version": "0.1.6",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.bizmuse/bizmuse",
+      "registry_status": "active",
+      "published_at": "2026-07-20T13:46:35.915847Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bizmuse": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "bizmuse-mcp"
+            ],
+            "env": {
+              "BIZMUSE_API_KEY": "${VALUE}",
+              "BIZMUSE_API_URL": "${VALUE}"
+            }
           }
         }
       }
@@ -1698,7 +1816,7 @@
       "source_url": "https://blast-radius.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-30T16:00:12.196014Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "blast-radius": {
@@ -1716,7 +1834,7 @@
       "source_url": "https://mcp.bloopo.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T06:11:28.73772Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bloopo": {
@@ -1728,13 +1846,13 @@
     },
     {
       "name": "ai.bluenexus/universal-mcp",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://api.bluenexus.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-17T07:04:15.607467Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T01:55:29.877967Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "universal-mcp": {
@@ -1752,7 +1870,7 @@
       "source_url": "https://mcp.bodenrichtwert.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-05T19:34:18.827643Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -1764,13 +1882,13 @@
     },
     {
       "name": "ai.bolthub/mcp",
-      "version": "0.5.2",
+      "version": "0.7.2",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.bolthub/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-15T12:01:51.493659Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-25T02:10:18.959626Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -1802,7 +1920,7 @@
       "source_url": "https://directory.boolsai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T13:30:35.464226Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "directory": {
@@ -1820,7 +1938,7 @@
       "source_url": "https://grep.boolsai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T13:30:36.222224Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "grep": {
@@ -1838,7 +1956,7 @@
       "source_url": "https://boolsai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T13:30:34.760247Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "scan": {
@@ -1856,7 +1974,7 @@
       "source_url": "https://signals.boolsai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T13:30:36.922608Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "signals": {
@@ -1874,12 +1992,33 @@
       "source_url": "https://borealhost.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-07-16T00:34:18.007723Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
             "type": "http",
             "url": "https://borealhost.ai/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.boundaryai/boundaryai",
+      "version": "0.7.31",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.boundaryai.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T16:21:56.590296Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "boundaryai": {
+            "type": "http",
+            "url": "https://mcp.boundaryai.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -1892,7 +2031,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.bourdon/bourdon",
       "registry_status": "active",
       "published_at": "2026-07-15T05:46:35.916984Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bourdon": {
@@ -1906,13 +2045,13 @@
     },
     {
       "name": "ai.bowmark/bowmark",
-      "version": "3.79.1",
+      "version": "3.106.10",
       "transport": "streamable-http",
       "auth_mode": "static-credential",
       "source_url": "https://api.bowmark.ai/mcp?s=r",
       "registry_status": "active",
-      "published_at": "2026-07-19T03:18:30.693559Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T03:15:21.248425Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bowmark": {
@@ -1933,7 +2072,7 @@
       "source_url": "https://app.brainattic.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-25T13:20:35.696854Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "knowledge-base": {
@@ -1951,7 +2090,7 @@
       "source_url": "https://bringyour.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-24T08:15:43.116321Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bringyour": {
@@ -1969,7 +2108,7 @@
       "source_url": "https://bunzee.ai/mcp-server",
       "registry_status": "active",
       "published_at": "2026-06-05T01:24:59.568246Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bunzee": {
@@ -1987,7 +2126,7 @@
       "source_url": "https://app.buron.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-19T22:19:56.582694Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "buron": {
@@ -2005,7 +2144,7 @@
       "source_url": "https://api.butlerbrain.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-26T06:33:02.85583Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -2023,7 +2162,7 @@
       "source_url": "https://mcp.buyersense.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-03T09:49:36.790849Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "buyersense": {
@@ -2041,7 +2180,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.buywhere/buywhere-mcp",
       "registry_status": "active",
       "published_at": "2026-05-03T21:45:08.750713Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "buywhere-mcp": {
@@ -2066,7 +2205,7 @@
       "source_url": "https://mcp.byteask.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-19T12:57:43.612963Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "embedded-docs": {
@@ -2084,7 +2223,7 @@
       "source_url": "https://mcp.byteray.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-19T04:19:09.97653Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "byteray-mcp": {
@@ -2102,7 +2241,7 @@
       "source_url": "https://cabrini.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T20:42:10.821364Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "market-data": {
@@ -2120,7 +2259,7 @@
       "source_url": "https://calendarmcp.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-20T07:09:04.298867Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "server": {
@@ -2141,7 +2280,7 @@
       "source_url": "https://calfeed.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-05T19:00:28.019015Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "calfeed": {
@@ -2162,7 +2301,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.callmcp/server",
       "registry_status": "active",
       "published_at": "2026-07-10T00:53:26.478263Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "server": {
@@ -2187,7 +2326,7 @@
       "source_url": "https://www.canaryusers.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-13T18:31:58.336704Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "canaryusers": {
@@ -2201,14 +2340,32 @@
       }
     },
     {
+      "name": "ai.canivibe/status",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://canivibe.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T17:08:49.919308Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "status": {
+            "type": "http",
+            "url": "https://canivibe.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.canvora/canvora",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://api.canvora.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-14T14:09:37.639439Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-20T00:14:46.676606Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "canvora": {
@@ -2226,7 +2383,7 @@
       "source_url": "https://mcp.caulo.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T15:24:58.514124Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "caulo": {
@@ -2244,7 +2401,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.certscore/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T21:17:12.620633Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -2269,7 +2426,7 @@
       "source_url": "https://mcp.certscore.ai/mcp/light",
       "registry_status": "active",
       "published_at": "2026-07-16T04:46:23.003324Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-light": {
@@ -2287,7 +2444,7 @@
       "source_url": "https://app.chatthing.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-16T17:04:43.886064Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "chat-thing": {
@@ -2305,7 +2462,7 @@
       "source_url": "https://childadhd.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:13.381323Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -2323,7 +2480,7 @@
       "source_url": "https://childanxiety.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:17.518812Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -2341,7 +2498,7 @@
       "source_url": "https://childpsychiatry.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:20.484144Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -2359,7 +2516,7 @@
       "source_url": "https://api.chinamarketing.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-22T09:16:14.642505Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "intelligence": {
@@ -2377,7 +2534,7 @@
       "source_url": "https://api.chronary.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T21:12:59.153451Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -2398,7 +2555,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.circulara/plugin",
       "registry_status": "active",
       "published_at": "2026-07-09T11:54:08.843062Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "plugin": {
@@ -2426,7 +2583,7 @@
       "source_url": "https://mcp.cirra.ai/sfdc/mcp",
       "registry_status": "active",
       "published_at": "2026-06-17T21:41:17.956027Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "salesforce-mcp": {
@@ -2444,7 +2601,7 @@
       "source_url": "https://mcp.clarid.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-26T19:00:43.930817Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "compliance": {
@@ -2462,7 +2619,7 @@
       "source_url": "https://api.clarid.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-26T19:00:44.38512Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hmda": {
@@ -2480,7 +2637,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.clarx/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T14:52:08.25611Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -2505,7 +2662,7 @@
       "source_url": "https://mcp.clawterminal.ai",
       "registry_status": "active",
       "published_at": "2026-06-23T15:44:31.957977Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "markets": {
@@ -2526,7 +2683,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.clize/clize",
       "registry_status": "active",
       "published_at": "2026-07-17T06:17:17.687832Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "clize": {
@@ -2547,7 +2704,7 @@
       "source_url": "https://api.cobbles.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T18:03:43.51907Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cobbles": {
@@ -2565,7 +2722,7 @@
       "source_url": "https://mcp.cofoundagent.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-05T16:41:03.448222Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cofound": {
@@ -2583,7 +2740,7 @@
       "source_url": "https://contabo.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-08T13:19:46.430479Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "contabo": {
@@ -2605,7 +2762,7 @@
       "source_url": "https://{HAPI_FQDN}:{HAPI_PORT}/mcp",
       "registry_status": "active",
       "published_at": "2026-01-07T00:32:01.41626Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hapi-mcp": {
@@ -2623,7 +2780,7 @@
       "source_url": "https://lenny-rachitsky.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-16T11:08:36.481149Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lenny-rachitsky-podcast": {
@@ -2641,7 +2798,7 @@
       "source_url": "https://linkedin.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-19T15:17:12.346134Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "linkedin": {
@@ -2659,7 +2816,7 @@
       "source_url": "https://openai-tools.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-22T02:35:00.021804Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "openai-tools": {
@@ -2680,7 +2837,7 @@
       "source_url": "https://petstore.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-07T14:13:05.674855Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "petstore": {
@@ -2698,7 +2855,7 @@
       "source_url": "https://registry.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-10T22:33:54.03436Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "registry": {
@@ -2716,7 +2873,7 @@
       "source_url": "https://skills-sh.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-04T12:46:39.858109Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "skills-search": {
@@ -2734,7 +2891,7 @@
       "source_url": "https://strava.run.mcp.com.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-19T16:39:20.668626Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "strava": {
@@ -2752,7 +2909,7 @@
       "source_url": "https://compeller.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-05T03:21:40.918318Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "compel": {
@@ -2767,24 +2924,6 @@
       }
     },
     {
-      "name": "ai.complyhat/compliance",
-      "version": "1.5.0",
-      "transport": "streamable-http",
-      "auth_mode": "none",
-      "source_url": "https://complyhat.ai/api/mcp",
-      "registry_status": "active",
-      "published_at": "2026-05-31T17:28:15.351367Z",
-      "fetched_at": "2026-07-19",
-      "config": {
-        "mcpServers": {
-          "compliance": {
-            "type": "http",
-            "url": "https://complyhat.ai/api/mcp"
-          }
-        }
-      }
-    },
-    {
       "name": "ai.componecat/componecat",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -2792,7 +2931,7 @@
       "source_url": "https://app.componecat.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T20:31:01.239544Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "componecat": {
@@ -2810,7 +2949,7 @@
       "source_url": "https://mcp.constellationfinance.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-22T18:26:02.539221Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "constellation-finance-mcp": {
@@ -2828,7 +2967,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.contextstudios/mcp",
       "registry_status": "active",
       "published_at": "2026-04-02T14:12:47.594301Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -2849,7 +2988,7 @@
       "source_url": "https://app.conveo.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-06T11:05:24.104018Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "conveo": {
@@ -2867,7 +3006,7 @@
       "source_url": "https://s-api.cookiy.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-28T05:28:52.028499Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cookiy": {
@@ -2885,7 +3024,7 @@
       "source_url": "https://corduroy-labs.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T18:01:06.82434Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "updates": {
@@ -2903,7 +3042,7 @@
       "source_url": "https://nebula.cosmonote.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-05T08:30:35.974817Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "notes": {
@@ -2921,7 +3060,7 @@
       "source_url": "https://api.craneledger.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-25T16:03:19.605397Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "crane-ledger": {
@@ -2942,12 +3081,33 @@
       "source_url": "https://creationloop.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T00:13:17.622184Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "creationloop": {
             "type": "http",
             "url": "https://creationloop.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.creativescope/creative-intelligence",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.creativescope.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T09:51:05.050177Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "creative-intelligence": {
+            "type": "http",
+            "url": "https://mcp.creativescope.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -2960,7 +3120,7 @@
       "source_url": "https://data.crestsystems.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-22T16:29:28.288968Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "counterparty-intelligence": {
@@ -2978,7 +3138,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.cueapi/mcp",
       "registry_status": "active",
       "published_at": "2026-04-15T19:01:06.819529Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3003,7 +3163,7 @@
       "source_url": "https://api.cueframe.ai/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T20:46:10.818043Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cueframe": {
@@ -3021,7 +3181,7 @@
       "source_url": "https://mcp.customdomain.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T18:06:58.552306Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3039,7 +3199,7 @@
       "source_url": "https://app.d50.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T08:27:04.313042Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "d50-platform": {
@@ -3060,7 +3220,7 @@
       "source_url": "https://dataecho.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-04T19:46:27.691356Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3078,7 +3238,7 @@
       "source_url": "https://mcp.dataforb2b.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-14T20:00:08.289344Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dataforb2b": {
@@ -3096,7 +3256,7 @@
       "source_url": "https://mcp.datamerge.ai",
       "registry_status": "active",
       "published_at": "2026-02-27T11:50:11.005967Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3117,7 +3277,7 @@
       "source_url": "https://dealfilter.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T07:59:13.738871Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3135,7 +3295,7 @@
       "source_url": "https://www.decisionlog.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T04:19:14.368455Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3157,7 +3317,7 @@
       "source_url": "https://mcp.deepledger.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-30T08:25:20.319133Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3175,7 +3335,7 @@
       "source_url": "https://deinai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-05T10:16:43.633426Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "creator-skill": {
@@ -3196,7 +3356,7 @@
       "source_url": "https://skill.deinai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-30T11:27:51.123362Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "creator-skill-v2": {
@@ -3217,7 +3377,7 @@
       "source_url": "https://calculator.delega.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-25T16:42:25.074565Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aws-pricing-calculator": {
@@ -3235,7 +3395,7 @@
       "source_url": "https://mcp.demanddiscovery.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-19T10:54:31.540682Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3253,7 +3413,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.demomagic/interactive-video-guide",
       "registry_status": "active",
       "published_at": "2026-06-18T00:38:53.356402Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "interactive-video-guide": {
@@ -3274,7 +3434,7 @@
       "source_url": "https://mcp.diagramzu.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-16T02:21:03.832798Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3292,7 +3452,7 @@
       "source_url": "https://www.dimetrics.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T23:38:11.024345Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dimetrics": {
@@ -3310,7 +3470,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/apprise-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T11:58:27.866195Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "apprise-rmcp": {
@@ -3339,7 +3499,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/arcane-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T11:58:28.276344Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arcane-rmcp": {
@@ -3368,7 +3528,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/cortex-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T11:58:28.58298Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cortex-rmcp": {
@@ -3398,7 +3558,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/gotify-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T11:58:28.849931Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gotify-rmcp": {
@@ -3428,7 +3588,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/labby",
       "registry_status": "active",
       "published_at": "2026-07-13T04:02:29.258343Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "labby": {
@@ -3447,24 +3607,25 @@
       }
     },
     {
-      "name": "ai.dinglebear/soma-rmcp",
-      "version": "0.4.7",
+      "name": "ai.dinglebear/soma",
+      "version": "0.6.0",
       "transport": "stdio",
       "auth_mode": "local-stdio",
-      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/soma-rmcp",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/soma",
       "registry_status": "active",
-      "published_at": "2026-07-12T12:00:30.442345Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T01:47:05.818138Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
-          "soma-rmcp": {
-            "command": "npx",
+          "soma": {
+            "command": "docker",
             "args": [
-              "-y",
-              "soma-rmcp"
+              "run",
+              "-i",
+              "--rm",
+              "ghcr.io/dinglebear-ai/soma:0.6.0"
             ],
             "env": {
-              "SOMA_BIN": "${VALUE}",
               "SOMA_HOME": "${VALUE}",
               "SOMA_PROVIDER_DIR": "${VALUE}",
               "SOMA_API_URL": "${VALUE}",
@@ -3483,7 +3644,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/synapse-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:37.079017Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "synapse-rmcp": {
@@ -3513,7 +3674,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/tailscale-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:37.314618Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "tailscale-rmcp": {
@@ -3541,7 +3702,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/unifi-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:37.570413Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "unifi-rmcp": {
@@ -3570,7 +3731,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/unraid-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:37.970335Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "unraid-rmcp": {
@@ -3599,7 +3760,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/yarr-mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:38.673496Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "yarr-mcp": {
@@ -3632,7 +3793,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dinglebear/ytdl-rmcp",
       "registry_status": "active",
       "published_at": "2026-07-12T12:00:38.93391Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ytdl-rmcp": {
@@ -3661,7 +3822,7 @@
       "source_url": "https://tv.djwizard.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-04-27T13:19:31.955204Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "tvwizard": {
@@ -3679,7 +3840,7 @@
       "source_url": "https://mcp.djzs.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T01:26:59.067995Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "trust-mcp": {
@@ -3697,7 +3858,7 @@
       "source_url": "https://app.docuwriter.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T13:45:25.00311Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "docuwriter": {
@@ -3715,7 +3876,7 @@
       "source_url": "https://mcp.donethat.ai/",
       "registry_status": "active",
       "published_at": "2026-04-08T10:14:41.080859Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "donethat": {
@@ -3733,7 +3894,7 @@
       "source_url": "https://nexus.api.dragoneye.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-14T18:31:00.872003Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3751,7 +3912,7 @@
       "source_url": "https://mcp.dreamlit.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-07T04:59:39.740016Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3769,7 +3930,7 @@
       "source_url": "https://gateway.drillr.ai/mcp/data",
       "registry_status": "active",
       "published_at": "2026-06-04T12:38:06.605598Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "drillr": {
@@ -3790,7 +3951,7 @@
       "source_url": "https://mcp.dripmetrics.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T23:03:42.782423Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3808,7 +3969,7 @@
       "source_url": "https://www.dsght.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T20:46:36.890846Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "public": {
@@ -3826,7 +3987,7 @@
       "source_url": "https://app.duvera.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T19:25:28.904765Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gateway": {
@@ -3841,13 +4002,13 @@
     },
     {
       "name": "ai.dynamicfeed/dynamic-feed",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://dynamicfeed.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-16T01:36:05.755042Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T01:37:59.940833Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dynamic-feed": {
@@ -3865,7 +4026,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.dynsoft/sac",
       "registry_status": "active",
       "published_at": "2026-05-24T02:09:53.574937Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sac": {
@@ -3891,7 +4052,7 @@
       "source_url": "https://edusignal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-02T23:28:39.570503Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "districts": {
@@ -3909,7 +4070,7 @@
       "source_url": "https://mcp.eevy.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T04:31:42.484368Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -3927,7 +4088,7 @@
       "source_url": "https://mcp.enyal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-28T17:07:13.623823Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "enyal": {
@@ -3945,7 +4106,7 @@
       "source_url": "https://api.epanya.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-19T00:51:35.978362Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "epanya": {
@@ -3963,7 +4124,7 @@
       "source_url": "https://api.epinu.ai/api/agent/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T17:09:34.7899Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "epinu": {
@@ -3981,7 +4142,7 @@
       "source_url": "https://everway.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-16T11:24:45.21724Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "everway-mcp-server": {
@@ -3999,7 +4160,7 @@
       "source_url": "https://mcp.exa.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-12-05T21:51:53.421065Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "exa": {
@@ -4017,7 +4178,7 @@
       "source_url": "https://mcp.example4.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-23T22:09:33.915723Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "xmp4": {
@@ -4035,7 +4196,7 @@
       "source_url": "https://mcp-github-registry.explorium.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-11-03T13:21:46.054906Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-explorium": {
@@ -4053,7 +4214,7 @@
       "source_url": "https://app.ezel.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-22T19:58:09.836023Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ezel": {
@@ -4071,7 +4232,7 @@
       "source_url": "https://mcp.factori.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T11:09:02.436389Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4089,7 +4250,7 @@
       "source_url": "https://mcp.fantopy.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-18T10:23:58.349661Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fantopy": {
@@ -4107,12 +4268,30 @@
       "source_url": "https://api.fathom.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-17T01:36:06.979854Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
             "type": "http",
             "url": "https://api.fathom.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.featureboard/featureboard",
+      "version": "0.7.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.featureboard/featureboard",
+      "registry_status": "active",
+      "published_at": "2026-07-24T05:43:14.453244Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "featureboard": {
+            "command": "https://github.com/valentil/featureboard-mcp/releases/download/v0.7/featureboard.plugin",
+            "args": []
           }
         }
       }
@@ -4125,7 +4304,7 @@
       "source_url": "https://mcp.fiber.ai/mcp/v2/",
       "registry_status": "active",
       "published_at": "2026-03-05T17:07:19.663739Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4143,7 +4322,7 @@
       "source_url": "https://api.filegraph.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-24T04:06:08.693646Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "document-processing": {
@@ -4161,7 +4340,7 @@
       "source_url": "https://api.filepad.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-02T16:44:40.690055Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "filepad": {
@@ -4179,7 +4358,7 @@
       "source_url": "https://mcp.filtrix.ai/",
       "registry_status": "active",
       "published_at": "2026-03-15T17:09:25.330187Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "filtrix-ai": {
@@ -4200,7 +4379,7 @@
       "source_url": "https://fincontext.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-24T04:24:10.738444Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fincontext": {
@@ -4218,7 +4397,7 @@
       "source_url": "https://mcp.findip.ai",
       "registry_status": "active",
       "published_at": "2026-07-01T02:49:37.02037Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "patent-search": {
@@ -4236,7 +4415,7 @@
       "source_url": "https://finestructure.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T22:09:33.664242Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fine-structure": {
@@ -4251,13 +4430,13 @@
     },
     {
       "name": "ai.firmbrain/x402-services",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://x402-services-production.up.railway.app/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-14T21:30:50.464744Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T04:28:56.846304Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "x402-services": {
@@ -4275,7 +4454,7 @@
       "source_url": "https://flipdomain.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T04:19:25.43002Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "domain-sales": {
@@ -4293,7 +4472,7 @@
       "source_url": "https://api.flowcastle.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T13:54:22.253093Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "flowcastle": {
@@ -4314,7 +4493,7 @@
       "source_url": "https://api.flowstep.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T14:13:54.566048Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4325,19 +4504,19 @@
       }
     },
     {
-      "name": "ai.fluxink/mcp-server",
+      "name": "ai.fluxink/fci-mcp",
       "version": "1.0.0",
       "transport": "streamable-http",
       "auth_mode": "none",
-      "source_url": "https://mcp.fluxink.ai/servers/d0ca718e86d140788af422fedbe5622e/mcp",
+      "source_url": "https://mcp.fluxink.ai/servers/f6b6758dba6c4c92b83407a113fdb80b/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-17T00:14:17.917912Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-22T00:30:47.497862Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
-          "mcp-server": {
+          "fci-mcp": {
             "type": "http",
-            "url": "https://mcp.fluxink.ai/servers/d0ca718e86d140788af422fedbe5622e/mcp"
+            "url": "https://mcp.fluxink.ai/servers/f6b6758dba6c4c92b83407a113fdb80b/mcp"
           }
         }
       }
@@ -4350,7 +4529,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.fodda/mcp-server",
       "registry_status": "active",
       "published_at": "2026-07-03T14:25:57.93371Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -4375,7 +4554,7 @@
       "source_url": "https://mcp.forkmate.ai/",
       "registry_status": "active",
       "published_at": "2026-07-04T05:22:43.286763Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "forkmate": {
@@ -4393,7 +4572,7 @@
       "source_url": "https://mcp.foura.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T12:15:46.838999Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4411,7 +4590,7 @@
       "source_url": "https://spi.fugentic.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T12:56:01.42555Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "service-provider-index": {
@@ -4429,7 +4608,7 @@
       "source_url": "https://mcp.gavelin.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-26T05:42:50.607071Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4447,7 +4626,7 @@
       "source_url": "https://gemus.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-01T03:26:51.818837Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gemus": {
@@ -4465,7 +4644,7 @@
       "source_url": "https://app.geodesiclabs.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-03T18:34:34.343475Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "governance-platform": {
@@ -4483,7 +4662,7 @@
       "source_url": "https://gethal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-13T07:26:03.291266Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4501,7 +4680,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.getoptimal/optibot",
       "registry_status": "active",
       "published_at": "2026-06-04T15:48:15.016308Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "optibot": {
@@ -4525,7 +4704,7 @@
       "source_url": "https://getperspective.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-28T10:17:57.85874Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4543,7 +4722,7 @@
       "source_url": "https://getthroughline.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T07:14:40.267456Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "throughline": {
@@ -4561,7 +4740,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.getvet/vet",
       "registry_status": "active",
       "published_at": "2026-06-15T21:29:47.444351Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "vet": {
@@ -4586,7 +4765,7 @@
       "source_url": "https://gigaverse.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T06:38:37.735179Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gigaverse": {
@@ -4604,7 +4783,7 @@
       "source_url": "https://apps.gomarble.ai/mcp-api/sse",
       "registry_status": "active",
       "published_at": "2025-10-14T05:56:54.505554Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-api": {
@@ -4616,13 +4795,13 @@
     },
     {
       "name": "ai.gondola/gondola",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://mcp.gondola.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-07T23:43:56.342107Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-19T16:53:59.530765Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gondola": {
@@ -4640,7 +4819,7 @@
       "source_url": "https://mcp.good-sport.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T02:16:30.532709Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "good-sport": {
@@ -4658,7 +4837,7 @@
       "source_url": "https://mcp.gossiper.io/mcp",
       "registry_status": "active",
       "published_at": "2026-01-06T18:20:42.175634Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "shopify-admin-mcp": {
@@ -4679,12 +4858,30 @@
       "source_url": "https://api.groundroute.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T19:08:27.400818Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "web-search": {
             "type": "http",
             "url": "https://api.groundroute.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.gtfi/groundtruth",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://gtfi.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T10:26:09.443545Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "groundtruth": {
+            "type": "http",
+            "url": "https://gtfi.ai/mcp"
           }
         }
       }
@@ -4697,7 +4894,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.haymon/dbmcp",
       "registry_status": "active",
       "published_at": "2026-05-29T17:10:15.064945Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dbmcp": {
@@ -4720,7 +4917,7 @@
       "source_url": "https://mcp.helixar.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-27T13:04:20.59969Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4738,7 +4935,7 @@
       "source_url": "https://hermitsh.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-05T01:08:15.235339Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "texts": {
@@ -4756,7 +4953,7 @@
       "source_url": "https://mcp.hirey.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T14:11:11.39443Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hi": {
@@ -4774,7 +4971,7 @@
       "source_url": "https://mcp.hivewiki.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T04:04:40.771482Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hivewiki": {
@@ -4792,7 +4989,7 @@
       "source_url": "https://mcp.hostingbrain.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-04T13:38:10.359005Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "intelligence": {
@@ -4810,7 +5007,7 @@
       "source_url": "https://hostprofit-mcp-production.up.railway.app/mcp",
       "registry_status": "active",
       "published_at": "2026-05-06T22:37:41.270139Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4828,7 +5025,7 @@
       "source_url": "https://mcp.i18nagent.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-16T10:02:49.134686Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "i18n-agent": {
@@ -4846,7 +5043,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.imboard/dossier",
       "registry_status": "active",
       "published_at": "2026-03-07T09:20:43.263852Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dossier": {
@@ -4867,7 +5064,7 @@
       "source_url": "https://app.inflowpay.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-01T08:15:17.136175Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "inflow": {
@@ -4885,7 +5082,7 @@
       "source_url": "https://api.infolang.ai/v1/mcp/",
       "registry_status": "active",
       "published_at": "2026-07-13T22:58:34.21363Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -4903,7 +5100,7 @@
       "source_url": "https://mcp.insideralpha.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T00:03:24.271611Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "insider-alpha": {
@@ -4921,7 +5118,7 @@
       "source_url": "https://the-stall.intuitek.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-29T04:08:05.230042Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "the-stall": {
@@ -4939,7 +5136,7 @@
       "source_url": "https://mcp.prod.inventoryhero.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T19:55:41.213195Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "inventory-hero": {
@@ -4957,7 +5154,7 @@
       "source_url": "https://inxy.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T20:05:43.547521Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "seo-audit": {
@@ -4975,7 +5172,7 @@
       "source_url": "https://mcp.ironscout.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-08T21:51:00.310323Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ironscout": {
@@ -4993,7 +5190,7 @@
       "source_url": "https://iturri.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T02:31:38.876373Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "market-data": {
@@ -5007,6 +5204,24 @@
       }
     },
     {
+      "name": "ai.izap/whatsapp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.izap.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T00:26:53.80447Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "whatsapp": {
+            "type": "http",
+            "url": "https://api.izap.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.jeda/jeda-ai",
       "version": "1.23.40",
       "transport": "streamable-http",
@@ -5014,7 +5229,7 @@
       "source_url": "https://mcp.jeda.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-25T10:54:36.592102Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jeda-ai": {
@@ -5032,7 +5247,7 @@
       "source_url": "https://joinmultiplayer.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T21:42:20.612154Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gpu": {
@@ -5046,6 +5261,24 @@
       }
     },
     {
+      "name": "ai.jurisprudencias/case-law",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://jurisprudencias.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T02:52:42.844306Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "case-law": {
+            "type": "http",
+            "url": "https://jurisprudencias.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.justdeploy/mcp",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -5053,7 +5286,7 @@
       "source_url": "https://mcp.justdeploy.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-19T05:10:40.161842Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5071,12 +5304,37 @@
       "source_url": "https://mcp.justdomain.ai/",
       "registry_status": "active",
       "published_at": "2026-07-15T16:28:36.188603Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "just-domain": {
             "type": "http",
             "url": "https://mcp.justdomain.ai/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.justdrop/mcp",
+      "version": "0.1.6",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.justdrop/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T11:16:06.439604Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "justdrop-mcp"
+            ],
+            "env": {
+              "JUSTDROP_ROOT": "${VALUE}",
+              "JUSTDROP_DEFAULT_EXPIRY_MINUTES": "${VALUE}"
+            }
           }
         }
       }
@@ -5089,7 +5347,7 @@
       "source_url": "https://mcp.justpublish.ai/",
       "registry_status": "active",
       "published_at": "2026-07-01T14:20:10.824981Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "just-publish": {
@@ -5107,7 +5365,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.kavel/kavel-mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T08:07:56.211621Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kavel-mcp": {
@@ -5122,13 +5380,13 @@
     },
     {
       "name": "ai.kawacode/mcp",
-      "version": "6.9.1",
+      "version": "6.9.4",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.kawacode/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-18T09:25:52.895891Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-24T22:31:01.705774Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5149,7 +5407,7 @@
       "source_url": "https://api.keenable.ai/mcp?keenable_title=mcp-registry",
       "registry_status": "active",
       "published_at": "2026-06-26T14:00:39.740011Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "web-search": {
@@ -5170,7 +5428,7 @@
       "source_url": "https://kifly.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-06T15:07:11.800519Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5191,7 +5449,7 @@
       "source_url": "https://mcp.kive.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T15:08:53.460119Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5209,7 +5467,7 @@
       "source_url": "https://strata.klavis.ai/mcp/",
       "registry_status": "active",
       "published_at": "2025-09-28T19:13:44.307076Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "strata": {
@@ -5227,7 +5485,7 @@
       "source_url": "https://mcp.klodkot.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T20:23:36.490711Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gen": {
@@ -5245,7 +5503,7 @@
       "source_url": "https://kolens.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-23T14:53:01.933497Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kolens-mcp": {
@@ -5263,7 +5521,7 @@
       "source_url": "https://api.kontato.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T19:18:52.96317Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kontato": {
@@ -5281,7 +5539,7 @@
       "source_url": "https://mcp.korey.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-23T19:38:27.702563Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5299,7 +5557,7 @@
       "source_url": "https://www.krtr.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-27T20:57:35.993735Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "krtr": {
@@ -5317,7 +5575,7 @@
       "source_url": "https://mcp.kubit.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-12-09T00:18:46.752966Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -5335,12 +5593,30 @@
       "source_url": "https://mcp.kumbuka.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-08T15:41:59.571531Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kumbuka-server": {
             "type": "http",
             "url": "https://mcp.kumbuka.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.ladderflow/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ladderflow.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T09:52:35.38811Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.ladderflow.ai/mcp"
           }
         }
       }
@@ -5353,7 +5629,7 @@
       "source_url": "https://api.lattiq.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-26T21:58:49.321402Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "x402-trading-signals": {
@@ -5374,7 +5650,7 @@
       "source_url": "https://mcp.law.ai",
       "registry_status": "active",
       "published_at": "2026-05-29T16:12:44.195062Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lawyer-search": {
@@ -5392,12 +5668,30 @@
       "source_url": "https://app.lenshub.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T17:44:09.113497Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lenshub": {
             "type": "http",
             "url": "https://app.lenshub.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.libers/libers-suite",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.libers.ai/mcp/libers-suite",
+      "registry_status": "active",
+      "published_at": "2026-07-25T08:36:23.138683Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "libers-suite": {
+            "type": "http",
+            "url": "https://api.libers.ai/mcp/libers-suite"
           }
         }
       }
@@ -5410,12 +5704,30 @@
       "source_url": "https://mcp.licensy.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-28T00:25:40.697917Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
             "type": "http",
             "url": "https://mcp.licensy.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.lifeisagame/signal-not-noise",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://signal.lifeisagame.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T18:42:18.493854Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "signal-not-noise": {
+            "type": "http",
+            "url": "https://signal.lifeisagame.ai/mcp"
           }
         }
       }
@@ -5428,7 +5740,7 @@
       "source_url": "https://api.limitguard.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-24T13:42:25.987571Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "trust-intelligence": {
@@ -5449,7 +5761,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.linkguard/linkguard-mcp",
       "registry_status": "active",
       "published_at": "2026-05-21T19:57:16.953951Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "linkguard-mcp": {
@@ -5473,7 +5785,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.lithtrix/lithtrix-mcp",
       "registry_status": "active",
       "published_at": "2026-06-20T07:55:20.564771Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lithtrix-mcp": {
@@ -5490,6 +5802,42 @@
       }
     },
     {
+      "name": "ai.livingmeta/ai-in-research",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai-in-research.livingmeta.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T07:42:38.084523Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-in-research": {
+            "type": "http",
+            "url": "https://ai-in-research.livingmeta.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.llamanotes/llamanotes",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.llamanotes.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T21:22:19.849163Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "llamanotes": {
+            "type": "http",
+            "url": "https://mcp.llamanotes.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.llmhosting/pricing",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -5497,7 +5845,7 @@
       "source_url": "https://llmhosting.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T19:54:38.601862Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pricing": {
@@ -5515,7 +5863,7 @@
       "source_url": "https://llmse.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-21T16:19:36.12182Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5533,7 +5881,7 @@
       "source_url": "https://api.lucasandersen.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-15T21:25:53.503719Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mlp-tax": {
@@ -5551,7 +5899,7 @@
       "source_url": "https://mcp.ludo.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-30T17:59:40.034021Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "game-assets": {
@@ -5566,13 +5914,13 @@
     },
     {
       "name": "ai.lumify/sports-intelligence",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": "streamable-http",
       "auth_mode": "static-credential",
       "source_url": "https://lumify.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-12T16:58:33.973712Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-20T17:01:48.656618Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sports-intelligence": {
@@ -5586,6 +5934,30 @@
       }
     },
     {
+      "name": "ai.mafdet/mcp",
+      "version": "0.1.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.mafdet/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T03:30:25.90535Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@mafdet/mcp"
+            ],
+            "env": {
+              "MAFDET_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "ai.magicinsights/insights",
       "version": "0.1.1",
       "transport": "streamable-http",
@@ -5593,12 +5965,33 @@
       "source_url": "https://app.magicinsights.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-25T14:40:26.188033Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "insights": {
             "type": "http",
             "url": "https://app.magicinsights.ai/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.maguyva/maguyva",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://maguyva.tools/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T16:11:17.48051Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "maguyva": {
+            "type": "http",
+            "url": "https://maguyva.tools/mcp",
             "headers": {
               "Authorization": "${SECRET}"
             }
@@ -5614,7 +6007,7 @@
       "source_url": "https://mcp.mailjunky.ai/sse",
       "registry_status": "active",
       "published_at": "2026-01-24T00:30:06.33677Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5635,7 +6028,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.marchward/mcp-server",
       "registry_status": "active",
       "published_at": "2026-06-24T18:26:08.462318Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -5660,7 +6053,7 @@
       "source_url": "https://mcp.marcora.ai/",
       "registry_status": "active",
       "published_at": "2026-05-22T23:15:01.043285Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5678,7 +6071,7 @@
       "source_url": "https://api.marketintell.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-01T22:07:15.763336Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "marketintell": {
@@ -5699,12 +6092,30 @@
       "source_url": "https://api.markettrace.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-04T06:35:37.03302Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "agent-feed": {
             "type": "http",
             "url": "https://api.markettrace.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.masaro/masaro",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://masaro.ai/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T12:54:18.619448Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "masaro": {
+            "type": "http",
+            "url": "https://masaro.ai/api/mcp/mcp"
           }
         }
       }
@@ -5717,7 +6128,7 @@
       "source_url": "https://masnavi.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T19:48:44.714729Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "masnavi": {
@@ -5735,7 +6146,7 @@
       "source_url": "https://mcp.matih.ai/api/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-07-06T18:41:28.871763Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5753,12 +6164,33 @@
       "source_url": "https://maxcv.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-15T19:27:51.812985Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "resume": {
             "type": "http",
             "url": "https://maxcv.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.maximem/synap",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://synap-mcp.maximem.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T06:30:15.069666Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "synap": {
+            "type": "http",
+            "url": "https://synap-mcp.maximem.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -5771,7 +6203,7 @@
       "source_url": "https://api.mcpanalytics.ai/mcp/api-key",
       "registry_status": "active",
       "published_at": "2026-07-06T01:03:35.560921Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "analytics": {
@@ -5789,7 +6221,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.mcpcap/mcpcap",
       "registry_status": "active",
       "published_at": "2026-03-17T05:29:03.951926Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcpcap": {
@@ -5802,6 +6234,24 @@
       }
     },
     {
+      "name": "ai.mcpmyadmin/mcpmyadmin",
+      "version": "0.6.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcpmyadmin.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T23:02:49.470799Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcpmyadmin": {
+            "type": "http",
+            "url": "https://mcpmyadmin.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.meacheal/mrc-data",
       "version": "2.2.2",
       "transport": "streamable-http",
@@ -5809,7 +6259,7 @@
       "source_url": "https://api.meacheal.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-07T18:31:28.329956Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mrc-data": {
@@ -5830,7 +6280,7 @@
       "source_url": "https://meetlark.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-08T08:48:19.364402Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -5848,7 +6298,7 @@
       "source_url": "https://mcp.meetsquad.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-14T20:52:30.206678Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "squad": {
@@ -5866,7 +6316,7 @@
       "source_url": "https://mcp.memestack.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-09T14:25:58.46397Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5884,7 +6334,7 @@
       "source_url": "https://meminal.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-10-12T23:40:10.473855Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "meminal": {
@@ -5898,6 +6348,24 @@
       }
     },
     {
+      "name": "ai.memoket/memoket",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.memoket.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T12:26:24.498343Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "memoket": {
+            "type": "http",
+            "url": "https://mcp.memoket.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.mino/web-agent",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -5905,7 +6373,7 @@
       "source_url": "https://mino.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-28T02:20:51.640868Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "web-agent": {
@@ -5923,7 +6391,7 @@
       "source_url": "https://mitosislabs.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-18T17:37:42.491228Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mitosis": {
@@ -5935,13 +6403,13 @@
     },
     {
       "name": "ai.modelrunner/mcp",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://mcp.modelrunner.run/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-09T11:44:24.139905Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T19:05:13.941128Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5959,7 +6427,7 @@
       "source_url": "https://www.modulos.ai/api/mcp/",
       "registry_status": "active",
       "published_at": "2026-05-21T15:01:57.628905Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "demo-booking": {
@@ -5977,7 +6445,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.monnet/mcp",
       "registry_status": "active",
       "published_at": "2026-06-22T13:45:44.924804Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -5994,6 +6462,24 @@
       }
     },
     {
+      "name": "ai.moonlings/moonlings",
+      "version": "0.4.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://moonlings.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T15:32:09.787047Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "moonlings": {
+            "type": "http",
+            "url": "https://moonlings.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.moxt/mcp-workspace",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -6001,7 +6487,7 @@
       "source_url": "https://mcp.moxt.ai/openapi/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-05-13T11:19:51.786051Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-workspace": {
@@ -6022,7 +6508,7 @@
       "source_url": "https://mcp.mrmarket.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T03:05:08.422299Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mrmarket-mcp": {
@@ -6040,7 +6526,7 @@
       "source_url": "https://api.multi-turn.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T10:08:30.999963Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "enacta": {
@@ -6061,7 +6547,7 @@
       "source_url": "https://mcp.multinex.ai/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-06-08T22:15:55.055202Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "memq": {
@@ -6079,7 +6565,7 @@
       "source_url": "https://app.myriade.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-05-07T12:34:17.775318Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "myriade": {
@@ -6097,7 +6583,7 @@
       "source_url": "https://namewhisper.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-27T04:30:43.134538Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ens-tools": {
@@ -6115,7 +6601,7 @@
       "source_url": "https://nashboard.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-28T08:18:55.370069Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "nashboard-merchants": {
@@ -6127,13 +6613,13 @@
     },
     {
       "name": "ai.nauro/nauro",
-      "version": "1.6.0",
+      "version": "1.9.0",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.nauro/nauro",
       "registry_status": "active",
-      "published_at": "2026-07-19T04:48:35.961498Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T07:24:43.916431Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "nauro": {
@@ -6153,7 +6639,7 @@
       "source_url": "https://mcp.nefesh.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-03T19:42:18.337564Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "human-state": {
@@ -6174,7 +6660,7 @@
       "source_url": "https://api.newzai.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-04-08T02:47:09.644135Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "NewzAI": {
@@ -6192,7 +6678,7 @@
       "source_url": "https://api.newzai.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-08T15:21:34.735478Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "news-mcp": {
@@ -6210,7 +6696,7 @@
       "source_url": "https://nexez.app/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T15:12:55.11092Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "commerce": {
@@ -6228,7 +6714,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.nexustoken/nexustoken-sdk",
       "registry_status": "active",
       "published_at": "2026-04-24T15:11:58.794139Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "nexustoken-sdk": {
@@ -6252,7 +6738,7 @@
       "source_url": "https://ninar.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-21T21:02:38.796814Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ninar": {
@@ -6270,7 +6756,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.nocturnus/logic-server",
       "registry_status": "active",
       "published_at": "2026-04-16T01:50:31.889198Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "logic-server": {
@@ -6297,7 +6783,7 @@
       "source_url": "https://mcp.nordax.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-07T14:05:48.832804Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6315,7 +6801,7 @@
       "source_url": "https://mcp.normhyra.ai/",
       "registry_status": "active",
       "published_at": "2026-07-16T21:45:43.221676Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "normhyra": {
@@ -6333,7 +6819,7 @@
       "source_url": "https://nothumansearch.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-28T00:50:27.63351Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "search": {
@@ -6351,7 +6837,7 @@
       "source_url": "https://mcp.nudg3.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-31T10:27:44.28554Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "brand-intelligence": {
@@ -6369,7 +6855,7 @@
       "source_url": "https://mcp.nullary.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-25T00:44:06.690461Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "nullary": {
@@ -6387,7 +6873,7 @@
       "source_url": "https://api.obaron.ai/aeo/mcp",
       "registry_status": "active",
       "published_at": "2026-04-05T05:19:07.413315Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aeo": {
@@ -6405,7 +6891,7 @@
       "source_url": "https://mcp.obris.ai/",
       "registry_status": "active",
       "published_at": "2026-03-07T15:43:41.190623Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6423,7 +6909,7 @@
       "source_url": "https://api.odei.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T22:50:36.212634Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "connect": {
@@ -6441,7 +6927,7 @@
       "source_url": "https://mcp.offerhopper.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-27T17:55:13.825919Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "shopping-optimizer": {
@@ -6459,7 +6945,7 @@
       "source_url": "https://mcp.ohmyfin.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T11:47:06.337981Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "banking-intelligence": {
@@ -6471,13 +6957,13 @@
     },
     {
       "name": "ai.onelore/lore",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://mcp.onelore.ai",
       "registry_status": "active",
-      "published_at": "2026-07-09T19:45:19.5226Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T20:15:14.809432Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lore": {
@@ -6495,7 +6981,7 @@
       "source_url": "https://onzero.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T08:12:39.26379Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "creative-studio": {
@@ -6516,7 +7002,7 @@
       "source_url": "https://mcp.sap.oobeprotocol.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T17:26:19.245835Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sap-mcp": {
@@ -6534,7 +7020,7 @@
       "source_url": "https://mcp.openarx.ai/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-05-12T19:52:34.330776Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "openarx": {
@@ -6552,7 +7038,7 @@
       "source_url": "https://mcp.openhelm.ai/research/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:13:55.563974Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "deep-research": {
@@ -6570,7 +7056,7 @@
       "source_url": "https://mcp.openhelm.ai/dev/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:14:04.17636Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dev-changes": {
@@ -6588,7 +7074,7 @@
       "source_url": "https://mcp.openhelm.ai/email/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:14:02.525829Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "email-outreach": {
@@ -6606,7 +7092,7 @@
       "source_url": "https://mcp.openhelm.ai/watch/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:14:40.531118Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "monitoring": {
@@ -6624,7 +7110,7 @@
       "source_url": "https://mcp.openhelm.ai/main/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:13:06.772591Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "openhelm": {
@@ -6642,7 +7128,7 @@
       "source_url": "https://mcp.openhelm.ai/seo/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:14:00.42049Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "seo-growth": {
@@ -6660,7 +7146,7 @@
       "source_url": "https://mcp.openmandate.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-15T05:19:50.135009Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6674,6 +7160,24 @@
       }
     },
     {
+      "name": "ai.opinly/opinly",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.opinly.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T23:03:04.515829Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "opinly": {
+            "type": "http",
+            "url": "https://mcp.opinly.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.optimly/scout",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -6681,7 +7185,7 @@
       "source_url": "https://scout.optimly.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-18T05:46:04.612377Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "scout": {
@@ -6699,7 +7203,7 @@
       "source_url": "https://www.orggen.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-17T19:54:05.296818Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "orggen": {
@@ -6721,7 +7225,7 @@
       "source_url": "https://relay.orgsdk.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T04:12:32.070107Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6739,7 +7243,7 @@
       "source_url": "https://mcp.outlit.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-25T06:51:17.539297Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "outlit": {
@@ -6757,7 +7261,7 @@
       "source_url": "https://api.outset.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-07-02T20:29:22.357679Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6775,7 +7279,7 @@
       "source_url": "https://app.packmind.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-11-24T15:23:52.365339Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -6796,7 +7300,7 @@
       "source_url": "https://painspotter.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-02T06:30:40.797521Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "painspotter": {
@@ -6817,7 +7321,7 @@
       "source_url": "https://palmyr.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T00:26:09.037913Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "palmyr": {
@@ -6835,7 +7339,7 @@
       "source_url": "https://mcp.paperlantern.ai/chat/mcp",
       "registry_status": "active",
       "published_at": "2026-04-21T06:03:58.313689Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "code": {
@@ -6853,7 +7357,7 @@
       "source_url": "https://search-mcp.parallel.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-09T11:15:39.72942Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "search-mcp": {
@@ -6871,7 +7375,7 @@
       "source_url": "https://task-mcp.parallel.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-01-09T11:11:31.316037Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "task-mcp": {
@@ -6889,7 +7393,7 @@
       "source_url": "https://parceled.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-04-18T20:36:08.233242Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -6907,7 +7411,7 @@
       "source_url": "https://mcp.pathbound.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T12:26:52.894173Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pathbound": {
@@ -6925,7 +7429,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.perplexity/mcp-server",
       "registry_status": "active",
       "published_at": "2026-03-23T19:39:48.003259Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -6939,6 +7443,24 @@
       }
     },
     {
+      "name": "ai.petraport/agent-commerce",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://petraport.ai/api/agent-commerce/v1/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T07:21:40.379291Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-commerce": {
+            "type": "http",
+            "url": "https://petraport.ai/api/agent-commerce/v1/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.physea/liminality",
       "version": "1.0.4",
       "transport": "streamable-http",
@@ -6946,7 +7468,7 @@
       "source_url": "https://liminality.physea.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-06T01:02:37.781217Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "liminality": {
@@ -6967,7 +7489,7 @@
       "source_url": "https://api.pictomancer.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-03T12:08:41.783276Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "image-processing": {
@@ -6985,7 +7507,7 @@
       "source_url": "https://api.pimea.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-05-25T16:51:59.545831Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pimea": {
@@ -7003,7 +7525,7 @@
       "source_url": "https://plith.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-04-15T16:42:54.217435Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "plith": {
@@ -7015,13 +7537,13 @@
     },
     {
       "name": "ai.plori/plori",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://api.plori.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-16T04:33:33.514588Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T03:35:09.65248Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "plori": {
@@ -7039,7 +7561,7 @@
       "source_url": "https://pocketdrives.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T18:48:53.202822Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pocket-drives": {
@@ -7057,7 +7579,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.ponlo/server",
       "registry_status": "active",
       "published_at": "2026-03-04T21:01:15.992017Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "server": {
@@ -7082,7 +7604,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.positif/positif",
       "registry_status": "active",
       "published_at": "2026-07-14T23:19:23.238169Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "positif": {
@@ -7095,6 +7617,24 @@
       }
     },
     {
+      "name": "ai.posteverywhere/mcp",
+      "version": "1.5.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.posteverywhere.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T15:34:18.83809Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.posteverywhere.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.preclick/preclick-mcp",
       "version": "0.3.6",
       "transport": "streamable-http",
@@ -7102,7 +7642,7 @@
       "source_url": "https://preclick.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-03T15:48:04.727414Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "preclick-mcp": {
@@ -7123,12 +7663,33 @@
       "source_url": "https://api.presentations.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-18T06:26:51.040273Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "presentations-ai": {
             "type": "http",
             "url": "https://api.presentations.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.primateintelligence/mcp",
+      "version": "0.1.3",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.primateintelligence.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T01:10:51.498131Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.primateintelligence.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -7141,7 +7702,7 @@
       "source_url": "https://primeta.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-24T18:39:30.210978Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "primeta": {
@@ -7159,7 +7720,7 @@
       "source_url": "https://api.productnow-prod.com/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T00:58:26.927528Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "productnow": {
@@ -7177,7 +7738,7 @@
       "source_url": "https://mcp.promptarch.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T15:31:01.640653Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7198,7 +7759,7 @@
       "source_url": "https://promptsharp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T20:53:29.565075Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "promptsharp": {
@@ -7216,7 +7777,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.proofslip/mcp-server",
       "registry_status": "active",
       "published_at": "2026-04-05T07:54:11.612339Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -7241,7 +7802,7 @@
       "source_url": "https://gateway.proxygate.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-25T19:26:01.43236Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7259,7 +7820,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.proxyllm/proxyllm-mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T04:43:32.640064Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "proxyllm-mcp": {
@@ -7278,13 +7839,13 @@
     },
     {
       "name": "ai.pubfi/mcp",
-      "version": "0.1.63",
+      "version": "0.1.73",
       "transport": "streamable-http",
       "auth_mode": "static-credential",
       "source_url": "https://mcp.pubfi.ai",
       "registry_status": "active",
-      "published_at": "2026-07-17T04:03:57.959412Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-25T14:29:18.18126Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7305,7 +7866,7 @@
       "source_url": "https://publishwith.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-31T10:23:55.67889Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7323,7 +7884,7 @@
       "source_url": "https://api.pullpush.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T17:06:44.624271Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pullpush-mcp": {
@@ -7341,7 +7902,7 @@
       "source_url": "https://pyrimid.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-12T13:41:36.323745Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pyrimid": {
@@ -7359,7 +7920,7 @@
       "source_url": "https://qr-manager.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-17T05:06:20.934627Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "qr-manager": {
@@ -7380,12 +7941,33 @@
       "source_url": "https://mcp.quantifyme.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-20T04:41:08.163998Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "quantifyme": {
             "type": "http",
             "url": "https://mcp.quantifyme.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.quotefirst/quotefirst",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://quotefirst.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T22:22:23.55229Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "quotefirst": {
+            "type": "http",
+            "url": "https://quotefirst.ai/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
           }
         }
       }
@@ -7398,7 +7980,7 @@
       "source_url": "https://www.radiusos.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-04-22T19:14:38.551374Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "crm": {
@@ -7416,7 +7998,7 @@
       "source_url": "https://mcp.radixia.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-11T19:48:43.749766Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "blog": {
@@ -7434,7 +8016,7 @@
       "source_url": "https://radmail.ai/api/mcp/sandbox",
       "registry_status": "active",
       "published_at": "2026-07-02T09:34:44.346573Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "radmail-mcp": {
@@ -7452,7 +8034,7 @@
       "source_url": "https://mcp.raisonn.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-04-01T21:37:52.119242Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "connect": {
@@ -7470,7 +8052,7 @@
       "source_url": "https://mcp.rallyprop.ai?key={api_key}",
       "registry_status": "active",
       "published_at": "2026-05-28T16:27:01.946218Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gov-funding": {
@@ -7488,7 +8070,7 @@
       "source_url": "https://worker.rams.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-18T19:39:51.561841Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "rams": {
@@ -7509,7 +8091,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.rapay/mcp-server",
       "registry_status": "active",
       "published_at": "2026-02-09T18:54:17.964435Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -7524,21 +8106,18 @@
     },
     {
       "name": "ai.ravenmcp/raven-mcp",
-      "version": "1.3.3",
-      "transport": "stdio",
-      "auth_mode": "local-stdio",
-      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.ravenmcp/raven-mcp",
+      "version": "2.2.8",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ravenmcp.ai/api/mcp",
       "registry_status": "active",
-      "published_at": "2026-05-04T17:26:51.026933Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T06:39:38.154662Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "raven-mcp": {
-            "command": "npx",
-            "args": [
-              "-y",
-              "raven-mcp"
-            ]
+            "type": "http",
+            "url": "https://mcp.ravenmcp.ai/api/mcp"
           }
         }
       }
@@ -7551,7 +8130,7 @@
       "source_url": "https://rnfonkwthefktfvfwypr.supabase.co/functions/v1/mcp-server",
       "registry_status": "active",
       "published_at": "2026-04-28T16:43:57.168584Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "geo": {
@@ -7572,7 +8151,7 @@
       "source_url": "https://redditgrow.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-27T21:03:46.086012Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7593,7 +8172,7 @@
       "source_url": "https://mcp.reka.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-14T04:55:01.210652Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7614,7 +8193,7 @@
       "source_url": "https://api.relaystation.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T12:22:03.874584Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "relaystation": {
@@ -7632,7 +8211,7 @@
       "source_url": "https://mcp.responsibleailabs.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T10:54:59.982536Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "rail-score": {
@@ -7650,7 +8229,7 @@
       "source_url": "https://mcp.retrodiffusion.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-10T16:06:45.185326Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pixel-art": {
@@ -7671,7 +8250,7 @@
       "source_url": "https://www.revuo.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T15:32:20.613792Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "revuo": {
@@ -7689,7 +8268,7 @@
       "source_url": "https://mcp.rfix.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-04T00:25:08.559287Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7707,7 +8286,7 @@
       "source_url": "https://rfp.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T09:23:51.525839Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "rfp-ai": {
@@ -7728,7 +8307,7 @@
       "source_url": "https://figlime.rise2.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T18:58:43.437561Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "figlime": {
@@ -7746,7 +8325,7 @@
       "source_url": "https://api.riskstate.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T09:47:03.896406Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7764,7 +8343,7 @@
       "source_url": "https://mcp.robomart.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-03T09:52:56.686482Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "robomart": {
@@ -7782,12 +8361,30 @@
       "source_url": "https://mcp.roc.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-15T05:04:55.016683Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
             "type": "http",
             "url": "https://mcp.roc.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.rocketsloth/rocketsloth",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://rocketsloth.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T20:39:47.908875Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rocketsloth": {
+            "type": "http",
+            "url": "https://rocketsloth.ai/mcp"
           }
         }
       }
@@ -7800,7 +8397,7 @@
       "source_url": "https://mcp.rockmoon.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T05:10:09.036143Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "financial-data": {
@@ -7821,7 +8418,7 @@
       "source_url": "https://mcp.roic.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-18T11:27:28.992456Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "roic": {
@@ -7839,7 +8436,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.rolli/mcp",
       "registry_status": "active",
       "published_at": "2026-05-15T20:43:55.86045Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -7864,7 +8461,7 @@
       "source_url": "https://mcp.roopslaw.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-25T07:11:07.724108Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "legalsearch": {
@@ -7885,7 +8482,7 @@
       "source_url": "https://rootdata.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-27T16:19:01.935842Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "public-directory": {
@@ -7903,7 +8500,7 @@
       "source_url": "https://www.roryplans.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T15:33:42.520125Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "roryplans": {
@@ -7915,13 +8512,13 @@
     },
     {
       "name": "ai.rosterresolve/roster",
-      "version": "1.1.1",
+      "version": "1.2.2",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://{roster_host}/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-17T18:43:13.698283Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T20:38:23.283911Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "roster": {
@@ -7939,7 +8536,7 @@
       "source_url": "https://mcp.router.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T10:17:38.65273Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ai-gateway": {
@@ -7960,7 +8557,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.roxels/roxels-mcp",
       "registry_status": "active",
       "published_at": "2026-04-08T22:42:57.358698Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "roxels-mcp": {
@@ -7984,7 +8581,7 @@
       "source_url": "https://mcp.rxmanager.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T03:04:45.957939Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8002,7 +8599,7 @@
       "source_url": "https://api.saltybytes.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T20:20:23.866477Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "recipes": {
@@ -8020,7 +8617,7 @@
       "source_url": "https://satoshidata.ai/mcp/v1/",
       "registry_status": "active",
       "published_at": "2026-06-27T22:29:47.985759Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "wallet-intelligence": {
@@ -8041,7 +8638,7 @@
       "source_url": "https://scamverify.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-03-15T16:59:11.611467Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8059,7 +8656,7 @@
       "source_url": "https://api.scite.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-27T19:54:43.430271Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8077,12 +8674,30 @@
       "source_url": "https://mcp.seaotter.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T15:09:38.228456Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "otterscore": {
             "type": "http",
             "url": "https://mcp.seaotter.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.searchconsole/searchconsole-ai",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://searchconsole.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T21:29:25.923785Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "searchconsole-ai": {
+            "type": "http",
+            "url": "https://searchconsole.ai/mcp"
           }
         }
       }
@@ -8095,7 +8710,7 @@
       "source_url": "https://searchshopai-mcp.fly.dev/mcp/apostleman",
       "registry_status": "active",
       "published_at": "2026-07-16T10:19:39.632363Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "apostleman": {
@@ -8113,7 +8728,7 @@
       "source_url": "https://api.secapi.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T08:44:53.0965Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "secapi": {
@@ -8134,7 +8749,7 @@
       "source_url": "https://mcp.seltz.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-12-05T09:24:21.447908Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "seltz-ai-seltz-mcp": {
@@ -8155,7 +8770,7 @@
       "source_url": "https://sendfast.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-21T14:43:52.651223Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sendfast": {
@@ -8176,7 +8791,7 @@
       "source_url": "https://sendinel.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T04:53:14.945762Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -8197,7 +8812,7 @@
       "source_url": "https://sentedge.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-12T18:33:36.065781Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "idea-machine": {
@@ -8215,7 +8830,7 @@
       "source_url": "https://app.sentisense.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T01:17:40.334724Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "market-intelligence": {
@@ -8233,7 +8848,7 @@
       "source_url": "https://mcp.seocrawl.ai",
       "registry_status": "active",
       "published_at": "2026-06-07T21:47:17.425106Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8251,7 +8866,7 @@
       "source_url": "https://api.serff.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-11T19:55:25.23982Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ca-rate-filings": {
@@ -8269,7 +8884,7 @@
       "source_url": "https://api.sessionkeeper.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-06T18:58:40.2293Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8287,7 +8902,7 @@
       "source_url": "https://mcp-public.sharebench.ai",
       "registry_status": "active",
       "published_at": "2026-06-24T05:51:45.975188Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "registry": {
@@ -8305,7 +8920,7 @@
       "source_url": "https://mcp.shawndurrani.ai/sse",
       "registry_status": "active",
       "published_at": "2025-09-16T22:54:28.454307Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-merchant": {
@@ -8323,7 +8938,7 @@
       "source_url": "https://mcp-registry.shawndurrani.ai/sse",
       "registry_status": "active",
       "published_at": "2025-09-16T23:02:09.738662Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-registry": {
@@ -8335,13 +8950,13 @@
     },
     {
       "name": "ai.shipeasy/mcp",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "transport": "stdio",
       "auth_mode": "local-stdio",
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.shipeasy/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-11T20:17:37.92029Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-26T00:53:54.610103Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8355,6 +8970,31 @@
       }
     },
     {
+      "name": "ai.shippp/mcp",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.shippp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T15:24:14.31324Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@shippp/mcp"
+            ],
+            "env": {
+              "SHIPPP_API_KEY": "${VALUE}",
+              "SHIPPP_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "ai.sig.foodlog/food-logger",
       "version": "1.1.0",
       "transport": "streamable-http",
@@ -8362,7 +9002,7 @@
       "source_url": "https://foodlog.sig.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T07:20:41.152771Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "food-logger": {
@@ -8383,7 +9023,7 @@
       "source_url": "https://mcp.signal8.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-17T08:01:47.807249Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8398,13 +9038,13 @@
     },
     {
       "name": "ai.simsense/mcp",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://my.simsense.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-03-27T18:25:54.796415Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-24T13:42:27.511554Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8422,7 +9062,7 @@
       "source_url": "https://my.simstim.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-03-24T19:17:16.584443Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8440,7 +9080,7 @@
       "source_url": "https://mcp.sitepulsar.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-10T18:43:58.777532Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8458,7 +9098,7 @@
       "source_url": "https://connect.sixta.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-22T12:16:14.591547Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sixta-connect": {
@@ -8476,7 +9116,7 @@
       "source_url": "https://mcp.sleepwalker.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-28T08:30:02.680683Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sleepwalker": {
@@ -8494,7 +9134,7 @@
       "source_url": "https://mcp.slideless.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-30T10:17:01.200612Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -8512,7 +9152,7 @@
       "source_url": "https://server.smithery.ai/@222wcnm/bilistalkermcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T06:57:33.936879Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "222wcnm-bilistalkermcp": {
@@ -8533,7 +9173,7 @@
       "source_url": "https://server.smithery.ai/@Aman-Amith-Shastry/scientific_computation_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T01:14:07.07827Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Aman-Amith-Shastry-scientific_computation_mcp": {
@@ -8554,7 +9194,7 @@
       "source_url": "https://server.smithery.ai/@Artin0123/gemini-image-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T06:18:22.754577Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Artin0123-gemini-image-mcp-server": {
@@ -8575,7 +9215,7 @@
       "source_url": "https://server.smithery.ai/@BadRooBot/my_test_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T14:25:46.094496Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BadRooBot-my_test_mcp": {
@@ -8596,7 +9236,7 @@
       "source_url": "https://server.smithery.ai/@BadRooBot/test_m/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T14:41:53.772797Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BadRooBot-test_m": {
@@ -8617,7 +9257,7 @@
       "source_url": "https://server.smithery.ai/@BigVik193/reddit-ads-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T22:00:51.726311Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BigVik193-reddit-ads-mcp": {
@@ -8638,7 +9278,7 @@
       "source_url": "https://server.smithery.ai/@BigVik193/reddit-ads-mcp-api/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T22:40:30.852738Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BigVik193-reddit-ads-mcp-api": {
@@ -8659,7 +9299,7 @@
       "source_url": "https://server.smithery.ai/@BigVik193/reddit-ads-mcp-test/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T21:38:57.984339Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BigVik193-reddit-ads-mcp-test": {
@@ -8680,7 +9320,7 @@
       "source_url": "https://server.smithery.ai/@BigVik193/reddit-user-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T21:19:18.64908Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BigVik193-reddit-user-mcp": {
@@ -8701,7 +9341,7 @@
       "source_url": "https://server.smithery.ai/@BowenXU0126/aistudio_hw3/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T00:54:01.690641Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "BowenXU0126-aistudio_hw3": {
@@ -8722,7 +9362,7 @@
       "source_url": "https://server.smithery.ai/@ChiR24/unreal_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T05:30:22.169534Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ChiR24-unreal_mcp": {
@@ -8743,7 +9383,7 @@
       "source_url": "https://server.smithery.ai/@ChiR24/unreal_mcp_server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T07:12:00.299485Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ChiR24-unreal_mcp_server": {
@@ -8764,7 +9404,7 @@
       "source_url": "https://server.smithery.ai/@CollectiveSpend/collectivespend-smithery-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T17:03:02.996325Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "CollectiveSpend-collectivespend-smithery-mcp": {
@@ -8785,7 +9425,7 @@
       "source_url": "https://server.smithery.ai/@CryptoCultCurt/appfolio-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T00:42:54.555978Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "CryptoCultCurt-appfolio-mcp-server": {
@@ -8806,7 +9446,7 @@
       "source_url": "https://server.smithery.ai/@Danushkumar-V/mcp-discord/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T22:54:39.805525Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Danushkumar-V-mcp-discord": {
@@ -8827,7 +9467,7 @@
       "source_url": "https://server.smithery.ai/@DynamicEndpoints/autogen_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T13:57:38.18553Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "DynamicEndpoints-autogen_mcp": {
@@ -8848,7 +9488,7 @@
       "source_url": "https://server.smithery.ai/@DynamicEndpoints/m365-core-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T13:58:16.278261Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "DynamicEndpoints-m365-core-mcp": {
@@ -8869,7 +9509,7 @@
       "source_url": "https://server.smithery.ai/@DynamicEndpoints/powershell-exec-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T13:54:30.703395Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "DynamicEndpoints-powershell-exec-mcp-server": {
@@ -8890,7 +9530,7 @@
       "source_url": "https://server.smithery.ai/@FelixYifeiWang/felix-mcp-smithery/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T07:15:10.498525Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "FelixYifeiWang-felix-mcp-smithery": {
@@ -8911,7 +9551,7 @@
       "source_url": "https://server.smithery.ai/@Funding-Machine/ghl-mcp-fundingmachine/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T21:20:15.688859Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Funding-Machine-ghl-mcp-fundingmachine": {
@@ -8932,7 +9572,7 @@
       "source_url": "https://server.smithery.ai/@HARJAP-SINGH-3105/splitwise_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T18:42:59.470988Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "HARJAP-SINGH-3105-splitwise_mcp": {
@@ -8953,7 +9593,7 @@
       "source_url": "https://server.smithery.ai/@Hint-Services/obsidian-github-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T15:20:36.371442Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Hint-Services-obsidian-github-mcp": {
@@ -8974,7 +9614,7 @@
       "source_url": "https://server.smithery.ai/@IlyaGusev/academia_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T18:00:50.572805Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "IlyaGusev-academia_mcp": {
@@ -8995,7 +9635,7 @@
       "source_url": "https://server.smithery.ai/@ImRonAI/mcp-server-browserbase/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T06:05:33.453619Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ImRonAI-mcp-server-browserbase": {
@@ -9016,7 +9656,7 @@
       "source_url": "https://server.smithery.ai/@IndianAppGuy/magicslide-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T05:29:39.856257Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "IndianAppGuy-magicslide-mcp": {
@@ -9037,7 +9677,7 @@
       "source_url": "https://server.smithery.ai/@IndianAppGuy/magicslide-mcp-actual-test/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T12:06:34.023568Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "IndianAppGuy-magicslide-mcp-actual-test": {
@@ -9058,7 +9698,7 @@
       "source_url": "https://server.smithery.ai/@JMoak/chrono-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T02:23:35.312972Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "JMoak-chrono-mcp": {
@@ -9079,7 +9719,7 @@
       "source_url": "https://server.smithery.ai/@JunoJunHyun/festival-finder-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T09:40:14.759675Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "JunoJunHyun-festival-finder-mcp": {
@@ -9100,7 +9740,7 @@
       "source_url": "https://server.smithery.ai/@Kim-soung-won/mcp-smithery-exam/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T06:32:38.498462Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Kim-soung-won-mcp-smithery-exam": {
@@ -9121,7 +9761,7 @@
       "source_url": "https://server.smithery.ai/@Kryptoskatt/mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T10:41:17.402979Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Kryptoskatt-mcp-server": {
@@ -9142,7 +9782,7 @@
       "source_url": "https://server.smithery.ai/@Leghis/smart-thinking/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T14:04:13.933299Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Leghis-smart-thinking": {
@@ -9163,7 +9803,7 @@
       "source_url": "https://server.smithery.ai/@LinkupPlatform/linkup-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-27T11:25:12.402429Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "LinkupPlatform-linkup-mcp-server": {
@@ -9184,7 +9824,7 @@
       "source_url": "https://server.smithery.ai/@MetehanGZL/pokemcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-15T17:56:16.25232Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "MetehanGZL-pokemcp": {
@@ -9205,7 +9845,7 @@
       "source_url": "https://server.smithery.ai/@MisterSandFR/supabase-mcp-selfhosted/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T14:42:06.197815Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "MisterSandFR-supabase-mcp-selfhosted": {
@@ -9226,7 +9866,7 @@
       "source_url": "https://server.smithery.ai/@Nekzus/npm-sentinel-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T23:26:41.744482Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Nekzus-npm-sentinel-mcp": {
@@ -9247,7 +9887,7 @@
       "source_url": "https://server.smithery.ai/@Open-Scout/mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T15:08:39.247411Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Open-Scout-mcp": {
@@ -9268,7 +9908,7 @@
       "source_url": "https://server.smithery.ai/@PabloLec/keyprobe-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T18:08:11.479456Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "PabloLec-keyprobe-mcp": {
@@ -9289,7 +9929,7 @@
       "source_url": "https://server.smithery.ai/@Parc-Dev/task-breakdown-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T18:37:20.988548Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Parc-Dev-task-breakdown-server": {
@@ -9310,7 +9950,7 @@
       "source_url": "https://server.smithery.ai/@Phionx/mcp-hello-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T06:11:06.81562Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Phionx-mcp-hello-server": {
@@ -9331,7 +9971,7 @@
       "source_url": "https://server.smithery.ai/@PixdataOrg/coderide/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T14:23:37.184036Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "PixdataOrg-coderide": {
@@ -9352,7 +9992,7 @@
       "source_url": "https://server.smithery.ai/@Pratiksha-Kanoja/magicslide-mcp-test/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T10:10:48.100762Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "Pratiksha-Kanoja-magicslide-mcp-test": {
@@ -9373,7 +10013,7 @@
       "source_url": "https://server.smithery.ai/@ProfessionalWiki/mediawiki-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T12:49:06.317403Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ProfessionalWiki-mediawiki-mcp-server": {
@@ -9394,7 +10034,7 @@
       "source_url": "https://server.smithery.ai/@RectiFlex/centerassist-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T15:38:17.960766Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "RectiFlex-centerassist-mcp": {
@@ -9415,7 +10055,7 @@
       "source_url": "https://server.smithery.ai/@RectiFlex/centerassist-mcp-cp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T03:31:56.911791Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "RectiFlex-centerassist-mcp-cp": {
@@ -9436,7 +10076,7 @@
       "source_url": "https://server.smithery.ai/@RectiFlex/centerassist-mcp-cp1/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T03:54:36.038569Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "RectiFlex-centerassist-mcp-cp1": {
@@ -9457,7 +10097,7 @@
       "source_url": "https://server.smithery.ai/@RectiFlex/centerassist-mcp1/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T05:13:44.681143Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "RectiFlex-centerassist-mcp1": {
@@ -9478,7 +10118,7 @@
       "source_url": "https://server.smithery.ai/@STUzhy/py_execute_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T04:55:34.956438Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "STUzhy-py_execute_mcp": {
@@ -9499,7 +10139,7 @@
       "source_url": "https://server.smithery.ai/@ScrapeGraphAI/scrapegraph-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-25T21:42:44.755249Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ScrapeGraphAI-scrapegraph-mcp": {
@@ -9520,7 +10160,7 @@
       "source_url": "https://server.smithery.ai/@TakoData/tako-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T20:40:52.702786Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "TakoData-tako-mcp": {
@@ -9541,7 +10181,7 @@
       "source_url": "https://server.smithery.ai/@a-ariff/canvas-instant-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T00:50:43.815585Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "a-ariff-canvas-instant-mcp": {
@@ -9562,7 +10202,7 @@
       "source_url": "https://server.smithery.ai/@aamangeldi/dad-jokes-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T00:21:20.72031Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aamangeldi-dad-jokes-mcp": {
@@ -9583,7 +10223,7 @@
       "source_url": "https://server.smithery.ai/@adamamer20/paper-search-mcp-openai/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T10:21:35.776286Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "adamamer20-paper-search-mcp-openai": {
@@ -9604,7 +10244,7 @@
       "source_url": "https://server.smithery.ai/@afgong/sqlite-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T21:47:24.293477Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "afgong-sqlite-mcp-server": {
@@ -9625,7 +10265,7 @@
       "source_url": "https://server.smithery.ai/@aicastle-school/openai-api-agent-project/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T11:12:18.988861Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aicastle-school-openai-api-agent-project": {
@@ -9646,7 +10286,7 @@
       "source_url": "https://server.smithery.ai/@aicastle-school/openai-api-agent-project11/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T11:12:19.115931Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aicastle-school-openai-api-agent-project11": {
@@ -9667,7 +10307,7 @@
       "source_url": "https://server.smithery.ai/@airmang/hwpx-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T07:51:38.712981Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "airmang-hwpx-mcp": {
@@ -9688,7 +10328,7 @@
       "source_url": "https://server.smithery.ai/@akilat-spec/leave-manager-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T10:13:37.506388Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "akilat-spec-leave-manager-mcp": {
@@ -9709,7 +10349,7 @@
       "source_url": "https://server.smithery.ai/@alex-llm/attack-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T17:11:31.060313Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "alex-llm-attack-mcp-server": {
@@ -9730,7 +10370,7 @@
       "source_url": "https://server.smithery.ai/@alphago2580/naramarketmcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T02:36:55.167644Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "alphago2580-naramarketmcp": {
@@ -9751,7 +10391,7 @@
       "source_url": "https://server.smithery.ai/@anirbanbasu/frankfurtermcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T11:56:36.086039Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "anirbanbasu-frankfurtermcp": {
@@ -9772,7 +10412,7 @@
       "source_url": "https://server.smithery.ai/@anirbanbasu/pymcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T05:41:08.153835Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "anirbanbasu-pymcp": {
@@ -9793,7 +10433,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/ahoy/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T03:11:31.224722Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-ahoy": {
@@ -9814,7 +10454,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/ahoy2/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T09:44:13.762613Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-ahoy2": {
@@ -9835,7 +10475,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/boba-tea/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T01:51:32.373165Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-boba-tea": {
@@ -9856,7 +10496,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/bobo/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T03:28:29.606731Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-bobo": {
@@ -9877,7 +10517,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/brave-search-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T06:39:58.418517Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-brave-search-mcp-server": {
@@ -9898,7 +10538,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/clock/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T08:00:25.675646Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-clock": {
@@ -9919,7 +10559,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/fetch/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T02:32:40.481877Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-fetch": {
@@ -9940,7 +10580,7 @@
       "source_url": "https://server.smithery.ai/arjunkmrm/http-test",
       "registry_status": "active",
       "published_at": "2026-01-08T07:46:22.969746Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-http-test": {
@@ -9961,7 +10601,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/local-test2/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T08:52:53.0348Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-local-test2": {
@@ -9982,7 +10622,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/local001/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T12:44:39.189348Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-local001": {
@@ -10003,7 +10643,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/local01/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T04:20:15.678667Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-local01": {
@@ -10024,7 +10664,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/local02/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T09:02:26.911871Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-local02": {
@@ -10045,7 +10685,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/lta-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T16:52:48.059122Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-lta-mcp": {
@@ -10066,7 +10706,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/mango-sago/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T02:20:25.785458Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-mango-sago": {
@@ -10087,7 +10727,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/perplexity-search/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T13:59:26.758557Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-perplexity-search": {
@@ -10108,7 +10748,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/py-test-0/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T02:06:51.365096Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-py-test-0": {
@@ -10129,7 +10769,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/py-test-2/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T03:00:46.274065Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-py-test-2": {
@@ -10150,7 +10790,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/scrapermcp_el/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:13:12.824688Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-scrapermcp_el": {
@@ -10171,7 +10811,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/sg-bus-test/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T08:54:49.020099Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-sg-bus-test": {
@@ -10192,7 +10832,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/test0/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T08:18:08.952463Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-test0": {
@@ -10213,7 +10853,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/test01/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T09:01:40.590024Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-test01": {
@@ -10234,7 +10874,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/test2/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T10:33:30.587409Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-test2": {
@@ -10255,7 +10895,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/time/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T08:35:12.663422Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-time": {
@@ -10276,7 +10916,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/ts-test-2/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T02:01:26.06959Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-ts-test-2": {
@@ -10297,7 +10937,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/tutorials/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:55:16.098975Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-tutorials": {
@@ -10318,7 +10958,7 @@
       "source_url": "https://server.smithery.ai/@arjunkmrm/watch2/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T08:31:21.361328Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "arjunkmrm-watch2": {
@@ -10339,7 +10979,7 @@
       "source_url": "https://server.smithery.ai/@aryankeluskar/poke-video-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T17:42:05.006814Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "aryankeluskar-poke-video-mcp": {
@@ -10360,7 +11000,7 @@
       "source_url": "https://server.smithery.ai/@bergeramit/bergeramit-hw3-tech/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:49:39.923485Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bergeramit-bergeramit-hw3-tech": {
@@ -10381,7 +11021,7 @@
       "source_url": "https://server.smithery.ai/@bergeramit/bergeramit-hw3-tech-1/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:45:13.016748Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bergeramit-bergeramit-hw3-tech-1": {
@@ -10402,7 +11042,7 @@
       "source_url": "https://server.smithery.ai/@bhushangitfull/file-mcp-smith/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T07:58:50.393118Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bhushangitfull-file-mcp-smith": {
@@ -10423,7 +11063,7 @@
       "source_url": "https://server.smithery.ai/@bielacki/igdb-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T21:24:56.528261Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "bielacki-igdb-mcp-server": {
@@ -10444,7 +11084,7 @@
       "source_url": "https://server.smithery.ai/@blacklotusdev8/test_m/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T19:12:16.602435Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "blacklotusdev8-test_m": {
@@ -10465,7 +11105,7 @@
       "source_url": "https://server.smithery.ai/@blbl147/xhs-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-15T03:34:24.676763Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "blbl147-xhs-mcp": {
@@ -10486,7 +11126,7 @@
       "source_url": "https://server.smithery.ai/@blockscout/mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T00:50:33.619952Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "blockscout-mcp-server": {
@@ -10507,7 +11147,7 @@
       "source_url": "https://server.smithery.ai/@brandonbosco/sigao-scf-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T17:06:30.80395Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "brandonbosco-sigao-scf-mcp": {
@@ -10528,7 +11168,7 @@
       "source_url": "https://server.smithery.ai/brave/mcp",
       "registry_status": "active",
       "published_at": "2025-10-25T09:09:32.842127Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "brave": {
@@ -10549,7 +11189,7 @@
       "source_url": "https://server.smithery.ai/@browserbasehq/mcp-browserbase/mcp",
       "registry_status": "active",
       "published_at": "2025-10-16T21:51:16.500712Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "browserbasehq-mcp-browserbase": {
@@ -10570,7 +11210,7 @@
       "source_url": "https://server.smithery.ai/@callmybot/cookbook-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T09:25:11.477139Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "callmybot-cookbook-mcp-server": {
@@ -10591,7 +11231,7 @@
       "source_url": "https://server.smithery.ai/@callmybot/domoticz/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T10:31:39.650923Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "callmybot-domoticz": {
@@ -10612,7 +11252,7 @@
       "source_url": "https://server.smithery.ai/@callmybot/hello-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T07:48:26.611267Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "callmybot-hello-mcp-server": {
@@ -10633,7 +11273,7 @@
       "source_url": "https://server.smithery.ai/@cc25a/openai-api-agent-project123123123/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T03:32:54.14302Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cc25a-openai-api-agent-project123123123": {
@@ -10654,7 +11294,7 @@
       "source_url": "https://server.smithery.ai/@cindyloo/dropbox-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T02:02:08.583268Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cindyloo-dropbox-mcp-server": {
@@ -10675,7 +11315,7 @@
       "source_url": "https://server.smithery.ai/@clpi/clp-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T00:23:04.174735Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "clpi-clp-mcp": {
@@ -10696,7 +11336,7 @@
       "source_url": "https://server.smithery.ai/@cpretzinger/ai-assistant-simple/mcp",
       "registry_status": "active",
       "published_at": "2025-09-15T00:26:36.144736Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cpretzinger-ai-assistant-simple": {
@@ -10717,7 +11357,7 @@
       "source_url": "https://server.smithery.ai/@cristianoaredes/mcp-dadosbr/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T12:13:44.073155Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cristianoaredes-mcp-dadosbr": {
@@ -10738,7 +11378,7 @@
       "source_url": "https://server.smithery.ai/@ctaylor86/mcp-video-download-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-15T11:45:18.173946Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ctaylor86-mcp-video-download-server": {
@@ -10759,7 +11399,7 @@
       "source_url": "https://server.smithery.ai/@cuongpo/coti-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T07:26:17.819584Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cuongpo-coti-mcp": {
@@ -10780,7 +11420,7 @@
       "source_url": "https://server.smithery.ai/@cuongpo/coti-mcp-1/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T15:24:18.456616Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "cuongpo-coti-mcp-1": {
@@ -10801,7 +11441,7 @@
       "source_url": "https://server.smithery.ai/@data-mindset/sts-google-forms-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T09:13:16.21757Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "data-mindset-sts-google-forms-mcp": {
@@ -10822,7 +11462,7 @@
       "source_url": "https://server.smithery.ai/@demomagic/duckchain-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T05:32:58.075994Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "demomagic-duckchain-mcp": {
@@ -10843,7 +11483,7 @@
       "source_url": "https://server.smithery.ai/@devbrother2024/typescript-mcp-server-boilerplate/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T16:12:55.711869Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "devbrother2024-typescript-mcp-server-boilerplate": {
@@ -10864,7 +11504,7 @@
       "source_url": "https://server.smithery.ai/@docfork/mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T18:25:16.049647Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "docfork-mcp": {
@@ -10885,7 +11525,7 @@
       "source_url": "https://server.smithery.ai/@dsharipova/mcp-hw/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T13:26:30.70555Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "dsharipova-mcp-hw": {
@@ -10906,7 +11546,7 @@
       "source_url": "https://server.smithery.ai/@duvomike/mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-21T03:33:47.332418Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "duvomike-mcp": {
@@ -10927,7 +11567,7 @@
       "source_url": "https://server.smithery.ai/@eliu243/oura-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T18:41:13.003678Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "eliu243-oura-mcp-server": {
@@ -10948,7 +11588,7 @@
       "source_url": "https://server.smithery.ai/@eliu243/oura-mcp-server-2/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T18:40:49.71696Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "eliu243-oura-mcp-server-2": {
@@ -10969,7 +11609,7 @@
       "source_url": "https://server.smithery.ai/@eliu243/oura-mcp-server-eliu/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T18:40:51.593152Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "eliu243-oura-mcp-server-eliu": {
@@ -10990,7 +11630,7 @@
       "source_url": "https://server.smithery.ai/@exa-labs/exa-code-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T20:44:09.235886Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "exa-labs-exa-code-mcp": {
@@ -11011,7 +11651,7 @@
       "source_url": "https://server.smithery.ai/@faithk7/gmail-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T13:42:20.134258Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "faithk7-gmail-mcp": {
@@ -11032,7 +11672,7 @@
       "source_url": "https://server.smithery.ai/@feeefapp/mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T01:55:09.587519Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "feeefapp-mcp": {
@@ -11053,7 +11693,7 @@
       "source_url": "https://server.smithery.ai/@fengyinxia/jimeng-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T13:13:51.711543Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fengyinxia-jimeng-mcp": {
@@ -11074,7 +11714,7 @@
       "source_url": "https://server.smithery.ai/@fitaf-ai/fitaf-ai-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T17:59:11.653728Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fitaf-ai-fitaf-ai-mcp": {
@@ -11095,7 +11735,7 @@
       "source_url": "https://server.smithery.ai/@fitaf-ai/fitaf-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T20:09:50.974663Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "fitaf-ai-fitaf-mcp": {
@@ -11116,7 +11756,7 @@
       "source_url": "https://server.smithery.ai/@flight505/mcp_dincoder/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T21:53:12.422748Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "flight505-mcp_dincoder": {
@@ -11137,7 +11777,7 @@
       "source_url": "https://server.smithery.ai/@hithereiamaliff/mcp-datagovmy/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T05:56:30.06684Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hithereiamaliff-mcp-datagovmy": {
@@ -11158,7 +11798,7 @@
       "source_url": "https://server.smithery.ai/@hithereiamaliff/mcp-nextcloud/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T18:40:25.891252Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hithereiamaliff-mcp-nextcloud": {
@@ -11179,7 +11819,7 @@
       "source_url": "https://server.smithery.ai/@hjsh200219/pharminfo-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T06:55:47.401979Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hjsh200219-pharminfo-mcp": {
@@ -11200,7 +11840,7 @@
       "source_url": "https://server.smithery.ai/@hollaugo/financial-research-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T16:56:54.604903Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hollaugo-financial-research-mcp-server": {
@@ -11221,7 +11861,7 @@
       "source_url": "https://server.smithery.ai/@hustcc/mcp-mermaid/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T06:08:16.370383Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hustcc-mcp-mermaid": {
@@ -11242,7 +11882,7 @@
       "source_url": "https://server.smithery.ai/@huuthangntk/claude-vision-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T23:20:55.125959Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "huuthangntk-claude-vision-mcp-server": {
@@ -11263,7 +11903,7 @@
       "source_url": "https://server.smithery.ai/@infranodus/mcp-server-infranodus/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T08:08:11.981455Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "infranodus-mcp-server-infranodus": {
@@ -11284,7 +11924,7 @@
       "source_url": "https://server.smithery.ai/@isnow890/data4library-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T10:45:21.467985Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "isnow890-data4library-mcp": {
@@ -11305,7 +11945,7 @@
       "source_url": "https://server.smithery.ai/@jekakos/mcp-user-data-enrichment/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T12:50:51.350056Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jekakos-mcp-user-data-enrichment": {
@@ -11326,7 +11966,7 @@
       "source_url": "https://server.smithery.ai/@jenniferjiang0511/mit-ai-studio-hw3/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T03:01:55.290688Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jenniferjiang0511-mit-ai-studio-hw3": {
@@ -11347,7 +11987,7 @@
       "source_url": "https://server.smithery.ai/@jessicayanwang/test/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T02:03:00.046026Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jessicayanwang-test": {
@@ -11368,7 +12008,7 @@
       "source_url": "https://server.smithery.ai/@jirispilka/actors-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T11:59:13.452963Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jirispilka-actors-mcp-server": {
@@ -11389,7 +12029,7 @@
       "source_url": "https://server.smithery.ai/@jjlabsio/korea-stock-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T09:01:49.012754Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jjlabsio-korea-stock-mcp": {
@@ -11410,7 +12050,7 @@
       "source_url": "https://server.smithery.ai/@jweingardt12/mlb_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T14:52:36.727607Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "jweingardt12-mlb_mcp": {
@@ -11431,7 +12071,7 @@
       "source_url": "https://server.smithery.ai/@kaszek/kaszek-attio-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T23:26:13.627724Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kaszek-kaszek-attio-mcp": {
@@ -11452,7 +12092,7 @@
       "source_url": "https://server.smithery.ai/@keithah/hostex-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T04:10:38.519183Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "keithah-hostex-mcp": {
@@ -11473,7 +12113,7 @@
       "source_url": "https://server.smithery.ai/@keithah/tessie-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T04:22:17.289426Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "keithah-tessie-mcp": {
@@ -11494,7 +12134,7 @@
       "source_url": "https://server.smithery.ai/@keremurat/json/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T13:28:40.425657Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "keremurat-json": {
@@ -11515,7 +12155,7 @@
       "source_url": "https://server.smithery.ai/@keremurat/jsonmcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T13:28:42.90749Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "keremurat-jsonmcp": {
@@ -11536,7 +12176,7 @@
       "source_url": "https://server.smithery.ai/@keremurat/mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T13:28:45.319778Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "keremurat-mcp": {
@@ -11557,7 +12197,7 @@
       "source_url": "https://server.smithery.ai/@kesslerio/attio-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T01:00:35.437419Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kesslerio-attio-mcp-server": {
@@ -11578,7 +12218,7 @@
       "source_url": "https://server.smithery.ai/@kesslerio/attio-mcp-server-beta/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T04:36:42.08064Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kesslerio-attio-mcp-server-beta": {
@@ -11599,7 +12239,7 @@
       "source_url": "https://server.smithery.ai/@kirbah/mcp-youtube/mcp",
       "registry_status": "active",
       "published_at": "2025-10-04T16:31:58.771823Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kirbah-mcp-youtube": {
@@ -11620,7 +12260,7 @@
       "source_url": "https://server.smithery.ai/@kkjdaniel/bgg-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T00:14:29.642756Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kkjdaniel-bgg-mcp": {
@@ -11641,7 +12281,7 @@
       "source_url": "https://server.smithery.ai/@kodey-ai/mapwise-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T21:55:01.522892Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kodey-ai-mapwise-mcp": {
@@ -11662,7 +12302,7 @@
       "source_url": "https://server.smithery.ai/@kodey-ai/salesforce-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T03:10:49.227357Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kodey-ai-salesforce-mcp": {
@@ -11683,7 +12323,7 @@
       "source_url": "https://server.smithery.ai/@kodey-ai/salesforce-mcp-kodey/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T03:10:47.790579Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kodey-ai-salesforce-mcp-kodey": {
@@ -11704,7 +12344,7 @@
       "source_url": "https://server.smithery.ai/@kodey-ai/salesforce-mcp-minimal/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T03:10:50.179693Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kodey-ai-salesforce-mcp-minimal": {
@@ -11725,7 +12365,7 @@
       "source_url": "https://server.smithery.ai/@kodey-ai/salesforce-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-08T03:10:46.917883Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kodey-ai-salesforce-mcp-server": {
@@ -11746,7 +12386,7 @@
       "source_url": "https://server.smithery.ai/@kwp-lab/rss-reader-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T17:02:25.896522Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "kwp-lab-rss-reader-mcp": {
@@ -11767,7 +12407,7 @@
       "source_url": "https://server.smithery.ai/@leandrogavidia/vechain-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T18:35:25.040994Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "leandrogavidia-vechain-mcp-server": {
@@ -11788,7 +12428,7 @@
       "source_url": "https://server.smithery.ai/@lineex/pubmed-mcp-smithery/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T01:10:37.458959Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lineex-pubmed-mcp-smithery": {
@@ -11809,7 +12449,7 @@
       "source_url": "https://server.smithery.ai/@lukaskostka99/marketing-miner-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T19:53:18.718565Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "lukaskostka99-marketing-miner-mcp": {
@@ -11830,7 +12470,7 @@
       "source_url": "https://server.smithery.ai/@luminati-io/brightdata-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T11:04:51.228096Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "luminati-io-brightdata-mcp": {
@@ -11851,7 +12491,7 @@
       "source_url": "https://server.smithery.ai/@magenie33/quality-dimension-generator/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T15:11:34.739058Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "magenie33-quality-dimension-generator": {
@@ -11872,7 +12512,7 @@
       "source_url": "https://server.smithery.ai/@mayla-debug/mcp-google-calendar2/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T11:08:53.670394Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mayla-debug-mcp-google-calendar2": {
@@ -11893,7 +12533,7 @@
       "source_url": "https://server.smithery.ai/@mfukushim/map-traveler-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T15:14:24.853367Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mfukushim-map-traveler-mcp": {
@@ -11914,7 +12554,7 @@
       "source_url": "https://server.smithery.ai/@miguelgarzons/mcp-cun/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T03:30:01.02979Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "miguelgarzons-mcp-cun": {
@@ -11935,7 +12575,7 @@
       "source_url": "https://server.smithery.ai/@minionszyw/bazi/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T08:13:10.601278Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "minionszyw-bazi": {
@@ -11956,7 +12596,7 @@
       "source_url": "https://server.smithery.ai/@mjucius/cozi_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T23:46:02.266315Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mjucius-cozi_mcp": {
@@ -11977,7 +12617,7 @@
       "source_url": "https://server.smithery.ai/@morosss/sdfsdf/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T17:26:11.859Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "morosss-sdfsdf": {
@@ -11998,7 +12638,7 @@
       "source_url": "https://server.smithery.ai/@motorboy1/my-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T06:36:24.851605Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "motorboy1-my-mcp-server": {
@@ -12019,7 +12659,7 @@
       "source_url": "https://server.smithery.ai/@mrugankpednekar/bill_splitter_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T06:59:08.923806Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mrugankpednekar-bill_splitter_mcp": {
@@ -12040,7 +12680,7 @@
       "source_url": "https://server.smithery.ai/@mrugankpednekar/mcp-optimizer/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T21:15:31.815401Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mrugankpednekar-mcp-optimizer": {
@@ -12061,7 +12701,7 @@
       "source_url": "https://server.smithery.ai/@neverinfamous/memory-journal-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-15T03:39:21.90803Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "neverinfamous-memory-journal-mcp": {
@@ -12082,7 +12722,7 @@
       "source_url": "https://server.smithery.ai/@nickthelegend/test-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T14:15:26.542177Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "nickthelegend-test-mcp": {
@@ -12103,7 +12743,7 @@
       "source_url": "https://server.smithery.ai/@oxylabs/oxylabs-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T14:22:20.353742Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "oxylabs-oxylabs-mcp": {
@@ -12124,7 +12764,7 @@
       "source_url": "https://server.smithery.ai/@pinion05/supabase-mcp-lite/mcp",
       "registry_status": "active",
       "published_at": "2025-09-17T09:26:34.42483Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pinion05-supabase-mcp-lite": {
@@ -12145,7 +12785,7 @@
       "source_url": "https://server.smithery.ai/@pinkpixel-dev/web-scout-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T03:40:04.41882Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pinkpixel-dev-web-scout-mcp": {
@@ -12166,7 +12806,7 @@
       "source_url": "https://server.smithery.ai/@plainyogurt21/clintrials-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T12:56:11.696599Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "plainyogurt21-clintrials-mcp": {
@@ -12187,7 +12827,7 @@
       "source_url": "https://server.smithery.ai/@plainyogurt21/sec-edgar-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T21:20:44.610658Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "plainyogurt21-sec-edgar-mcp": {
@@ -12208,7 +12848,7 @@
       "source_url": "https://server.smithery.ai/@proflulab/documentassistant/mcp",
       "registry_status": "active",
       "published_at": "2025-10-06T07:24:02.799169Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "proflulab-documentassistant": {
@@ -12229,7 +12869,7 @@
       "source_url": "https://server.smithery.ai/@pythondev-pro/egw_writings_mcp_server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T12:48:16.278544Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "pythondev-pro-egw_writings_mcp_server": {
@@ -12250,7 +12890,7 @@
       "source_url": "https://server.smithery.ai/@rainbowgore/stealthee-mcp-tools/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T08:35:04.917713Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "rainbowgore-stealthee-mcp-tools": {
@@ -12271,7 +12911,7 @@
       "source_url": "https://server.smithery.ai/@ramadasmr/networkcalc-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-20T10:10:47.321873Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ramadasmr-networkcalc-mcp": {
@@ -12292,7 +12932,7 @@
       "source_url": "https://server.smithery.ai/@ref-tools/ref-tools-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-28T04:05:07.66948Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ref-tools-ref-tools-mcp": {
@@ -12313,7 +12953,7 @@
       "source_url": "https://server.smithery.ai/@renCosta2025/context7fork/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T10:26:07.372529Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "renCosta2025-context7fork": {
@@ -12334,7 +12974,7 @@
       "source_url": "https://server.smithery.ai/@rfdez/pvpc-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T16:57:17.590562Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "rfdez-pvpc-mcp-server": {
@@ -12355,7 +12995,7 @@
       "source_url": "https://server.smithery.ai/@sachicali/discordmcp-suite/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T18:19:06.201517Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sachicali-discordmcp-suite": {
@@ -12376,7 +13016,7 @@
       "source_url": "https://server.smithery.ai/@saidsef/mcp-github-pr-issue-analyser/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T14:58:08.898007Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "saidsef-mcp-github-pr-issue-analyser": {
@@ -12397,7 +13037,7 @@
       "source_url": "https://server.smithery.ai/@samihalawa/whatsapp-go-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T00:18:16.874195Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "samihalawa-whatsapp-go-mcp": {
@@ -12418,7 +13058,7 @@
       "source_url": "https://server.smithery.ai/@sasabasara/where_is_my_bus_mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T03:53:53.151653Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sasabasara-where_is_my_bus_mcp": {
@@ -12439,7 +13079,7 @@
       "source_url": "https://server.smithery.ai/@sebastianall1977/gmail-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T13:55:24.480833Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sebastianall1977-gmail-mcp": {
@@ -12460,7 +13100,7 @@
       "source_url": "https://server.smithery.ai/@serkan-ozal/driflyte-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T05:31:42.627664Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "serkan-ozal-driflyte-mcp-server": {
@@ -12481,7 +13121,7 @@
       "source_url": "https://server.smithery.ai/@shoumikdc/arxiv-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T06:59:26.159502Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "shoumikdc-arxiv-mcp": {
@@ -12502,7 +13142,7 @@
       "source_url": "https://server.smithery.ai/@skr-cloudify/clickup-mcp-server-new/mcp",
       "registry_status": "active",
       "published_at": "2025-09-21T11:44:55.497079Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "skr-cloudify-clickup-mcp-server-new": {
@@ -12523,7 +13163,7 @@
       "source_url": "https://server.smithery.ai/@slhad/aha-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-14T21:53:54.664726Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "slhad-aha-mcp": {
@@ -12544,7 +13184,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/cookbook-python-quickstart/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T16:07:02.461935Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-cookbook-python-quickstart": {
@@ -12565,7 +13205,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/cookbook-ts-smithery-cli/mcp",
       "registry_status": "active",
       "published_at": "2025-09-13T12:45:28.964188Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-cookbook-ts-smithery-cli": {
@@ -12586,7 +13226,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/fetch/mcp",
       "registry_status": "active",
       "published_at": "2025-10-14T03:19:26.387795Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-fetch": {
@@ -12607,7 +13247,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/github/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T18:22:12.930528Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-github": {
@@ -12628,7 +13268,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/national-weather-service/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T02:29:56.928105Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-national-weather-service": {
@@ -12649,7 +13289,7 @@
       "source_url": "https://server.smithery.ai/@smithery-ai/slack/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T20:56:36.64385Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-ai-slack": {
@@ -12670,7 +13310,7 @@
       "source_url": "https://server.smithery.ai/@smithery/notion/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T18:26:59.341637Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-notion": {
@@ -12691,7 +13331,7 @@
       "source_url": "https://server.smithery.ai/@smithery/toolbox/mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T20:39:40.188723Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-toolbox": {
@@ -12712,7 +13352,7 @@
       "source_url": "https://server.smithery.ai/@smithery/unicorn",
       "registry_status": "active",
       "published_at": "2026-01-09T15:44:17.95936Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "smithery-unicorn": {
@@ -12733,7 +13373,7 @@
       "source_url": "https://server.smithery.ai/@sunub/obsidian-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-09-18T13:40:45.500067Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "sunub-obsidian-mcp-server": {
@@ -12754,7 +13394,7 @@
       "source_url": "https://server.smithery.ai/@szge/lolwiki-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-10-07T01:41:22.282712Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "szge-lolwiki-mcp": {
@@ -12775,7 +13415,7 @@
       "source_url": "https://server.smithery.ai/@truss44/mcp-crypto-price/mcp",
       "registry_status": "active",
       "published_at": "2025-10-02T23:25:46.643562Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "truss44-mcp-crypto-price": {
@@ -12796,7 +13436,7 @@
       "source_url": "https://server.smithery.ai/@turnono/datacommons-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-03T09:53:14.229429Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "turnono-datacommons-mcp-server": {
@@ -12817,7 +13457,7 @@
       "source_url": "https://server.smithery.ai/@wgong/sqlite-mcp-server/mcp",
       "registry_status": "active",
       "published_at": "2025-10-05T01:52:30.252523Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "wgong-sqlite-mcp-server": {
@@ -12838,7 +13478,7 @@
       "source_url": "https://server.smithery.ai/@xinkuang/china-stock-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T01:41:03.405268Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "xinkuang-china-stock-mcp": {
@@ -12859,7 +13499,7 @@
       "source_url": "https://server.smithery.ai/@yuhuison/mediawiki-mcp-server-auth/mcp",
       "registry_status": "active",
       "published_at": "2025-09-16T11:19:24.929803Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "yuhuison-mediawiki-mcp-server-auth": {
@@ -12880,7 +13520,7 @@
       "source_url": "https://server.smithery.ai/@yuna0x0/anilist-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:46:26.531503Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "yuna0x0-anilist-mcp": {
@@ -12901,7 +13541,7 @@
       "source_url": "https://server.smithery.ai/@yuna0x0/hackmd-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-29T12:48:21.84888Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "yuna0x0-hackmd-mcp": {
@@ -12922,7 +13562,7 @@
       "source_url": "https://server.smithery.ai/@zeta-chain/cli/mcp",
       "registry_status": "active",
       "published_at": "2025-09-19T16:55:43.436334Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "zeta-chain-cli": {
@@ -12943,7 +13583,7 @@
       "source_url": "https://server.smithery.ai/@zhaoganghao/hellomcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-30T10:35:36.775049Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "zhaoganghao-hellomcp": {
@@ -12964,7 +13604,7 @@
       "source_url": "https://server.smithery.ai/@zwldarren/akshare-one-mcp/mcp",
       "registry_status": "active",
       "published_at": "2025-09-11T19:15:39.84882Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "zwldarren-akshare-one-mcp": {
@@ -12985,7 +13625,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.snapdiff/mcp",
       "registry_status": "active",
       "published_at": "2026-06-14T08:21:11.413337Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -13010,7 +13650,7 @@
       "source_url": "https://mcp.snowdata.ai",
       "registry_status": "active",
       "published_at": "2026-06-19T08:49:51.255708Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "live-snow": {
@@ -13028,7 +13668,7 @@
       "source_url": "https://www.snowsure.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T10:28:38.738098Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "snow": {
@@ -13046,7 +13686,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.social-api/socialapi",
       "registry_status": "active",
       "published_at": "2026-05-02T11:22:45.878556Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "socialapi": {
@@ -13070,7 +13710,7 @@
       "source_url": "https://netsuite.solenium.ai/api/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T21:53:15.677361Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "netsuite-link": {
@@ -13084,6 +13724,42 @@
       }
     },
     {
+      "name": "ai.sourcemill/au-hot-water-payback",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://heatpump.sourcemill.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T01:59:48.478688Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "au-hot-water-payback": {
+            "type": "http",
+            "url": "https://heatpump.sourcemill.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.sourcemill/au-towing-legality",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://towing.sourcemill.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T01:59:49.206501Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "au-towing-legality": {
+            "type": "http",
+            "url": "https://towing.sourcemill.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.sovantica/engrava",
       "version": "0.5.1",
       "transport": "stdio",
@@ -13091,7 +13767,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.sovantica/engrava",
       "registry_status": "active",
       "published_at": "2026-07-09T11:54:02.466666Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "engrava": {
@@ -13105,13 +13781,13 @@
     },
     {
       "name": "ai.spala/public-mcp",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "transport": "streamable-http",
       "auth_mode": "header-nonsecret",
       "source_url": "https://mcp.spala.ai/mcp",
       "registry_status": "active",
-      "published_at": "2026-07-09T15:32:06.369154Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-23T17:06:35.615704Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "public-mcp": {
@@ -13132,7 +13808,7 @@
       "source_url": "https://mcp.specproof.ai/",
       "registry_status": "active",
       "published_at": "2026-02-01T20:43:12.895842Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "specproof-mcp": {
@@ -13150,7 +13826,7 @@
       "source_url": "https://mcp.speko.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-15T10:47:39.907966Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -13171,7 +13847,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.spideriq/gate",
       "registry_status": "active",
       "published_at": "2026-06-19T23:39:43.467752Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "gate": {
@@ -13192,7 +13868,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.spideriq/mail",
       "registry_status": "active",
       "published_at": "2026-06-19T23:39:42.906953Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mail": {
@@ -13213,7 +13889,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.spideriq/media",
       "registry_status": "active",
       "published_at": "2026-06-19T23:39:44.004773Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "media": {
@@ -13234,7 +13910,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.spideriq/publish",
       "registry_status": "active",
       "published_at": "2026-06-19T23:39:42.215763Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "publish": {
@@ -13255,7 +13931,7 @@
       "source_url": "https://api.spritecook.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-01T19:32:20.774038Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "generate": {
@@ -13276,7 +13952,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.ssid/ssid-mcp",
       "registry_status": "active",
       "published_at": "2026-07-13T09:14:47.363251Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ssid-mcp": {
@@ -13290,6 +13966,24 @@
       }
     },
     {
+      "name": "ai.stackeasy/credit-cards",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://data.stackeasy.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T16:28:03.187448Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "credit-cards": {
+            "type": "http",
+            "url": "https://data.stackeasy.ai/mcp"
+          }
+        }
+      }
+    },
+    {
       "name": "ai.statey/statey",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -13297,12 +13991,30 @@
       "source_url": "https://mcp.statey.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T10:59:56.108865Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "statey": {
             "type": "http",
             "url": "https://mcp.statey.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.statshawk/statshawk",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.statshawk.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T21:53:27.608441Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "statshawk": {
+            "type": "http",
+            "url": "https://mcp.statshawk.ai/mcp"
           }
         }
       }
@@ -13315,7 +14027,7 @@
       "source_url": "https://mcp.stompy.ai",
       "registry_status": "active",
       "published_at": "2026-03-08T10:20:54.210632Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "stompy": {
@@ -13333,7 +14045,7 @@
       "source_url": "https://stumpy.ai/mcp/message",
       "registry_status": "active",
       "published_at": "2026-01-31T00:02:06.764828Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "agents": {
@@ -13351,7 +14063,7 @@
       "source_url": "https://app.sugra.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-18T20:47:27.270617Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "api-mcp": {
@@ -13369,7 +14081,7 @@
       "source_url": "https://superfact.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-02T17:26:40.506325Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "superfact": {
@@ -13387,7 +14099,7 @@
       "source_url": "https://mcp.switchapp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-04T21:20:01.872003Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "switch": {
@@ -13405,7 +14117,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.synchronex/mcp-proxy",
       "registry_status": "active",
       "published_at": "2026-07-03T03:59:19.084398Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-proxy": {
@@ -13426,7 +14138,7 @@
       "source_url": "https://api.synlake.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-05-27T01:35:27.99319Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "synlake": {
@@ -13441,13 +14153,13 @@
     },
     {
       "name": "ai.syntheticbrew/syntheticbrew",
-      "version": "1.14.0",
+      "version": "1.18.0",
       "transport": "streamable-http",
       "auth_mode": "none",
       "source_url": "https://app.syntheticbrew.ai/api/v1/mcp/rpc",
       "registry_status": "active",
-      "published_at": "2026-07-11T17:55:53.83482Z",
-      "fetched_at": "2026-07-19",
+      "published_at": "2026-07-22T19:47:39.292849Z",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "syntheticbrew": {
@@ -13465,7 +14177,7 @@
       "source_url": "https://mcp.syntitan.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-03T01:18:09.135522Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "syntitan-mcp": {
@@ -13483,7 +14195,7 @@
       "source_url": "https://mcp.tachyo.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-06-20T17:50:27.513977Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "tachyo": {
@@ -13501,7 +14213,7 @@
       "source_url": "https://auth.xbarry.ai/api/mcp/token-safety",
       "registry_status": "active",
       "published_at": "2026-06-20T17:56:56.927318Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "token-safety": {
@@ -13519,7 +14231,7 @@
       "source_url": "https://auth.xbarry.ai/api/mcp/verify",
       "registry_status": "active",
       "published_at": "2026-06-20T17:57:38.741911Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "verify": {
@@ -13537,12 +14249,30 @@
       "source_url": "https://mcp.taskforcehq.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-22T19:28:02.104697Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "taskforce": {
             "type": "http",
             "url": "https://mcp.taskforcehq.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.taskive/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.taskive.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T08:47:26.47862Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.taskive.ai/mcp"
           }
         }
       }
@@ -13555,7 +14285,7 @@
       "source_url": "https://teenadhd.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:26.254338Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -13573,7 +14303,7 @@
       "source_url": "https://teenanxiety.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:29.383793Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -13591,7 +14321,7 @@
       "source_url": "https://teenpsychiatry.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:38.877493Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
@@ -13609,12 +14339,30 @@
       "source_url": "https://teentherapy.ai/api/mcp/v1",
       "registry_status": "active",
       "published_at": "2026-04-26T00:04:42.145147Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "library": {
             "type": "http",
             "url": "https://teentherapy.ai/api/mcp/v1"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.tekboss/assessment",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tekboss.ai/mcp/assessment",
+      "registry_status": "active",
+      "published_at": "2026-07-22T04:50:23.782644Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "assessment": {
+            "type": "http",
+            "url": "https://tekboss.ai/mcp/assessment"
           }
         }
       }
@@ -13627,7 +14375,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.telbase/deploy",
       "registry_status": "active",
       "published_at": "2026-02-23T22:05:13.575274Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "deploy": {
@@ -13648,7 +14396,7 @@
       "source_url": "https://mcp.tensorfeed.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-04T06:39:51.567207Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp-server": {
@@ -13666,7 +14414,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.tensorfeed/x402-base-mcp",
       "registry_status": "active",
       "published_at": "2026-05-28T03:46:35.010007Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "x402-base-mcp": {
@@ -13690,12 +14438,30 @@
       "source_url": "https://tessen.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-07T09:39:26.663521Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "grader": {
             "type": "http",
             "url": "https://tessen.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.theaggregate/the-aggregate",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://theaggregate.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T18:25:18.84469Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "the-aggregate": {
+            "type": "http",
+            "url": "https://theaggregate.ai/mcp"
           }
         }
       }
@@ -13708,7 +14474,7 @@
       "source_url": "https://mcp.thinkneo.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-02T18:24:49.557975Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "control-plane": {
@@ -13726,7 +14492,7 @@
       "source_url": "https://thinkpattern.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-07-18T16:51:31.532065Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "news": {
@@ -13744,7 +14510,7 @@
       "source_url": "https://mcp.thiri.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-18T02:28:34.618985Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "chord-intelligence": {
@@ -13762,7 +14528,7 @@
       "source_url": "https://api.thoughtbox.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-12T21:41:43.26527Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "thoughts": {
@@ -13780,7 +14546,7 @@
       "source_url": "https://mcp.threadminder.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-05T01:59:03.850331Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "threadminder": {
@@ -13798,7 +14564,7 @@
       "source_url": "https://mcp-server.thrivee.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-20T07:35:25.924485Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "financial-intelligence": {
@@ -13816,7 +14582,7 @@
       "source_url": "https://mcp.tickettailor.ai/mcp",
       "registry_status": "active",
       "published_at": "2025-09-12T10:10:54.188764Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "mcp": {
@@ -13834,7 +14600,7 @@
       "source_url": "https://api.timix.ai/api/integration/v1/mcp",
       "registry_status": "active",
       "published_at": "2026-07-15T10:32:15.514926Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "time-tracking": {
@@ -13852,12 +14618,30 @@
       "source_url": "https://agent.tinyfish.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-02-17T03:00:36.680724Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "web-agent": {
             "type": "http",
             "url": "https://agent.tinyfish.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.toffu/toffu",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.toffu.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T04:20:35.560083Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "toffu": {
+            "type": "http",
+            "url": "https://mcp.toffu.ai/mcp"
           }
         }
       }
@@ -13870,7 +14654,7 @@
       "source_url": "https://tokenarcade.ai/mcp/",
       "registry_status": "active",
       "published_at": "2026-05-17T04:08:06.857953Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "tokenarcade": {
@@ -13891,7 +14675,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.tokonomix/council",
       "registry_status": "active",
       "published_at": "2026-06-30T01:05:24.79849Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "council": {
@@ -13915,7 +14699,7 @@
       "source_url": "https://tooldirectory.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-06-28T01:16:34.999323Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "catalog": {
@@ -13933,7 +14717,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.toolprint/hypertool-mcp",
       "registry_status": "active",
       "published_at": "2025-09-10T22:05:20.65584Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "hypertool-mcp": {
@@ -13954,7 +14738,7 @@
       "source_url": "https://trackradar.ai/api/mcp",
       "registry_status": "active",
       "published_at": "2026-07-09T12:31:01.077805Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "trackradar": {
@@ -13972,7 +14756,7 @@
       "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.traderouter/trade-router-mcp",
       "registry_status": "active",
       "published_at": "2026-04-27T08:26:46.822524Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "trade-router-mcp": {
@@ -13995,6 +14779,30 @@
       }
     },
     {
+      "name": "ai.tradesearcher/mcp-server",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.tradesearcher/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-07-23T16:53:23.760246Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@tradesearcher/mcp-server"
+            ],
+            "env": {
+              "TRADESEARCHER_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "ai.travelminds/concierge",
       "version": "1.0.0",
       "transport": "streamable-http",
@@ -14002,7 +14810,7 @@
       "source_url": "https://mcp.travelminds.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-05-30T11:32:18.810727Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "concierge": {
@@ -14023,7 +14831,7 @@
       "source_url": "https://amazon.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:08:38.537679Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "amazon": {
@@ -14044,7 +14852,7 @@
       "source_url": "https://app-store.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:08:41.390484Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "app-store": {
@@ -14065,7 +14873,7 @@
       "source_url": "https://competitor-tracking.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:02:18.925493Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "competitor-tracking": {
@@ -14086,7 +14894,7 @@
       "source_url": "https://content-strategy.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:02:20.244589Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "content-strategy": {
@@ -14107,7 +14915,7 @@
       "source_url": "https://crypto.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:02:19.37875Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "crypto": {
@@ -14128,7 +14936,7 @@
       "source_url": "https://ecommerce.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:02:20.683615Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "ecommerce": {
@@ -14149,7 +14957,7 @@
       "source_url": "https://google-trends.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:08:36.623827Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "google-trends": {
@@ -14170,7 +14978,7 @@
       "source_url": "https://market-research.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:02:19.80772Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "market-research": {
@@ -14191,12 +14999,16750 @@
       "source_url": "https://news-sentiment.api.trendsmcp.ai/mcp",
       "registry_status": "active",
       "published_at": "2026-06-21T02:08:41.829459Z",
-      "fetched_at": "2026-07-19",
+      "fetched_at": "2026-07-26",
       "config": {
         "mcpServers": {
           "news-sentiment": {
             "type": "http",
             "url": "https://news-sentiment.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/news-volume",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://news-volume.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:42.34865Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "news-volume": {
+            "type": "http",
+            "url": "https://news-volume.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/npm",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://npm.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:40.946908Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "npm": {
+            "type": "http",
+            "url": "https://npm.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/reddit",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://reddit.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:38.079868Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "reddit": {
+            "type": "http",
+            "url": "https://reddit.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/seo",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://seo.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:02:18.370492Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "seo": {
+            "type": "http",
+            "url": "https://seo.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/social-media",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://social-media.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:29:27.75421Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "social-media": {
+            "type": "http",
+            "url": "https://social-media.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/spotify",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://spotify.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:40.005805Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "spotify": {
+            "type": "http",
+            "url": "https://spotify.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/steam",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://steam.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:40.478649Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "steam": {
+            "type": "http",
+            "url": "https://steam.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/tiktok",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://tiktok.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:37.601606Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tiktok": {
+            "type": "http",
+            "url": "https://tiktok.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/trends",
+      "version": "1.0.5",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:10:36.423887Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trends": {
+            "type": "http",
+            "url": "https://api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/wikipedia",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://wikipedia.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:39.036397Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wikipedia": {
+            "type": "http",
+            "url": "https://wikipedia.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/x-twitter",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://x-twitter.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:39.555965Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "x-twitter": {
+            "type": "http",
+            "url": "https://x-twitter.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trendsmcp/youtube",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://youtube.api.trendsmcp.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-21T02:08:37.105703Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "youtube": {
+            "type": "http",
+            "url": "https://youtube.api.trendsmcp.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trustysquire/trusty-squire",
+      "version": "1.1.4",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.trustysquire/trusty-squire",
+      "registry_status": "active",
+      "published_at": "2026-07-25T21:23:50.597496Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trusty-squire": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@trusty-squire/mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trycanonical/company-search",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://trycanonical.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T06:50:56.87531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "company-search": {
+            "type": "http",
+            "url": "https://trycanonical.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.trydock/dock",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://trydock.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-15T02:06:57.43531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dock": {
+            "type": "http",
+            "url": "https://trydock.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.tunnelmind/data",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-data.tunnelmind.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-25T00:50:14.85281Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "data": {
+            "type": "http",
+            "url": "https://mcp-data.tunnelmind.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.tunnelmind/scry",
+      "version": "0.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.tunnelmind.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-25T01:01:59.607954Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "scry": {
+            "type": "http",
+            "url": "https://mcp.tunnelmind.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.tunnelmind/sigil",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.sigil.tunnelmind.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-25T00:49:16.460811Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sigil": {
+            "type": "http",
+            "url": "https://mcp.sigil.tunnelmind.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.tuteliq/mcp",
+      "version": "3.13.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.tuteliq.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-29T11:02:31.986692Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.tuteliq.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.unpaper/cli",
+      "version": "0.2.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.unpaper/cli",
+      "registry_status": "active",
+      "published_at": "2026-07-18T08:14:22.854223Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cli": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@unpaper/cli"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.unulu/unulu",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.unulu.ai",
+      "registry_status": "active",
+      "published_at": "2026-03-07T08:39:34.646691Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "unulu": {
+            "type": "http",
+            "url": "https://mcp.unulu.ai"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.upgradeagent/upgrade-agent",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.upgradeagent.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T14:44:34.355847Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "upgrade-agent": {
+            "type": "http",
+            "url": "https://www.upgradeagent.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.upriver/upriver",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.upriver.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T23:30:54.974046Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "upriver": {
+            "type": "http",
+            "url": "https://mcp.upriver.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.urlcheck/urlcheck-mcp",
+      "version": "0.1.5",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://urlcheck.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-10T08:44:43.048053Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "urlcheck-mcp": {
+            "type": "http",
+            "url": "https://urlcheck.ai/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.usealloy/alloy",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aus.usealloy.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-29T07:04:25.887363Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "alloy": {
+            "type": "http",
+            "url": "https://aus.usealloy.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.uselamina/lamina",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.uselamina.ai/mcp/agent",
+      "registry_status": "active",
+      "published_at": "2026-07-23T13:53:09.356464Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lamina": {
+            "type": "http",
+            "url": "https://app.uselamina.ai/mcp/agent"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.usestring/web-access",
+      "version": "1.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.usestring.ai/v1/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T22:38:34.193861Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "web-access": {
+            "type": "http",
+            "url": "https://mcp.usestring.ai/v1/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.uxbert/cms",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://cms-mcp.uxbert.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T11:18:21.351823Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cms": {
+            "type": "http",
+            "url": "https://cms-mcp.uxbert.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.v-safe/vsafe-risk",
+      "version": "0.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.v-safe.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-20T14:47:56.050866Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vsafe-risk": {
+            "type": "http",
+            "url": "https://mcp.v-safe.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.vaaya/mcp",
+      "version": "0.3.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://vaaya.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T23:26:55.002548Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://vaaya.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.variel/mcp-server",
+      "version": "0.1.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.variel/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-07-01T16:28:24.858408Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@variel/mcp-server"
+            ],
+            "env": {
+              "BRAND_API_KEY": "${VALUE}",
+              "VARIEL_API_URL": "${VALUE}",
+              "ANTHROPIC_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.veecle/chiplab",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://chiplab.veecle.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T11:25:06.592442Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chiplab": {
+            "type": "http",
+            "url": "https://chiplab.veecle.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.velarion/company-intelligence",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://velarion-scraper-production.up.railway.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T19:38:10.914662Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "company-intelligence": {
+            "type": "http",
+            "url": "https://velarion-scraper-production.up.railway.app/mcp",
+            "headers": {
+              "X-Velarion-Agent-Token": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.verant/verant",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://verant.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-13T13:03:45.329764Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "verant": {
+            "type": "http",
+            "url": "https://verant.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.vergio/vergio",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://vergio.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T14:39:50.42823Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vergio": {
+            "type": "http",
+            "url": "https://vergio.ai/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.verifox/email-verifier",
+      "version": "1.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.verifox.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T10:38:59.102118Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "email-verifier": {
+            "type": "http",
+            "url": "https://mcp.verifox.ai/mcp",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.verlon/mcp",
+      "version": "0.3.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.verlon/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T23:05:47.576783Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@verlon-ai/mcp"
+            ],
+            "env": {
+              "VERLON_API_KEY": "${VALUE}",
+              "VERLON_BASE_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.vibe-bi/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.vibe-bi.ai",
+      "registry_status": "active",
+      "published_at": "2026-03-28T12:24:49.421084Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.vibe-bi.ai"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.villiers/charter",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.villiers.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-31T14:41:45.270675Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "charter": {
+            "type": "http",
+            "url": "https://mcp.villiers.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.viralspin/viralspin",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.viralspin.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T14:03:28.141421Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "viralspin": {
+            "type": "http",
+            "url": "https://mcp.viralspin.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.visuary/actuarial-value-calculator",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.visuary.ai/av",
+      "registry_status": "active",
+      "published_at": "2026-07-05T18:43:44.161307Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "actuarial-value-calculator": {
+            "type": "http",
+            "url": "https://mcp.visuary.ai/av"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.vocci/mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.vocci.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T18:08:15.796765Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.vocci.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.voris.mcp/server",
+      "version": "0.0.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.voris.mcp/server",
+      "registry_status": "active",
+      "published_at": "2026-07-15T08:45:22.520413Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@voris-ai/mcp"
+            ],
+            "env": {
+              "VORIS_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.vortexiq/vortex-iq",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.vortexiq.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T12:44:40.027157Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vortex-iq": {
+            "type": "http",
+            "url": "https://app.vortexiq.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.voxell/forge",
+      "version": "0.1.5",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.voxell/forge",
+      "registry_status": "active",
+      "published_at": "2026-05-30T17:01:42.294979Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "forge": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@voxell/forge-mcp"
+            ],
+            "env": {
+              "FORGE_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.voxplo/voxplo",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.voxplo.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-01T20:30:01.888479Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "voxplo": {
+            "type": "http",
+            "url": "https://mcp.voxplo.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.walterwrites/mcp-server",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-server.walterwrites.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-01T15:23:06.249793Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp-server.walterwrites.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/airtable",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/airtable/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:23:23.086629Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "airtable": {
+            "type": "http",
+            "url": "https://waystation.ai/airtable/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/gmail",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/gmail/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:46:07.96981Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "gmail": {
+            "type": "http",
+            "url": "https://waystation.ai/gmail/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/jira",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/jira/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:46:07.210891Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jira": {
+            "type": "http",
+            "url": "https://waystation.ai/jira/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/mcp",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T12:10:02.48793Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://waystation.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/miro",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/miro/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:32:52.805916Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "miro": {
+            "type": "http",
+            "url": "https://waystation.ai/miro/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/monday",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/monday/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:20:40.836347Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "monday": {
+            "type": "http",
+            "url": "https://waystation.ai/monday/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/office",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/office/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:32:54.334202Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "office": {
+            "type": "http",
+            "url": "https://waystation.ai/office/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/postgres",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/postgres/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:46:09.489652Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "postgres": {
+            "type": "http",
+            "url": "https://waystation.ai/postgres/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/slack",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/slack/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:32:49.571767Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "slack": {
+            "type": "http",
+            "url": "https://waystation.ai/slack/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/supabase",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/supabase/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:46:10.221625Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "supabase": {
+            "type": "http",
+            "url": "https://waystation.ai/supabase/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/teams",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/teams/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:46:08.709922Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "teams": {
+            "type": "http",
+            "url": "https://waystation.ai/teams/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.waystation/wrike",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://waystation.ai/wrike/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T14:37:01.216779Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wrike": {
+            "type": "http",
+            "url": "https://waystation.ai/wrike/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.webanatomy/webanatomy",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.webanatomy.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-17T14:37:16.425861Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "webanatomy": {
+            "type": "http",
+            "url": "https://mcp.webanatomy.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.webhound/webhound",
+      "version": "0.5.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.webhound.ai/api/v2/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T02:18:40.593655Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "webhound": {
+            "type": "http",
+            "url": "https://api.webhound.ai/api/v2/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.webmatik/audit",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://webmatik.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T16:05:54.002149Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "audit": {
+            "type": "http",
+            "url": "https://webmatik.ai/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.websitepublisher/mcp",
+      "version": "1.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.websitepublisher.ai/",
+      "registry_status": "active",
+      "published_at": "2026-02-18T13:37:52.652645Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.websitepublisher.ai/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.webuplink/mcp",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.webuplink/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T19:55:06.104364Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@webuplink/mcp"
+            ],
+            "env": {
+              "WEBUPLINK_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.weftly/weftly",
+      "version": "0.25.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.weftly.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T00:05:58.199161Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "weftly": {
+            "type": "http",
+            "url": "https://api.weftly.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.wellnessproject/wellness-project",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://wellnessproject.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T18:49:46.288777Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wellness-project": {
+            "type": "http",
+            "url": "https://wellnessproject.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.wild-card/deepcontext",
+      "version": "0.1.15",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.wild-card/deepcontext",
+      "registry_status": "active",
+      "published_at": "2025-09-26T03:44:16.929896Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "deepcontext": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@wildcard-ai/deepcontext"
+            ],
+            "env": {
+              "JINA_API_KEY": "${VALUE}",
+              "TURBOPUFFER_API_KEY": "${VALUE}",
+              "WILDCARD_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.willform/willform-agent",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://agent.willform.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-09T05:39:51.653075Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "willform-agent": {
+            "type": "http",
+            "url": "https://agent.willform.ai/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.windsor/windsor-mcp",
+      "version": "0.1.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://mcp.windsor.ai/sse",
+      "registry_status": "active",
+      "published_at": "2026-03-16T17:31:42.303937Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "windsor-mcp": {
+            "type": "sse",
+            "url": "https://mcp.windsor.ai/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.wiplash/wiplash",
+      "version": "0.7.6",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.wiplash.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T18:42:58.582063Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wiplash": {
+            "type": "http",
+            "url": "https://mcp.wiplash.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.workingmemory/memory",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.workingmemory.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T08:35:09.9042Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "memory": {
+            "type": "http",
+            "url": "https://app.workingmemory.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.wubble/audio",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.wubble.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T14:47:38.286906Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "audio": {
+            "type": "http",
+            "url": "https://mcp.wubble.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.xpoz/social-insights",
+      "version": "1.4.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.xpoz.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T13:56:06.314985Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "social-insights": {
+            "type": "http",
+            "url": "https://mcp.xpoz.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.xr-utilities/h-index",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://h-index.xr-utilities.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-25T23:53:01.914778Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "h-index": {
+            "type": "http",
+            "url": "https://h-index.xr-utilities.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.xurprise/mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://xurprise.ai/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-15T07:21:56.627356Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://xurprise.ai/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.yempik/company-brain",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.yempik.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T15:53:22.594837Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "company-brain": {
+            "type": "http",
+            "url": "https://mcp.yempik.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zairalabs/guide",
+      "version": "0.1.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://zairalabs.ai/guide/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T18:38:29.43355Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "guide": {
+            "type": "http",
+            "url": "https://zairalabs.ai/guide/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zencap/zencap",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.zencap.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T22:56:19.827241Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "zencap": {
+            "type": "http",
+            "url": "https://mcp.zencap.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zentrik/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://zentrik.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T05:22:01.252813Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://zentrik.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zevari/mcp",
+      "version": "0.3.9",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.zevari.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T13:56:21.466567Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.zevari.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zimac/mnema",
+      "version": "0.2.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=ai.zimac/mnema",
+      "registry_status": "active",
+      "published_at": "2026-07-12T03:25:22.614005Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mnema": {
+            "command": "https://github.com/Zimac-AI/mnema/releases/download/v0.2.0/mnema-0.2.0-macos-universal.mcpb",
+            "args": [],
+            "env": {
+              "MNEMA_DATA_DIR": "${VALUE}",
+              "MNEMA_URL": "${VALUE}",
+              "MNEMA_TOKEN": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "ai.zine/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.zine.ai/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-10T18:02:28.773522Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://www.zine.ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "am.mana/mana-public",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.mana.am/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-28T05:03:37.659419Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mana-public": {
+            "type": "http",
+            "url": "https://api.mana.am/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.3dstreet/3dstreet",
+      "version": "0.2.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.3dstreet/3dstreet",
+      "registry_status": "active",
+      "published_at": "2026-05-07T16:17:40.226341Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "3dstreet": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "3dstreet-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app.aiconduit/conduit",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aiconduit.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T00:29:53.168047Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "conduit": {
+            "type": "http",
+            "url": "https://mcp.aiconduit.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.aiponge/mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aiponge.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T13:07:14.256837Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.aiponge.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.anakior/atlas-mind",
+      "version": "1.0.8",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://{ATLAS_MCP_URL}",
+      "registry_status": "active",
+      "published_at": "2026-06-30T08:40:55.530898Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "atlas-mind": {
+            "type": "http",
+            "url": "https://{ATLAS_MCP_URL}"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.anamneseai/anamnese",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://anamneseai.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-17T11:22:32.790539Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "anamnese": {
+            "type": "http",
+            "url": "https://anamneseai.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.askloop/askloop",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.askloop.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T08:14:32.327263Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "askloop": {
+            "type": "http",
+            "url": "https://api.askloop.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.asmhunter/asmhunter-mcp",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.asmhunter/asmhunter-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:16:18.082803Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "asmhunter-mcp": {
+            "command": "uvx",
+            "args": [
+              "asmhunter-mcp"
+            ],
+            "env": {
+              "ASMHUNTER_TOKEN": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.aspirelearning/mcp",
+      "version": "0.0.3",
+      "transport": "streamable-http",
+      "auth_mode": "header-nonsecret",
+      "source_url": "https://mcp.aspirelearning.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-06T08:49:35.487917Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.aspirelearning.app/mcp",
+            "headers": {
+              "X-Auth": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.aveiro/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.aveiro.app/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T09:22:55.411442Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://www.aveiro.app/api/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.bauta/bauta",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bauta.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T22:42:59.790661Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bauta": {
+            "type": "http",
+            "url": "https://bauta.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.blip-board/blipboard",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://blip-board.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T13:02:48.379715Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "blipboard": {
+            "type": "http",
+            "url": "https://blip-board.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.businys/mcp-server",
+      "version": "1.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.businys/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-04-02T16:47:23.627321Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@businys/mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cannonstudio/cannon-studio",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.cannonstudio.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-15T13:02:09.340677Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cannon-studio": {
+            "type": "http",
+            "url": "https://www.cannonstudio.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cardog/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cardog.io/mcp?api_key={api_key}",
+      "registry_status": "active",
+      "published_at": "2026-03-21T00:39:25.726542Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.cardog.io/mcp?api_key={api_key}"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cellarion/cellarion",
+      "version": "1.82.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cellarion.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T18:34:09.625947Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cellarion": {
+            "type": "http",
+            "url": "https://cellarion.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cellarion/wine-registry",
+      "version": "1.82.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cellarion.app/api/mcp/public",
+      "registry_status": "active",
+      "published_at": "2026-07-18T18:31:14.140848Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wine-registry": {
+            "type": "http",
+            "url": "https://cellarion.app/api/mcp/public"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.certman/server",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.certman.app",
+      "registry_status": "active",
+      "published_at": "2026-02-08T00:10:32.652705Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "type": "http",
+            "url": "https://mcp.certman.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cleanor/cleanor",
+      "version": "0.6.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cleanor.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T19:57:06.696306Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cleanor": {
+            "type": "http",
+            "url": "https://mcp.cleanor.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.clearpolicy/clearpolicy",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.clearpolicy.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-01T03:48:14.959054Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "clearpolicy": {
+            "type": "http",
+            "url": "https://api.clearpolicy.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.clicon/lotus",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://lotus.clicon.app/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-04-30T18:42:40.711707Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lotus": {
+            "type": "http",
+            "url": "https://lotus.clicon.app/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cloudmindmaps/mindmaps",
+      "version": "1.1.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.cloudmindmaps/mindmaps",
+      "registry_status": "active",
+      "published_at": "2026-07-07T05:53:06.596802Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mindmaps": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "cloudmindmaps-mcp"
+            ],
+            "env": {
+              "CLOUDMINDMAPS_API_KEY": "${VALUE}",
+              "CLOUDMINDMAPS_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cnvs/whiteboard",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cnvs.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T18:01:23.940241Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "whiteboard": {
+            "type": "http",
+            "url": "https://cnvs.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.contendeo/contendeo",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://contendeo.app/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-04-22T12:54:41.214342Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "contendeo": {
+            "type": "http",
+            "url": "https://contendeo.app/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.cooperpetcare.www/cooper",
+      "version": "0.6.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.cooperpetcare.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T05:20:22.294308Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cooper": {
+            "type": "http",
+            "url": "https://www.cooperpetcare.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.crawlie/crawlie",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://crawlie.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T00:13:54.470347Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "crawlie": {
+            "type": "http",
+            "url": "https://crawlie.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.dealermax/public-search",
+      "version": "1.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.dealermax.app/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-06-28T13:31:06.540529Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "public-search": {
+            "type": "http",
+            "url": "https://mcp.dealermax.app/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.decibelshield/decibel-shield",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://decibelshield.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T04:42:15.472519Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "decibel-shield": {
+            "type": "http",
+            "url": "https://decibelshield.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.desktopcommander/remote-desktop-commander",
+      "version": "1.0.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.desktopcommander.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T20:01:32.244472Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "remote-desktop-commander": {
+            "type": "http",
+            "url": "https://mcp.desktopcommander.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.deviceshelf/deviceshelf-server",
+      "version": "1.6.22",
+      "transport": "streamable-http",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.deviceshelf/deviceshelf-server",
+      "registry_status": "active",
+      "published_at": "2026-07-19T21:06:15.818161Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "deviceshelf-server": {
+            "command": "docker",
+            "args": [
+              "run",
+              "-i",
+              "--rm",
+              "ghcr.io/wealthwallet/deviceshelf-server:1.6.22"
+            ],
+            "env": {
+              "DEVICESHELF_API_PORT": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.docwand/pdf",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.docwand.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T19:21:09.872611Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pdf": {
+            "type": "http",
+            "url": "https://mcp.docwand.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.easykanb/easykanban",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://easykanb.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T14:40:25.872606Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "easykanban": {
+            "type": "http",
+            "url": "https://easykanb.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.edgelock/journal",
+      "version": "0.5.7",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.edgelock.app",
+      "registry_status": "active",
+      "published_at": "2026-06-15T21:24:25.919297Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "journal": {
+            "type": "http",
+            "url": "https://mcp.edgelock.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.elasticflow/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.elasticflow.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T11:26:11.726579Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.elasticflow.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.eurocomply/compliance",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://eurocomply.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T19:24:21.431355Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "compliance": {
+            "type": "http",
+            "url": "https://eurocomply.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.eurolytics/eurolytics",
+      "version": "2.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://eurolytics.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T05:10:58.068927Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "eurolytics": {
+            "type": "http",
+            "url": "https://eurolytics.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.everpop/everpop",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://everpop.app/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T00:52:37.584469Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "everpop": {
+            "type": "http",
+            "url": "https://everpop.app/api/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.evlek/mcp-server",
+      "version": "1.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://evlek.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-13T02:09:08.746024Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://evlek.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.flaim/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.flaim.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-04T15:07:07.728989Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.flaim.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.fluentive/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.fluentive.app",
+      "registry_status": "active",
+      "published_at": "2026-06-23T09:01:53.306261Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.fluentive.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.forgeengine/forge",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mmvdabzadclebfxyzudg.supabase.co/functions/v1/forge-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T03:54:21.031236Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "forge": {
+            "type": "http",
+            "url": "https://mmvdabzadclebfxyzudg.supabase.co/functions/v1/forge-mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.fryd/mcp-server",
+      "version": "1.0.10",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.fryd.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-29T09:00:27.77485Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.fryd.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.ganty/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ganty.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-03T08:13:39.446652Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://ganty.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.getcallme/call-me",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://getcallme.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T02:17:00.685442Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "call-me": {
+            "type": "http",
+            "url": "https://getcallme.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.getdialer/dialer",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://getdialer.app/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-09T00:16:49.107843Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dialer": {
+            "type": "http",
+            "url": "https://getdialer.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.getquieta/quieta-mcp",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://getquieta.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-13T22:24:16.714393Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "quieta-mcp": {
+            "type": "http",
+            "url": "https://getquieta.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.getsalta/salta",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.getsalta.app",
+      "registry_status": "active",
+      "published_at": "2026-06-25T12:08:05.173009Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "salta": {
+            "type": "http",
+            "url": "https://mcp.getsalta.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.glif/glif",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://glif.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T12:54:14.417372Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "glif": {
+            "type": "http",
+            "url": "https://glif.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.goshipyard/shipyard",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://goshipyard.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T00:24:45.690925Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "shipyard": {
+            "type": "http",
+            "url": "https://goshipyard.app/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.govauctions/govauctions",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://govauctions.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T04:01:37.016801Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "govauctions": {
+            "type": "http",
+            "url": "https://govauctions.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.havnre/havn",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.havnre.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T16:30:48.553614Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "havn": {
+            "type": "http",
+            "url": "https://mcp.havnre.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.himalayas/mcp",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.himalayas.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-02T02:05:20.529527Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.himalayas.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.hoaster/hoaster",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://hoaster.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-27T08:09:09.256526Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hoaster": {
+            "type": "http",
+            "url": "https://hoaster.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.hoodex/hoodex",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://hoodex.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T21:17:25.84048Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hoodex": {
+            "type": "http",
+            "url": "https://hoodex.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.humanform/mcp",
+      "version": "0.1.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.humanform/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-05T17:34:40.019542Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@humanform/mcp"
+            ],
+            "env": {
+              "HUMANFORM_API_KEY": "${VALUE}",
+              "HUMANFORM_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.humantaste/taste-mcp",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.humantaste.app/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-05-21T22:57:12.702814Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "taste-mcp": {
+            "type": "http",
+            "url": "https://api.humantaste.app/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.immoapi/immoapi",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://immoapi.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-06T21:07:11.75254Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "immoapi": {
+            "type": "http",
+            "url": "https://immoapi.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.indicia/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.indicia.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T19:21:47.486526Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.indicia.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.interbang/interbang",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://interbang.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T04:23:17.881378Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "interbang": {
+            "type": "http",
+            "url": "https://interbang.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.ip/ipinfo",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ip.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T16:08:10.228974Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ipinfo": {
+            "type": "http",
+            "url": "https://ip.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.jadenote/jade-note",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.jadenote.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T06:03:00.010282Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jade-note": {
+            "type": "http",
+            "url": "https://api.jadenote.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.joinways/joinways",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.joinways.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T16:06:33.707377Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "joinways": {
+            "type": "http",
+            "url": "https://mcp.joinways.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.knowtis/knowtis",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.knowtis.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T05:57:32.570189Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "knowtis": {
+            "type": "http",
+            "url": "https://mcp.knowtis.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.lance/app-manager",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.lance.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T04:43:03.832934Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "app-manager": {
+            "type": "http",
+            "url": "https://api.lance.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.learnwithagents/learn-with-agents",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://learnwithagents.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-01T16:47:28.550703Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "learn-with-agents": {
+            "type": "http",
+            "url": "https://learnwithagents.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.lightgen/lightgen",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://lightgen.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T12:04:00.365999Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lightgen": {
+            "type": "http",
+            "url": "https://lightgen.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.linear/linear",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://mcp.linear.app/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-18T15:51:15.598862Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "linear": {
+            "type": "sse",
+            "url": "https://mcp.linear.app/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.listentosadhu/corpus",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.listentosadhu.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T18:18:38.646499Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "corpus": {
+            "type": "http",
+            "url": "https://mcp.listentosadhu.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.livtakt/livtakt",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://livtakt.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T11:23:14.733694Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "livtakt": {
+            "type": "http",
+            "url": "https://livtakt.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.locize.mcp/server",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.locize.app",
+      "registry_status": "active",
+      "published_at": "2026-06-12T11:24:50.794241Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "type": "http",
+            "url": "https://mcp.locize.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.lucid.mcp/lucid",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.lucid.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T19:47:03.01253Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lucid": {
+            "type": "http",
+            "url": "https://mcp.lucid.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.mailstream/mailstream",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://my.mailstream.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T19:11:44.63133Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mailstream": {
+            "type": "http",
+            "url": "https://my.mailstream.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.marketgenius/mcp",
+      "version": "2026-07-25",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://marketgenius.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T07:19:45.693258Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://marketgenius.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.mashop/mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.mashop.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T17:41:03.793724Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.mashop.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.meepo/studio",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://meepo-mcp-server.meepo.app/sse",
+      "registry_status": "active",
+      "published_at": "2026-05-28T03:19:31.13807Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "studio": {
+            "type": "sse",
+            "url": "https://meepo-mcp-server.meepo.app/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.memol/memol",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://memol.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-03T08:31:35.985438Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "memol": {
+            "type": "http",
+            "url": "https://memol.app/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.mermail/mcp",
+      "version": "1.1.3",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://console.mermail.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T15:24:20.169817Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://console.mermail.app/mcp",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.metadock/metadock",
+      "version": "1.3.14",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.metadock/metadock",
+      "registry_status": "active",
+      "published_at": "2026-07-16T11:00:30.419325Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "metadock": {
+            "command": "https://github.com/metadockapp/metadock-mcp/releases/download/v1.3.14/metadock-1.3.14.mcpb",
+            "args": []
+          }
+        }
+      }
+    },
+    {
+      "name": "app.mhai/knihajizd",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://knihajizd.mhai.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T17:59:59.999944Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "knihajizd": {
+            "type": "http",
+            "url": "https://knihajizd.mhai.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.miromiro/miromiro",
+      "version": "0.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://miromiro.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T18:11:34.934065Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "miromiro": {
+            "type": "http",
+            "url": "https://miromiro.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.myghosts/myghosts",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://myghosts.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-26T13:01:45.491036Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "myghosts": {
+            "type": "http",
+            "url": "https://myghosts.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.nausika/mcp",
+      "version": "0.1.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.nausika.app",
+      "registry_status": "active",
+      "published_at": "2026-05-19T06:32:26.906756Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.nausika.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.netlify.gleaming-cassata-d41682/lion-mcp",
+      "version": "1.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://gleaming-cassata-d41682.netlify.app/api/mcp?src=mcpregistry_domain_v1_1",
+      "registry_status": "active",
+      "published_at": "2026-05-28T11:16:45.359233Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lion-mcp": {
+            "type": "http",
+            "url": "https://gleaming-cassata-d41682.netlify.app/api/mcp?src=mcpregistry_domain_v1_1"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.neurorank/mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://www.neurorank.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-18T12:54:10.761767Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://www.neurorank.app/mcp",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.newsmind/mcp",
+      "version": "0.25.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://newsmind.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T13:28:48.193379Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://newsmind.app/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.noemic/noemic",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://noemic.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T03:33:29.337014Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "noemic": {
+            "type": "http",
+            "url": "https://noemic.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.novumos/novumos",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "static-credential",
+      "source_url": "https://novumos.app/v1/mcp/sse",
+      "registry_status": "active",
+      "published_at": "2026-07-02T22:46:57.822974Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "novumos": {
+            "type": "sse",
+            "url": "https://novumos.app/v1/mcp/sse",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.octopad/octopad",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.octopad.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-06T16:34:38.566961Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "octopad": {
+            "type": "http",
+            "url": "https://mcp.octopad.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.octotrip/flights",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.octotrip.app/flights/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T13:56:25.893262Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "flights": {
+            "type": "http",
+            "url": "https://mcp.octotrip.app/flights/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.octotrip/rental-cars",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.octotrip.app/rental-cars/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T13:56:17.988893Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rental-cars": {
+            "type": "http",
+            "url": "https://mcp.octotrip.app/rental-cars/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.odyssey365/mcp-server",
+      "version": "0.6.4",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.odyssey365/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-07-15T08:40:46.118158Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@odyssey365/mcp-server"
+            ],
+            "env": {
+              "ODYSSEY_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.ofia/latex",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://ofia.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T15:49:29.554803Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "latex": {
+            "type": "http",
+            "url": "https://ofia.app/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.onehaus/haus",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.onehaus.app",
+      "registry_status": "active",
+      "published_at": "2026-07-11T16:57:34.236489Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "haus": {
+            "type": "http",
+            "url": "https://mcp.onehaus.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.openclip/openclip",
+      "version": "1.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://openclip.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T08:42:41.484531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "openclip": {
+            "type": "http",
+            "url": "https://openclip.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.opendealer/mcp",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.opendealer.app/rpc",
+      "registry_status": "active",
+      "published_at": "2026-07-02T21:45:53.023827Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.opendealer.app/rpc",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.ottodata/otto",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.ottodata.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T18:33:00.849111Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "otto": {
+            "type": "http",
+            "url": "https://api.ottodata.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.owlx/owlx",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://owlx.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T19:11:43.620403Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "owlx": {
+            "type": "http",
+            "url": "https://owlx.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.paichart/mcp-hub",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://paichart.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-23T06:13:08.197978Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-hub": {
+            "type": "http",
+            "url": "https://paichart.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.papertext.app/papertext-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.papertext.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-15T20:26:04.541639Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "papertext-mcp": {
+            "type": "http",
+            "url": "https://app.papertext.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.peil/peil-mcp",
+      "version": "0.1.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.peil/peil-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T15:01:06.019167Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "peil-mcp": {
+            "command": "uvx",
+            "args": [
+              "peil-mcp"
+            ],
+            "env": {
+              "PEIL_API_KEY": "${VALUE}",
+              "PEIL_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.penlog/penlog",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.penlog.app",
+      "registry_status": "active",
+      "published_at": "2026-07-11T21:44:16.442032Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "penlog": {
+            "type": "http",
+            "url": "https://mcp.penlog.app"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.percher/percher",
+      "version": "0.6.15",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.percher.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-01T20:14:53.423756Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "percher": {
+            "type": "http",
+            "url": "https://mcp.percher.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.pinsuite/pinsuite",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://pinsuite.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T06:11:27.943106Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pinsuite": {
+            "type": "http",
+            "url": "https://pinsuite.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.podstow/podstow",
+      "version": "1.0.3233",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.podstow.app/",
+      "registry_status": "active",
+      "published_at": "2026-06-07T20:36:11.784416Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "podstow": {
+            "type": "http",
+            "url": "https://mcp.podstow.app/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.potto/potto-japan",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://potto.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T02:36:35.277112Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "potto-japan": {
+            "type": "http",
+            "url": "https://potto.app/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.promptfax/promptfax",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://promptfax.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-30T17:57:28.233218Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "promptfax": {
+            "type": "http",
+            "url": "https://promptfax.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.pulltrader/seller-economics",
+      "version": "0.2.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.pulltrader.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T04:56:13.076736Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "seller-economics": {
+            "type": "http",
+            "url": "https://mcp.pulltrader.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.qwady/borough",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://borough.qwady.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-20T16:40:27.384696Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "borough": {
+            "type": "http",
+            "url": "https://borough.qwady.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.racecalendar/f1",
+      "version": "2.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://racecalendar.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T22:48:46.432128Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "f1": {
+            "type": "http",
+            "url": "https://racecalendar.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.railway.up.airy-enthusiasm-production/ai-commerce",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://airy-enthusiasm-production.up.railway.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T11:54:33.315358Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-commerce": {
+            "type": "http",
+            "url": "https://airy-enthusiasm-production.up.railway.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.railway.up.engine-production-3bdc/vhgengine",
+      "version": "2.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://engine-production-3bdc.up.railway.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T14:34:07.468851Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vhgengine": {
+            "type": "http",
+            "url": "https://engine-production-3bdc.up.railway.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.raster/raster",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.raster.app/",
+      "registry_status": "active",
+      "published_at": "2026-06-30T04:43:51.415708Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "raster": {
+            "type": "http",
+            "url": "https://mcp.raster.app/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.readwithleaf/leaf",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.readwithleaf.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-03T08:58:13.087717Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "leaf": {
+            "type": "http",
+            "url": "https://mcp.readwithleaf.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.reassign/reassign",
+      "version": "1.0.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://reassign.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T22:03:04.294142Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "reassign": {
+            "type": "http",
+            "url": "https://reassign.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.recao/recao-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://recao.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T08:57:37.279027Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "recao-mcp": {
+            "type": "http",
+            "url": "https://recao.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.recordo.api/calories-club",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.recordo.com/api/mcp/calories/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-03T13:02:02.381026Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "calories-club": {
+            "type": "http",
+            "url": "https://api.recordo.com/api/mcp/calories/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.recordo.api/recordo",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.recordo.com/api/mcp/adhd/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-03T11:40:43.242492Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "recordo": {
+            "type": "http",
+            "url": "https://api.recordo.com/api/mcp/adhd/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.remoote/remote-jobs",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.remoote.app/remoote/agents/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T07:53:25.435779Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "remote-jobs": {
+            "type": "http",
+            "url": "https://api.remoote.app/remoote/agents/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.repage/repage",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.repage.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-19T09:23:22.188613Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "repage": {
+            "type": "http",
+            "url": "https://www.repage.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.replit.austere-unsteady-pdf/free-agent-economy-lab",
+      "version": "0.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://austere-unsteady-pdf.replit.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T18:00:50.340891Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "free-agent-economy-lab": {
+            "type": "http",
+            "url": "https://austere-unsteady-pdf.replit.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.resumequick/resumequick",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.resumequick.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T05:20:35.414059Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "resumequick": {
+            "type": "http",
+            "url": "https://mcp.resumequick.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.roamward/roamward-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.roamward.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T00:24:51.929202Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "roamward-mcp": {
+            "type": "http",
+            "url": "https://www.roamward.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.robohub/robohub",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://robohub.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T15:12:54.076322Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "robohub": {
+            "type": "http",
+            "url": "https://robohub.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.roughsketch/roughsketch",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://roughsketch.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T15:52:14.176258Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "roughsketch": {
+            "type": "http",
+            "url": "https://roughsketch.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.saber.mcp/saber",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.saber.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-03T14:08:31.798835Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "saber": {
+            "type": "http",
+            "url": "https://mcp.saber.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.savedthat/savedthat",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://savedthat.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T20:55:13.207246Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "savedthat": {
+            "type": "http",
+            "url": "https://savedthat.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.scanbim/scanbim-mcp",
+      "version": "1.0.6",
+      "transport": "streamable-http",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.scanbim/scanbim-mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-12T22:42:00.420458Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "scanbim-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@scanbim-labs/scanbim-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app.scfcontrolsplatform/mcp-server-scf",
+      "version": "2.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.scfcontrolsplatform/mcp-server-scf",
+      "registry_status": "active",
+      "published_at": "2026-07-17T15:41:35.354541Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server-scf": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "mcp-server-scf"
+            ],
+            "env": {
+              "SCF_API_KEY": "${VALUE}",
+              "SCF_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.seatcanvas/seatcanvas",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.seatcanvas.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-20T00:31:24.335383Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "seatcanvas": {
+            "type": "http",
+            "url": "https://www.seatcanvas.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.selis.mcp/pmo",
+      "version": "0.2.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.selis.app/tmis/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-27T13:27:44.913104Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pmo": {
+            "type": "http",
+            "url": "https://mcp.selis.app/tmis/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.sendhey/sendhey",
+      "version": "0.11.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://sendhey.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T14:51:20.556502Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sendhey": {
+            "type": "http",
+            "url": "https://sendhey.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.sentinelx/sentinelx",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.sentinelx.app/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-18T22:19:54.404256Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sentinelx": {
+            "type": "http",
+            "url": "https://mcp.sentinelx.app/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.sharemypage/sharemypage",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://sharemypage.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T10:12:03.854934Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sharemypage": {
+            "type": "http",
+            "url": "https://sharemypage.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.somvia/health",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://somvia.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T01:25:55.415413Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "health": {
+            "type": "http",
+            "url": "https://somvia.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.sorsa/sorsa",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://sorsa.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:16:18.601774Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sorsa": {
+            "type": "http",
+            "url": "https://sorsa.app/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.spoonjoy/spoonjoy",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://spoonjoy.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-23T17:27:12.129311Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "spoonjoy": {
+            "type": "http",
+            "url": "https://spoonjoy.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.steadywrk/mcp-dispatch",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://steadywrk.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T05:59:31.47189Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-dispatch": {
+            "type": "http",
+            "url": "https://steadywrk.app/api/mcp",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.steep/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.steep.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-22T14:19:33.093871Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.steep.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.strikemission/surf-trip-planner",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.strikemission.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T01:44:22.86282Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "surf-trip-planner": {
+            "type": "http",
+            "url": "https://www.strikemission.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.studio99/calligraphy",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.studio99.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T18:17:19.993297Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "calligraphy": {
+            "type": "http",
+            "url": "https://mcp.studio99.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.subdomain/subdomains",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.subdomain.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T13:49:06.674575Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "subdomains": {
+            "type": "http",
+            "url": "https://api.subdomain.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.superdocs/superdocs",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.superdocs.app/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-07-11T09:13:56.904234Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "superdocs": {
+            "type": "http",
+            "url": "https://api.superdocs.app/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.surewhynot.quantum-artificer/quantum-artificer",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://quantum-artificer.surewhynot.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T16:42:16.628082Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "quantum-artificer": {
+            "type": "http",
+            "url": "https://quantum-artificer.surewhynot.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.surewhynot.quartermaster/quartermaster",
+      "version": "1.6.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://quartermaster.surewhynot.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T07:31:49.059357Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "quartermaster": {
+            "type": "http",
+            "url": "https://quartermaster.surewhynot.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.swissdeals/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.swissdeals.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-26T06:01:21.589346Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.swissdeals.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.takehub/mcp",
+      "version": "1.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.takehub/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-04T14:54:42.077035Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@takehub/mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app.tanjiren/tanjiren-mcp",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.tanjiren.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-29T23:56:45.769332Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tanjiren-mcp": {
+            "type": "http",
+            "url": "https://mcp.tanjiren.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.tbit/tbit",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.tbit.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T12:23:27.055101Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tbit": {
+            "type": "http",
+            "url": "https://api.tbit.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.thesignup/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://thesignup.app/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T05:36:42.869549Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://thesignup.app/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.thoughtspot/mcp-server",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://agent.thoughtspot.app/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-17T20:15:17.362825Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://agent.thoughtspot.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.tinkrr/intelligence",
+      "version": "2.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tinkrr-api.tinkrr.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-30T12:28:28.637572Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "intelligence": {
+            "type": "http",
+            "url": "https://tinkrr-api.tinkrr.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.toofi/dental-planning",
+      "version": "2026.5.12",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://toofi.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-11T22:50:24.537868Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dental-planning": {
+            "type": "http",
+            "url": "https://toofi.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.toolsnap/toolsnap-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.toolsnap.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T20:31:03.777052Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "toolsnap-mcp": {
+            "type": "http",
+            "url": "https://mcp.toolsnap.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.tradeit/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.tradeit.app/mcp",
+      "registry_status": "active",
+      "published_at": "2025-12-16T04:32:08.51866Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.tradeit.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.triplogistics/trip-logistics-assistant",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.triplogistics.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T08:18:58.196493Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trip-logistics-assistant": {
+            "type": "http",
+            "url": "https://api.triplogistics.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.trustrails/server",
+      "version": "1.0.7",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.trustrails/server",
+      "registry_status": "active",
+      "published_at": "2026-02-21T18:01:09.883723Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@trustrails/mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app.trustydata/trustydata",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.trustydata.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T22:04:58.447197Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trustydata": {
+            "type": "http",
+            "url": "https://mcp.trustydata.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.trysonar/sonar",
+      "version": "0.6.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.trysonar/sonar",
+      "registry_status": "active",
+      "published_at": "2026-07-14T09:03:50.32655Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sonar": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@sonarapp/mcp"
+            ],
+            "env": {
+              "SONAR_API_KEY": "${VALUE}",
+              "SONAR_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.twiceshy/twiceshy",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.twiceshy.app",
+      "registry_status": "active",
+      "published_at": "2026-07-07T21:06:10.254339Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "twiceshy": {
+            "type": "http",
+            "url": "https://api.twiceshy.app",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.undisk.mcp/stdio-proxy",
+      "version": "0.46.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.undisk.mcp/stdio-proxy",
+      "registry_status": "active",
+      "published_at": "2026-04-17T22:02:08.475721Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "stdio-proxy": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@undisk-mcp/stdio-proxy"
+            ],
+            "env": {
+              "UNDISK_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.uploadcheck/uploadcheck",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.uploadcheck/uploadcheck",
+      "registry_status": "active",
+      "published_at": "2026-06-10T22:24:54.074924Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uploadcheck": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@drantoniou/uploadcheck-mcp"
+            ],
+            "env": {
+              "UPLOADCHECK_API_BASE_URL": "${VALUE}",
+              "UPLOADCHECK_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.vayapin/mcp",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=app.vayapin/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-20T01:24:48.256119Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@vayacore/mcp"
+            ],
+            "env": {
+              "VAYAPIN_PAT": "${VALUE}",
+              "VAYAPIN_MCP_SLICE": "${VALUE}",
+              "VAYAPIN_MCP_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.vercel.agent-svg-registry/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent-svg-registry.vercel.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-28T13:19:53.38587Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://agent-svg-registry.vercel.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.vibecom/growth",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.vibecom.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-09T05:23:54.306364Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "growth": {
+            "type": "http",
+            "url": "https://www.vibecom.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.warplink/warplink",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.warplink.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T15:36:58.129347Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "warplink": {
+            "type": "http",
+            "url": "https://api.warplink.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.web.mindset-502113/mindset",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mindset-mcp-183316982259.europe-west2.run.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T17:46:00.689608Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mindset": {
+            "type": "http",
+            "url": "https://mindset-mcp-183316982259.europe-west2.run.app/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wisepenny/wise-penny",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.wisepenny.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T22:00:42.283284Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wise-penny": {
+            "type": "http",
+            "url": "https://www.wisepenny.app/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/algeria-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-dz.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:09:59.822997Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "algeria-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-dz.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/argentina-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-ar.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T23:08:07.534797Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "argentina-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-ar.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/argentina-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ar.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:43:31.338534Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "argentina-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ar.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/australia-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-au.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:40:05.361717Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "australia-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-au.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/australia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-au.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:13.30657Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "australia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-au.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/austria-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-at.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:08.924281Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "austria-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-at.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/bahrain-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-bh.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:51.341424Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bahrain-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-bh.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/bangladesh-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-bd.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:18.378297Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bangladesh-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-bd.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/belgium-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-be.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T07:48:59.969009Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "belgium-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-be.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/belgium-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-be.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:05.015534Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "belgium-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-be.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/brazil-invoice-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-br.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T04:28:49.525135Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "brazil-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-br.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/brazil-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-br.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T16:15:39.47026Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "brazil-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-br.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/bulgaria-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-bg.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:45.045261Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bulgaria-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-bg.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/canada-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ca.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:14.625195Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "canada-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ca.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/chile-invoice-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-cl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T04:08:47.554137Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chile-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-cl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/chile-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-cl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:44:58.414422Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chile-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-cl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/colombia-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-co.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T10:21:42.16013Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "colombia-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-co.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/colombia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-co.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:44:13.732041Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "colombia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-co.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/costa-rica-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-cr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T05:16:16.57932Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "costa-rica-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-cr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/costa-rica-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-cr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:10:01.242908Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "costa-rica-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-cr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/croatia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-hr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:45.729382Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "croatia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-hr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/cyprus-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-cy.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:10:03.277927Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cyprus-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-cy.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/czechia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-cz.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:15.859505Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "czechia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-cz.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/denmark-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-dk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:57:59.514636Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "denmark-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-dk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/denmark-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-dk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:11.431106Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "denmark-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-dk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/digital-goods-mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mor.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T11:47:32.973827Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "digital-goods-mcp": {
+            "type": "http",
+            "url": "https://mor.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/dominican-republic-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-do.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T09:45:33.428942Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dominican-republic-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-do.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/ecuador-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-ec.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T23:05:43.17924Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ecuador-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-ec.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/egypt-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-eg.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:17.732451Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "egypt-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-eg.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/estonia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ee.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:49.244242Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "estonia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ee.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/finland-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-fi.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:58:02.003639Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "finland-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-fi.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/finland-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-fi.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:12.660904Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "finland-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-fi.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/france-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-fr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:40:04.710706Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "france-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-fr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/france-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-fr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:05.659113Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "france-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-fr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/georgia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ge.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:09:59.150882Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "georgia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ge.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/germany-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-de.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:40:03.904931Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "germany-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-de.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/germany-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-de.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:04.373811Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "germany-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-de.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/ghana-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-gh.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:02.462207Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ghana-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-gh.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/global-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-global.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:43:42.152717Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "global-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-global.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/greece-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-gr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:47:21.778229Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "greece-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-gr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/greece-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-gr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:43.698205Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "greece-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-gr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/guatemala-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-gt.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:10:00.527045Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "guatemala-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-gt.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/hong-kong-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-hk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:15.236345Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hong-kong-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-hk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/hungary-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-hu.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T23:08:06.84331Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hungary-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-hu.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/hungary-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-hu.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:17.124814Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hungary-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-hu.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/india-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-in.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T20:40:19.683674Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "india-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-in.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/india-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-in.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:36:49.023008Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "india-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-in.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/india-payments-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-in.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T00:42:28.589278Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "india-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-in.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/indonesia-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-id.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:36:49.61561Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "indonesia-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-id.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/indonesia-payments-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-id.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T00:42:29.260942Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "indonesia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-id.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/ireland-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ie.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:12.053603Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ireland-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ie.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/israel-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-il.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:49.980925Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "israel-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-il.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/italy-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-it.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:04:22.493351Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "italy-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-it.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/italy-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-it.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T07:49:00.576416Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "italy-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-it.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/italy-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-it.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:07.083364Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "italy-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-it.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/ivory-coast-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ci.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:57.505154Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ivory-coast-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ci.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/japan-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-jp.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:43:40.847269Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "japan-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-jp.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/japan-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-jp.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T13:17:04.386183Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "japan-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-jp.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/jordan-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-jo.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:53.42653Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jordan-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-jo.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/kazakhstan-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-kz.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:09:58.483431Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kazakhstan-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-kz.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/kenya-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ke.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:01.816879Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kenya-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ke.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/korea-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-kr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:05:48.609796Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "korea-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-kr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/korea-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-kr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T15:00:19.669176Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "korea-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-kr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/kuwait-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-kw.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:50.654143Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kuwait-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-kw.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/latam-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-latam.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:43:41.510786Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "latam-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-latam.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/latvia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-lv.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:48.491199Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "latvia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-lv.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/lithuania-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-lt.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:47.771642Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lithuania-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-lt.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/luxembourg-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-lu.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:58:00.749932Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "luxembourg-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-lu.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/luxembourg-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-lu.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:44.377378Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "luxembourg-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-lu.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/malaysia-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-my.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:47:23.042666Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "malaysia-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-my.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/malaysia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-my.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T16:37:44.477794Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "malaysia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-my.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/malta-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-mt.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:10:02.610429Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "malta-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-mt.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/mexico-invoice-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-mx.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T04:00:50.599029Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mexico-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-mx.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/mexico-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-mx.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:42:49.591105Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mexico-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-mx.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/nepal-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-np.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:09:57.796369Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nepal-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-np.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/netherlands-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-nl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:58:00.1182Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "netherlands-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-nl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/netherlands-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-nl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:47:08.17514Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "netherlands-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-nl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/new-zealand-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-nz.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:13.982601Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "new-zealand-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-nz.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/nigeria-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-ng.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T00:40:28.368395Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nigeria-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-ng.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/nigeria-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ng.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:47:48.675497Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nigeria-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ng.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/norway-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-no.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:57:58.881928Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "norway-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-no.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/norway-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-no.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:10.794093Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "norway-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-no.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/oman-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-om.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:52.74276Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "oman-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-om.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/pakistan-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-pk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:19.015872Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pakistan-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-pk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/paraguay-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-py.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T07:48:59.345754Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "paraguay-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-py.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/peru-invoice-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-pe.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T04:28:50.182258Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "peru-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-pe.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/peru-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-pe.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:45:40.257843Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "peru-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-pe.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/philippines-payments-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ph.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T00:42:29.968043Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "philippines-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ph.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/poland-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-pl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T21:05:15.118411Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "poland-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-pl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/poland-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-pl.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:03.742383Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "poland-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-pl.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/portugal-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-pt.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:08.300029Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "portugal-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-pt.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/qatar-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-qa.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:52.038589Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "qatar-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-qa.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/romania-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-ro.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T20:57:10.246315Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "romania-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-ro.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/romania-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ro.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:16.51605Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "romania-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ro.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/rwanda-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-rw.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:55.458816Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rwanda-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-rw.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/saudi-arabia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-sa.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:00.509615Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "saudi-arabia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-sa.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/saudi-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-sa.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:04:23.147071Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "saudi-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-sa.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/senegal-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-sn.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:56.773485Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "senegal-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-sn.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/serbia-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-rs.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:47:22.40095Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "serbia-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-rs.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/singapore-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-sg.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:47:08.886657Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "singapore-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-sg.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/slovakia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-sk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:46.37889Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "slovakia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-sk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/slovenia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-si.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:47.060823Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "slovenia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-si.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/south-africa-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-za.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:03.127023Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "south-africa-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-za.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/spain-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-es.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:07.696404Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "spain-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-es.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/sweden-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-se.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T08:58:01.370835Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sweden-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-se.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/sweden-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-se.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:10.169991Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sweden-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-se.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/switzerland-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ch.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T02:42:09.548928Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "switzerland-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ch.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/taiwan-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-tw.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T21:05:15.747382Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "taiwan-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-tw.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/taiwan-payments-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T11:40:50.625067Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "taiwan-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/tanzania-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-tz.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:54.120004Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tanzania-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-tz.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/thailand-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-th.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T07:48:58.137476Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "thailand-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-th.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/thailand-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-th.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T16:32:53.326334Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "thailand-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-th.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/turkey-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-tr.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:36:59.840398Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "turkey-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-tr.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uae-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ae.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T21:37:01.162302Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uae-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ae.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uganda-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ug.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:54.795877Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uganda-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ug.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uk-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-uk.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T06:36:48.429591Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uk-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-uk.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uk-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-gb.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:47:05.284802Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uk-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-gb.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/ukraine-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-ua.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:09:57.107756Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ukraine-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-ua.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uruguay-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-uy.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:06:06.024466Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uruguay-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-uy.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/uruguay-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-uy.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T05:10:01.92738Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uruguay-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-uy.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/usa-logistics-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://logi-us.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T22:51:23.094475Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "usa-logistics-mcp": {
+            "type": "http",
+            "url": "https://logi-us.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/usa-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-us.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T18:46:23.117246Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "usa-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-us.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/vietnam-invoice-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inv-vn.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T07:48:58.72769Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vietnam-invoice-mcp": {
+            "type": "http",
+            "url": "https://inv-vn.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/vietnam-payments-mcp",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-vn.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T00:42:27.970437Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vietnam-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-vn.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.wishpool/zambia-payments-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-zm.wishpool.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T04:17:56.10777Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "zambia-payments-mcp": {
+            "type": "http",
+            "url": "https://mcp-zm.wishpool.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.work-handler/work-handler",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://work-handler.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T14:32:07.02242Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "work-handler": {
+            "type": "http",
+            "url": "https://work-handler.app/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.worldmonitor/mcp",
+      "version": "1.13.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://worldmonitor.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-05T12:27:24.160068Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://worldmonitor.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.xtiles/xtiles-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.xtiles.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T08:41:18.085573Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "xtiles-mcp": {
+            "type": "http",
+            "url": "https://mcp.xtiles.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.ytbulktranscript/transcripts",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ytbulktranscript.app/mcp/{api_key}",
+      "registry_status": "active",
+      "published_at": "2026-07-20T11:29:39.141059Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "transcripts": {
+            "type": "http",
+            "url": "https://ytbulktranscript.app/mcp/{api_key}"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.zaklad/design-system",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://platform.zaklad.app/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-16T20:03:44.571942Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "design-system": {
+            "type": "http",
+            "url": "https://platform.zaklad.app/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "app.zenable/zenable",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.zenable.app/",
+      "registry_status": "active",
+      "published_at": "2025-09-28T22:41:39.996616Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "zenable": {
+            "type": "http",
+            "url": "https://mcp.zenable.app/"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.zooza/mcp-server",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.zooza.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T19:47:30.716616Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.zooza.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "app.zwier/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.zwier.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-25T21:51:20.254595Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.zwier.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.almanac/almanac",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.almanac.ar/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-01T17:09:19.226133Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "almanac": {
+            "type": "http",
+            "url": "https://mcp.almanac.ar/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.com.consignatarias/cattle-market",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.consignatarias.com.ar/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T19:18:07.298875Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cattle-market": {
+            "type": "http",
+            "url": "https://www.consignatarias.com.ar/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.com.muovi/mcp-server",
+      "version": "0.1.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.muovi.com.ar/",
+      "registry_status": "active",
+      "published_at": "2026-07-17T15:28:26.324243Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.muovi.com.ar/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.com.ninox/ninoxnet",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ninox.com.ar/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T16:23:34.334978Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ninoxnet": {
+            "type": "http",
+            "url": "https://mcp.ninox.com.ar/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.energetica/data",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://energetica.ar/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-29T22:04:08.994361Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "data": {
+            "type": "http",
+            "url": "https://energetica.ar/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ar.indicadores/empresas",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://indicadores.ar/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T13:09:27.165044Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "empresas": {
+            "type": "http",
+            "url": "https://indicadores.ar/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "art.allover/agentee",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://allover.art/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T15:27:17.530738Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentee": {
+            "type": "http",
+            "url": "https://allover.art/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "art.travel/mcp",
+      "version": "1.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.travel.art/",
+      "registry_status": "active",
+      "published_at": "2026-06-21T20:44:57.22838Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.travel.art/"
+          }
+        }
+      }
+    },
+    {
+      "name": "at.baeck/nginx-proxy-manager",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=at.baeck/nginx-proxy-manager",
+      "registry_status": "active",
+      "published_at": "2026-04-23T08:52:04.601905Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nginx-proxy-manager": {
+            "command": "uvx",
+            "args": [
+              "nginx-proxy-manager-mcp-full"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "at.designare/knowledge",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://designare.at/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-18T06:57:14.064319Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "knowledge": {
+            "type": "http",
+            "url": "https://designare.at/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "at.memebo/memeboat-mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://memebo.at/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T20:25:32.273065Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "memeboat-mcp": {
+            "type": "http",
+            "url": "https://memebo.at/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "at.uurl/bundler",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://uurl.at/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-03T05:32:51.237915Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bundler": {
+            "type": "http",
+            "url": "https://uurl.at/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.aiframework/governance-framework-generator",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aiframework.com.au/api/mcp.php",
+      "registry_status": "active",
+      "published_at": "2026-07-07T00:22:51.772201Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "governance-framework-generator": {
+            "type": "http",
+            "url": "https://aiframework.com.au/api/mcp.php"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.appgenie/compliance-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://compliance.appgenie.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-06T03:29:31.699236Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "compliance-mcp": {
+            "type": "http",
+            "url": "https://compliance.appgenie.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.ato-mcp/ato-mcp",
+      "version": "2.1.5",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.ato-mcp.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T03:10:28.044569Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ato-mcp": {
+            "type": "http",
+            "url": "https://api.ato-mcp.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.cameronwilson.camfeed/camfeed",
+      "version": "0.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://camfeed.cameronwilson.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T00:30:38.249402Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "camfeed": {
+            "type": "http",
+            "url": "https://camfeed.cameronwilson.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.casaintelligence/casa-property",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.casaintelligence.com.au/mcp/public/v1/messages",
+      "registry_status": "active",
+      "published_at": "2026-07-16T08:48:12.463215Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "casa-property": {
+            "type": "http",
+            "url": "https://api.casaintelligence.com.au/mcp/public/v1/messages"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.iknowthepilot/flight-deals",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://iknowthepilot.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-29T04:06:30.232987Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "flight-deals": {
+            "type": "http",
+            "url": "https://iknowthepilot.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.manageyourloans/mortgage-tools",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp-myl-oov7xgbxua-ts.a.run.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T02:59:32.356258Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mortgage-tools": {
+            "type": "http",
+            "url": "https://mcp-myl-oov7xgbxua-ts.a.run.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.rtopacks/rtopacks",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.rtopacks.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-19T05:55:13.499945Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rtopacks": {
+            "type": "http",
+            "url": "https://mcp.rtopacks.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.totalparks/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.totalparks.com.au/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T03:10:07.644507Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.totalparks.com.au/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.travellersgroup/agent",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent.travellersgroup.com.au/v1/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T05:20:22.736694Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent": {
+            "type": "http",
+            "url": "https://agent.travellersgroup.com.au/v1/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.trip-planner/camping-australia",
+      "version": "1.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.trip-planner.com.au/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T03:57:49.914617Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "camping-australia": {
+            "type": "http",
+            "url": "https://app.trip-planner.com.au/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "au.com.vividads/vivid-ads-commerce",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent.vividads.com.au/api/ucp/public/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T01:12:56.943087Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vivid-ads-commerce": {
+            "type": "http",
+            "url": "https://agent.vividads.com.au/api/ucp/public/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "aws.api.us-east-1.ecs-mcp/server",
+      "version": "1.0.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=aws.api.us-east-1.ecs-mcp/server",
+      "registry_status": "active",
+      "published_at": "2026-02-09T23:18:00.777188Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "command": "uvx",
+            "args": [
+              "mcp-proxy-for-aws"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "aws.api.us-east-1.eks-mcp/server",
+      "version": "1.0.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=aws.api.us-east-1.eks-mcp/server",
+      "registry_status": "active",
+      "published_at": "2026-01-29T16:45:51.075699Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "command": "uvx",
+            "args": [
+              "mcp-proxy-for-aws"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "be.vibedeploy/vibedeploy",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.vibedeploy.be/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-29T14:11:44.256946Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vibedeploy": {
+            "type": "http",
+            "url": "https://mcp.vibedeploy.be/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bid.scope/aec",
+      "version": "1.0.6",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://scope.bid/api/mcp/aec",
+      "registry_status": "active",
+      "published_at": "2026-07-13T22:54:22.124752Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aec": {
+            "type": "http",
+            "url": "https://scope.bid/api/mcp/aec"
+          }
+        }
+      }
+    },
+    {
+      "name": "bid.scope/claims",
+      "version": "1.0.6",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://scope.bid/api/mcp/claims",
+      "registry_status": "active",
+      "published_at": "2026-07-13T22:54:21.501896Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "claims": {
+            "type": "http",
+            "url": "https://scope.bid/api/mcp/claims"
+          }
+        }
+      }
+    },
+    {
+      "name": "bid.scope/legal",
+      "version": "1.0.6",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://scope.bid/api/mcp/legal",
+      "registry_status": "active",
+      "published_at": "2026-07-13T22:54:20.229656Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "legal": {
+            "type": "http",
+            "url": "https://scope.bid/api/mcp/legal"
+          }
+        }
+      }
+    },
+    {
+      "name": "bio.atlarium/habitat-database",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.atlarium.bio/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-16T10:01:55.780369Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "habitat-database": {
+            "type": "http",
+            "url": "https://mcp.atlarium.bio/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bio.esst/esst-bio-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://esst.bio/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-17T13:09:28.776416Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "esst-bio-mcp": {
+            "type": "http",
+            "url": "https://esst.bio/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bio.irishealth/iris",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.irishealth.bio/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-23T14:15:45.818061Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "iris": {
+            "type": "http",
+            "url": "https://api.irishealth.bio/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bio.lnk/lnkbio",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://lnk.bio/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-11T08:36:47.656221Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lnkbio": {
+            "type": "http",
+            "url": "https://lnk.bio/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "biz.icecat/mcp",
+      "version": "1.0.3",
+      "transport": "sse",
+      "auth_mode": "header-nonsecret",
+      "source_url": "https://mcp.icecat.biz",
+      "registry_status": "active",
+      "published_at": "2025-12-18T08:09:20.694935Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "sse",
+            "url": "https://mcp.icecat.biz",
+            "headers": {
+              "Api-Token": "${SECRET}",
+              "Lang-Code": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "biz.keepingtrack/dejavu",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://dejavu.keepingtrack.biz/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-29T09:15:01.220719Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dejavu": {
+            "type": "http",
+            "url": "https://dejavu.keepingtrack.biz/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "biz.soeru/soeru",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.soeru.biz/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-27T00:55:45.675119Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "soeru": {
+            "type": "http",
+            "url": "https://api.soeru.biz/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "blog.tenjin/tenjin",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tenjin.blog/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T01:10:42.417011Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tenjin": {
+            "type": "http",
+            "url": "https://tenjin.blog/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bo.paralelo/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://paralelo.bo/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-23T01:24:52.426054Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://paralelo.bo/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.402/discovery-oracle",
+      "version": "1.0.1-beta",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.402.bot/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-08T03:24:57.935141Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "discovery-oracle": {
+            "type": "http",
+            "url": "https://api.402.bot/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.mailbox/mailbox",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mailbox.bot/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-27T18:43:37.200855Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mailbox": {
+            "type": "http",
+            "url": "https://mailbox.bot/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.meet/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.meet.bot",
+      "registry_status": "active",
+      "published_at": "2026-03-05T16:13:59.680431Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.meet.bot",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.myagi/openagent-registry",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://myagi.bot/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-07T03:04:00.175818Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "openagent-registry": {
+            "type": "http",
+            "url": "https://myagi.bot/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.persnickety/bridal",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://persnickety.bot/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T22:31:34.978761Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bridal": {
+            "type": "http",
+            "url": "https://persnickety.bot/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.ttrpg/grimoire",
+      "version": "1.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.ttrpg.bot/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T23:49:05.329239Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "grimoire": {
+            "type": "http",
+            "url": "https://api.ttrpg.bot/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bot.yeehaw/events",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://yeehaw.bot/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-08T02:03:30.924635Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "events": {
+            "type": "http",
+            "url": "https://yeehaw.bot/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.brasilnfe/fiscal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.brasilnfe.com.br/services/Mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T19:00:21.651652Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "fiscal": {
+            "type": "http",
+            "url": "https://api.brasilnfe.com.br/services/Mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.escoladeradio.www/public",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.escoladeradio.com.br/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T01:27:33.294064Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "public": {
+            "type": "http",
+            "url": "https://www.escoladeradio.com.br/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.fipex/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.fipex.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T22:46:32.925318Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.fipex.com.br/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.minutaia/pesquisa-juridica",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.minutaia.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T00:11:00.605194Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pesquisa-juridica": {
+            "type": "http",
+            "url": "https://mcp.minutaia.com.br/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.music360.app/mcp-server",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.music360.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-04T22:48:35.892873Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://app.music360.com.br/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.nineoneninetwo/9192",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://nineoneninetwo.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-22T21:19:09.951678Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "9192": {
+            "type": "http",
+            "url": "https://nineoneninetwo.com.br/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.nvoip/mcp-server",
+      "version": "0.2.3",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.nvoip.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-04T11:18:23.888276Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.nvoip.com.br/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.redentia/redentia",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://redentia-api.saraivada.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T21:28:44.304131Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "redentia": {
+            "type": "http",
+            "url": "https://redentia-api.saraivada.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "br.com.signdocs/mcp-server",
+      "version": "0.3.2",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.signdocs.com.br/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T05:20:09.115579Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.signdocs.com.br/mcp",
+            "headers": {
+              "X-SignDocs-Client-Id": "${SECRET}",
+              "X-SignDocs-Client-Secret": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "build.arca.mcp/arca-mcp-server",
+      "version": "0.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.arca.build",
+      "registry_status": "active",
+      "published_at": "2025-12-15T17:05:06.117783Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "arca-mcp-server": {
+            "type": "http",
+            "url": "https://mcp.arca.build",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "build.exascale/osint",
+      "version": "1.1.6",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.exascale.build/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T16:09:13.373227Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "osint": {
+            "type": "http",
+            "url": "https://api.exascale.build/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "build.uplink/uplink",
+      "version": "0.1.4",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=build.uplink/uplink",
+      "registry_status": "active",
+      "published_at": "2026-06-23T21:33:32.588926Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "uplink": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@uplink-code/mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "builders.bridgetown/bridge-town",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.bridgetown.builders/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T10:24:32.255834Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bridge-town": {
+            "type": "http",
+            "url": "https://api.bridgetown.builders/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "by.authorized/brands",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.authorized.by/api/public/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T08:31:31.450691Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "brands": {
+            "type": "http",
+            "url": "https://app.authorized.by/api/public/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "bz.manda/manda",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://manda.bz/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-11T12:39:53.528556Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "manda": {
+            "type": "http",
+            "url": "https://manda.bz/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.airiskmanagement/shadow-ai-list",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ailist.airiskmanagement.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-23T13:51:07.359616Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "shadow-ai-list": {
+            "type": "http",
+            "url": "https://ailist.airiskmanagement.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.canada-payroll/canada-payroll",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://canada-payroll.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T09:56:02.583029Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "canada-payroll": {
+            "type": "http",
+            "url": "https://canada-payroll.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.freelancertax/freelancertax",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://freelancertax.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T09:55:45.539027Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "freelancertax": {
+            "type": "http",
+            "url": "https://freelancertax.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.mattherbert/offers",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://offers.mattherbert.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T21:50:50.091514Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "offers": {
+            "type": "http",
+            "url": "https://offers.mattherbert.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.netgrant/canadian-grants",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.netgrant.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T14:29:47.204486Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "canadian-grants": {
+            "type": "http",
+            "url": "https://mcp.netgrant.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.oathready/citizenship-test",
+      "version": "1.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://oathready.ca/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T04:38:33.967124Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "citizenship-test": {
+            "type": "http",
+            "url": "https://oathready.ca/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.swiftsign/mcp",
+      "version": "0.5.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://swiftsign.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-09T23:55:17.091983Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://swiftsign.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.taparcelle/foncier",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.taparcelle.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T15:08:11.958531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "foncier": {
+            "type": "http",
+            "url": "https://mcp.taparcelle.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.tradebasis/automotive-appraisal",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tradebasis.ca/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T05:57:24.737669Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "automotive-appraisal": {
+            "type": "http",
+            "url": "https://tradebasis.ca/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ca.wiremi/marketing-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://wiremi-marketing-mcp-pqlquijg3q-uk.a.run.app/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T04:20:46.51121Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketing-mcp": {
+            "type": "http",
+            "url": "https://wiremi-marketing-mcp-pqlquijg3q-uk.a.run.app/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "capital.hove/read-only-local-mysql-mcp-server",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=capital.hove/read-only-local-mysql-mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-02-17T16:42:54.938922Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "read-only-local-mysql-mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@hovecapital/read-only-mysql-mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "capital.hove/read-only-local-postgres-mcp-server",
+      "version": "0.1.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=capital.hove/read-only-local-postgres-mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-01-29T08:50:16.035232Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "read-only-local-postgres-mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@hovecapital/read-only-postgres-mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "care.fysio/discovery",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://fysio.care/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T20:14:32.525034Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "discovery": {
+            "type": "http",
+            "url": "https://fysio.care/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "casa.find-me.sub1/send-email-mcp",
+      "version": "0.0.14",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://sub1.find-me.casa",
+      "registry_status": "active",
+      "published_at": "2025-11-28T14:02:14.089267Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "send-email-mcp": {
+            "type": "http",
+            "url": "https://sub1.find-me.casa",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cat.2022/catalunya-2022",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.2022.cat",
+      "registry_status": "active",
+      "published_at": "2026-04-10T19:00:13.358679Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalunya-2022": {
+            "type": "http",
+            "url": "https://mcp.2022.cat"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.accrue/mcp",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://accrue.cc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-14T21:12:44.309949Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://accrue.cc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.captcha/captchacc",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://captcha.cc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T04:40:31.31184Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "captchacc": {
+            "type": "http",
+            "url": "https://captcha.cc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.contexta/contexta-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.contexta.cc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-09T20:37:17.927486Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "contexta-mcp": {
+            "type": "http",
+            "url": "https://mcp.contexta.cc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.easydata/data",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://easydata.cc/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T01:47:20.285052Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "data": {
+            "type": "http",
+            "url": "https://easydata.cc/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.joules/coach",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://context.joules.cc/",
+      "registry_status": "active",
+      "published_at": "2026-07-01T03:12:15.975709Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "coach": {
+            "type": "http",
+            "url": "https://context.joules.cc/"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.operandi/operandi",
+      "version": "1.0.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=cc.operandi/operandi",
+      "registry_status": "active",
+      "published_at": "2026-07-22T16:10:31.969998Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "operandi": {
+            "command": "uvx",
+            "args": [
+              "operandi-mcp"
+            ],
+            "env": {
+              "OPERANDI_API_URL": "${VALUE}",
+              "OPERANDI_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.orionlabsone/orion-agent-kit",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://orionlabsone.cc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T07:38:59.359024Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "orion-agent-kit": {
+            "type": "http",
+            "url": "https://orionlabsone.cc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.thecolony/mcp-server",
+      "version": "1.14.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://thecolony.cc/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-06-12T12:52:39.481564Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://thecolony.cc/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.ticktape/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ticktape.cc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T00:47:04.26188Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://ticktape.cc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cc.wealthos/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.wealthos.cc",
+      "registry_status": "active",
+      "published_at": "2026-05-02T21:59:34.721609Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.wealthos.cc"
+          }
+        }
+      }
+    },
+    {
+      "name": "center.mylink/link-center",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mylink.center/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-07T13:25:32.460265Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "link-center": {
+            "type": "http",
+            "url": "https://mylink.center/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.arvi/catalog",
+      "version": "1.10.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.arvi.ch/",
+      "registry_status": "active",
+      "published_at": "2026-07-23T15:18:23.319554Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalog": {
+            "type": "http",
+            "url": "https://mcp.arvi.ch/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.cowork24/booking",
+      "version": "0.3.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cowork24.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T13:14:29.716254Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "booking": {
+            "type": "http",
+            "url": "https://mcp.cowork24.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.entscheidsuche/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.entscheidsuche.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T01:41:33.954513Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.entscheidsuche.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.fedlex-connector/fedlex-connector",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.fedlex-connector.ch/",
+      "registry_status": "active",
+      "published_at": "2026-04-09T19:51:36.805589Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "fedlex-connector": {
+            "type": "http",
+            "url": "https://mcp.fedlex-connector.ch/"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.immoswipe/immoswipe-ai",
+      "version": "1.1.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai.immoswipe.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T09:48:46.798935Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "immoswipe-ai": {
+            "type": "http",
+            "url": "https://ai.immoswipe.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.jassverband/jasswiki",
+      "version": "1.0.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://jasswiki.ch/mcp/http",
+      "registry_status": "active",
+      "published_at": "2026-07-02T12:47:07.825674Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jasswiki": {
+            "type": "http",
+            "url": "https://jasswiki.ch/mcp/http"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.lumabill/lumabill",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.lumabill.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T08:36:07.304367Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lumabill": {
+            "type": "http",
+            "url": "https://mcp.lumabill.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.martinelli/jooq-mcp",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://jooq-mcp.martinelli.ch/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-12T13:41:08.407071Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jooq-mcp": {
+            "type": "sse",
+            "url": "https://jooq-mcp.martinelli.ch/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.opencaselaw/swiss-caselaw",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://mcp.opencaselaw.ch",
+      "registry_status": "active",
+      "published_at": "2026-03-10T12:02:29.032478Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "swiss-caselaw": {
+            "type": "sse",
+            "url": "https://mcp.opencaselaw.ch"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.pfx/mcp-server",
+      "version": "1.1.9",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.pfx.ch/api/server",
+      "registry_status": "active",
+      "published_at": "2025-11-15T11:36:10.224083Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.pfx.ch/api/server"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.swisslivingindex/swiss-living-index",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://swisslivingindex.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-07T18:51:18.910098Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "swiss-living-index": {
+            "type": "http",
+            "url": "https://swisslivingindex.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.the-orbit/orbit",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://the-orbit.ch/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T18:12:10.087373Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "orbit": {
+            "type": "http",
+            "url": "https://the-orbit.ch/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.wejob/wejob",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.wejob.ch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:08:53.54371Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wejob": {
+            "type": "http",
+            "url": "https://mcp.wejob.ch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ch.zenarion/booking",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://zenarion.ch/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T10:00:16.340044Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "booking": {
+            "type": "http",
+            "url": "https://zenarion.ch/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "chat.mumo/mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mumo.chat/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-22T01:02:35.524773Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mumo.chat/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "chat.muro/support",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://muro.chat/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T07:32:26.431125Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "support": {
+            "type": "http",
+            "url": "https://muro.chat/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "chat.prelim/prelim",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.prelim.chat/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-23T02:28:40.69201Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "prelim": {
+            "type": "http",
+            "url": "https://mcp.prelim.chat/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "chat.prowl/prowl-mcp",
+      "version": "1.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://prowl.chat/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-01T10:11:37.155009Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "prowl-mcp": {
+            "type": "http",
+            "url": "https://prowl.chat/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "chat.trilo/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.trilo.chat/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-01T11:00:35.306415Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.trilo.chat/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "church.ai.mcp/mcp-hub",
+      "version": "0.9.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ai.church/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T06:01:34.359397Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-hub": {
+            "type": "http",
+            "url": "https://mcp.ai.church/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "ci.git/mymlh-mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mymlh-mcp.git.ci/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-18T01:20:01.35206Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mymlh-mcp-server": {
+            "type": "http",
+            "url": "https://mymlh-mcp.git.ci/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "city.close/close-api",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.close.city/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T05:25:53.548507Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "close-api": {
+            "type": "http",
+            "url": "https://mcp.close.city/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cl.repuestia/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.repuestia.cl/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T18:52:44.33863Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://www.repuestia.cl/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "click.tabula.www/tabula-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://www.tabula.click/api/mcp/stream",
+      "registry_status": "active",
+      "published_at": "2026-03-18T23:54:51.599594Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tabula-mcp": {
+            "type": "http",
+            "url": "https://www.tabula.click/api/mcp/stream",
+            "headers": {
+              "Authorization": "${SECRET}",
+              "X-Tabula-Guest-Session": "${SECRET}",
+              "X-Tabula-Approval": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "click.toolcall/toolcall",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://toolcall.click/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T14:35:41.687402Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "toolcall": {
+            "type": "http",
+            "url": "https://toolcall.click/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.aevia/warmnight-fishing",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aevia.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T00:55:37.696177Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "warmnight-fishing": {
+            "type": "http",
+            "url": "https://mcp.aevia.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.agentdomain/agentdomain-mcp",
+      "version": "1.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=cloud.agentdomain/agentdomain-mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T06:12:17.987845Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentdomain-mcp": {
+            "command": "uvx",
+            "args": [
+              "agentdomain-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.anythink/anythink",
+      "version": "0.2.21",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=cloud.anythink/anythink",
+      "registry_status": "active",
+      "published_at": "2026-06-28T11:52:04.917791Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "anythink": {
+            "command": "anythink-mcp",
+            "args": []
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.atatravel/travel-agency",
+      "version": "2.1.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://atatravel.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-30T02:13:06.031135Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "travel-agency": {
+            "type": "http",
+            "url": "https://atatravel.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.clawspan/shardlink",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.clawspan.cloud/v1/mcp/streamable",
+      "registry_status": "active",
+      "published_at": "2026-07-20T03:35:46.664776Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "shardlink": {
+            "type": "http",
+            "url": "https://app.clawspan.cloud/v1/mcp/streamable"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.dchub/mcp-server",
+      "version": "2.5.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://dchub.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T09:55:20.341684Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://dchub.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.factry.portal/historian-mcp-server",
+      "version": "0.0.5",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=cloud.factry.portal/historian-mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-05-04T14:42:12.428961Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "historian-mcp-server": {
+            "command": "docker",
+            "args": [
+              "run",
+              "-i",
+              "--rm",
+              "docker.io/factry/mcp-server:0.0.5"
+            ],
+            "env": {
+              "FACTRY_HISTORIAN_API_TOKEN": "${VALUE}",
+              "FACTRY_HISTORIAN_API_URL": "${VALUE}",
+              "FACTRY_HISTORIAN_ORGANIZATION_UUID": "${VALUE}",
+              "GRAFANA_URL": "${VALUE}",
+              "GRAFANA_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.iox/iox-cloud",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://iox-dispatch.matt-merutech.workers.dev/mcp?worker={project_slug}",
+      "registry_status": "active",
+      "published_at": "2026-04-06T02:02:15.636856Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "iox-cloud": {
+            "type": "http",
+            "url": "https://iox-dispatch.matt-merutech.workers.dev/mcp?worker={project_slug}"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.massdriver/mcp-server",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=cloud.massdriver/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-07-21T22:54:55.674888Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "docker",
+            "args": [
+              "run",
+              "-i",
+              "--rm",
+              "docker.io/massdrivercloud/mcp-server:0.1.2"
+            ],
+            "env": {
+              "MASSDRIVER_API_KEY": "${VALUE}",
+              "MASSDRIVER_ORGANIZATION_ID": "${VALUE}",
+              "MASSDRIVER_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.metrifyr/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.metrifyr.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-10T20:12:15.13954Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.metrifyr.cloud/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.nordicdata/nordic-data",
+      "version": "1.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.nordicdata.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T22:21:28.201757Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nordic-data": {
+            "type": "http",
+            "url": "https://api.nordicdata.cloud/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.nttzen.secdb/zen-secdb",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://secdb.nttzen.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T17:08:10.172079Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "zen-secdb": {
+            "type": "http",
+            "url": "https://secdb.nttzen.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.prince/prince",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://prince.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-25T22:29:46.869477Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "prince": {
+            "type": "http",
+            "url": "https://prince.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.redu/mcp",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.redu.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-09T21:56:22.463537Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.redu.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.servicepal/mcp",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://servicepal.cloud/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-04-15T15:37:49.962158Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://servicepal.cloud/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.spider/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.spider.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T17:11:34.993394Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.spider.cloud/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.theprotocol/registry",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://api.theprotocol.cloud/mcp/sse",
+      "registry_status": "active",
+      "published_at": "2026-03-20T23:44:51.054971Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "registry": {
+            "type": "sse",
+            "url": "https://api.theprotocol.cloud/mcp/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.verifi/human-verification",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://verifi.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T23:02:49.881245Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "human-verification": {
+            "type": "http",
+            "url": "https://verifi.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cloud.wavehouse/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.wavehouse.cloud/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T20:41:54.690273Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.wavehouse.cloud/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "club.elron/public-rentals",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://elron.club/api/agent/public/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T18:58:13.458461Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "public-rentals": {
+            "type": "http",
+            "url": "https://elron.club/api/agent/public/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "club.lity/lity",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://8p5dmrjzl1.execute-api.eu-north-1.amazonaws.com/poc/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T16:27:03.855652Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lity": {
+            "type": "http",
+            "url": "https://8p5dmrjzl1.execute-api.eu-north-1.amazonaws.com/poc/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "cn.com.grapecity/gcexcel",
+      "version": "1.0.0-beta.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.grapecity.com.cn/mcp/gcexcel",
+      "registry_status": "active",
+      "published_at": "2026-07-23T02:24:12.350201Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "gcexcel": {
+            "type": "http",
+            "url": "https://mcp.grapecity.com.cn/mcp/gcexcel",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cn.com.grapecity/spreadjs",
+      "version": "1.0.0-beta.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.grapecity.com.cn/mcp/spreadjs",
+      "registry_status": "active",
+      "published_at": "2026-07-23T02:24:12.552921Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "spreadjs": {
+            "type": "http",
+            "url": "https://mcp.grapecity.com.cn/mcp/spreadjs",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cn.housingsentinel/housing-sentinel",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.housingsentinel.cn/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T08:51:36.251255Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "housing-sentinel": {
+            "type": "http",
+            "url": "https://api.housingsentinel.cn/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "cn.syln.ai/lingjing-community",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://ai.syln.cn/sse",
+      "registry_status": "active",
+      "published_at": "2026-06-27T17:14:53.976182Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "lingjing-community": {
+            "type": "sse",
+            "url": "https://ai.syln.cn/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "cn.whylingxi/insurance",
+      "version": "3.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://whylingxi.cn/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T10:28:02.496922Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "insurance": {
+            "type": "http",
+            "url": "https://whylingxi.cn/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.ainumbers/tools",
+      "version": "0.4.8",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ainumbers.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T18:39:48.726715Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tools": {
+            "type": "http",
+            "url": "https://mcp.ainumbers.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.axiom/mcp",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://mcp.axiom.co/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-30T18:09:02.670593Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "sse",
+            "url": "https://mcp.axiom.co/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.bizverify/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.bizverify.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-03T07:47:15.785232Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.bizverify.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.brightkey/education-data",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://brightkey.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T16:12:54.95386Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "education-data": {
+            "type": "http",
+            "url": "https://brightkey.co/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.callendar/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.callendar.de/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-08T22:23:31.639817Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://app.callendar.de/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.clutch/mcp",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bot.clutch.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-28T18:44:00.178525Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://bot.clutch.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.contraption/mcp",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://mcp.contraption.co/",
+      "registry_status": "active",
+      "published_at": "2025-10-02T15:38:37.916768Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "sse",
+            "url": "https://mcp.contraption.co/"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.creativeclaw/creative-claw",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.creativeclaw.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T15:25:59.384727Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "creative-claw": {
+            "type": "http",
+            "url": "https://app.creativeclaw.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.curie/commerce",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "static-credential",
+      "source_url": "https://chat.curie.app/api/mcp/global",
+      "registry_status": "active",
+      "published_at": "2026-05-20T06:10:54.531321Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "commerce": {
+            "type": "sse",
+            "url": "https://chat.curie.app/api/mcp/global"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.dockai/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.dockai.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-01-05T11:44:43.544597Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.dockai.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.flow2/flow2",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.flow2.co/",
+      "registry_status": "active",
+      "published_at": "2026-05-05T18:23:23.374851Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "flow2": {
+            "type": "http",
+            "url": "https://mcp.flow2.co/"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.flyweel/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.flyweel.co/functions/v1/mcp-server/mcp",
+      "registry_status": "active",
+      "published_at": "2026-01-15T02:02:08.72561Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://api.flyweel.co/functions/v1/mcp-server/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.gemina/filetag",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.gemina.co/api/v1/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-05-19T15:42:06.477459Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "filetag": {
+            "type": "http",
+            "url": "https://api.gemina.co/api/v1/mcp/",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.gleanit/gleanit",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.gleanit.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-23T01:39:16.981777Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "gleanit": {
+            "type": "http",
+            "url": "https://api.gleanit.co/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.godmodeai/sprites",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://www.godmodeai.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T03:33:45.416587Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sprites": {
+            "type": "http",
+            "url": "https://www.godmodeai.co/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.haveny/california-hoa-law",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://haveny-mcp.havenyy.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-03T11:58:41.975829Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "california-hoa-law": {
+            "type": "http",
+            "url": "https://haveny-mcp.havenyy.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.heista/api",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://www.heista.co/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-11T04:18:46.865402Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "api": {
+            "type": "http",
+            "url": "https://www.heista.co/api/mcp/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.heyspark.mcp/server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.heyspark.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-16T13:12:52.113124Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "type": "http",
+            "url": "https://mcp.heyspark.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.huggingface/hf-mcp-server",
+      "version": "0.2.33",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://huggingface.co/mcp?login",
+      "registry_status": "active",
+      "published_at": "2025-10-22T10:55:52.98995Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hf-mcp-server": {
+            "type": "http",
+            "url": "https://huggingface.co/mcp?login"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.jacktrade/jacktrade-crm",
+      "version": "1.1.0-dev",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://frostsa2.ed1.jacktrade.xyz/jacktrade/mcp_api/v1/message",
+      "registry_status": "active",
+      "published_at": "2026-04-24T06:45:31.036715Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jacktrade-crm": {
+            "type": "http",
+            "url": "https://frostsa2.ed1.jacktrade.xyz/jacktrade/mcp_api/v1/message"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.kuickr/kuickr",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://kuickr.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T14:24:45.027735Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kuickr": {
+            "type": "http",
+            "url": "https://kuickr.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.launchtrust/launchtrust",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.launchtrust.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T10:38:14.49757Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "launchtrust": {
+            "type": "http",
+            "url": "https://mcp.launchtrust.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.loopgolf/tee-times",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.loopgolf.co/api/ai/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T19:56:28.721943Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tee-times": {
+            "type": "http",
+            "url": "https://www.loopgolf.co/api/ai/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.lovie/company-formation",
+      "version": "1.0.10",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.lovie.co/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-16T10:27:33.61459Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "company-formation": {
+            "type": "http",
+            "url": "https://mcp.lovie.co/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.machins/marketplace",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://machins.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-02T09:45:33.434957Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketplace": {
+            "type": "http",
+            "url": "https://machins.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.nexalink/manage",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://nexalink.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T17:15:11.097381Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "manage": {
+            "type": "http",
+            "url": "https://nexalink.co/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.obto/obto",
+      "version": "3.5.34",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.obto.co/ms/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T01:51:43.771326Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "obto": {
+            "type": "http",
+            "url": "https://app.obto.co/ms/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.okahu.mcp-registry/okahu",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.okahu.co/mcp",
+      "registry_status": "active",
+      "published_at": "2025-12-29T21:18:47.587908Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "okahu": {
+            "type": "http",
+            "url": "https://mcp.okahu.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.pepys/pepys-mcp",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://pepys.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T09:06:24.511359Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "pepys-mcp": {
+            "type": "http",
+            "url": "https://pepys.co/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.pipeboard/google-ads-mcp",
+      "version": "1.0.21",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://google-ads.mcp.pipeboard.co/",
+      "registry_status": "active",
+      "published_at": "2026-07-23T15:28:07.666513Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "google-ads-mcp": {
+            "type": "http",
+            "url": "https://google-ads.mcp.pipeboard.co/"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.pipeboard/meta-ads-mcp",
+      "version": "1.0.118",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.pipeboard.co/meta-ads-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T18:31:57.956324Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "meta-ads-mcp": {
+            "type": "http",
+            "url": "https://mcp.pipeboard.co/meta-ads-mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.pipeboard/snap-ads-mcp",
+      "version": "1.0.14",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://snap-ads.mcp.pipeboard.co/",
+      "registry_status": "active",
+      "published_at": "2026-07-24T18:34:02.495928Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "snap-ads-mcp": {
+            "type": "http",
+            "url": "https://snap-ads.mcp.pipeboard.co/"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.pipeboard/tiktok-ads-mcp",
+      "version": "1.0.33",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tiktok-ads.mcp.pipeboard.co/",
+      "registry_status": "active",
+      "published_at": "2026-07-25T10:56:14.815436Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tiktok-ads-mcp": {
+            "type": "http",
+            "url": "https://tiktok-ads.mcp.pipeboard.co/"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.policyforge/mcp",
+      "version": "0.4.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=co.policyforge/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T20:04:56.528719Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@policyforge/mcp"
+            ],
+            "env": {
+              "POLICYFORGE_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.promptguard/security",
+      "version": "1.0.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=co.promptguard/security",
+      "registry_status": "active",
+      "published_at": "2026-04-05T11:45:11.66947Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "security": {
+            "command": "uvx",
+            "args": [
+              "promptguard-mcp-server"
+            ],
+            "env": {
+              "PROMPTGUARD_API_KEY": "${VALUE}",
+              "PROMPTGUARD_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.raisekit/raisekit",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://raisekit.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-26T16:21:05.350456Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "raisekit": {
+            "type": "http",
+            "url": "https://raisekit.co/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.servicegraph.mcp/servicegraph",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.servicegraph.co",
+      "registry_status": "active",
+      "published_at": "2026-05-25T09:06:30.840201Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "servicegraph": {
+            "type": "http",
+            "url": "https://mcp.servicegraph.co"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.sivut.pay/sec-crypto-filing-radar",
+      "version": "2026.6.9",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://pay.sivut.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-09T22:15:11.41027Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sec-crypto-filing-radar": {
+            "type": "http",
+            "url": "https://pay.sivut.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.sofya/sofya",
+      "version": "1.27.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://sofya.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-27T11:51:47.004548Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sofya": {
+            "type": "http",
+            "url": "https://sofya.co/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.superforms/superforms",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://superforms.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-04T17:07:17.440457Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "superforms": {
+            "type": "http",
+            "url": "https://superforms.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.tempguru/event-staffing",
+      "version": "1.5.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.tempguru.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T04:40:14.274933Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "event-staffing": {
+            "type": "http",
+            "url": "https://mcp.tempguru.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.tenderly/tenderly-mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.tenderly.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-31T14:37:18.842334Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tenderly-mcp": {
+            "type": "http",
+            "url": "https://mcp.tenderly.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.thinair/data",
+      "version": "2.1.3",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://data.thinair.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-02T03:16:51.535643Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "data": {
+            "type": "http",
+            "url": "https://data.thinair.co/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.thinair/geo",
+      "version": "2.1.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://geo.thinair.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-02T03:19:57.592935Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "geo": {
+            "type": "http",
+            "url": "https://geo.thinair.co/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.thisdot.docusign-navigator/mcp",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://docusign-navigator.thisdot.co/mcp",
+      "registry_status": "active",
+      "published_at": "2025-10-27T15:57:26.278297Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://docusign-navigator.thisdot.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.truemarkets/marketdata",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.truemarkets.co/marketdata/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-08T20:36:32.325487Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketdata": {
+            "type": "http",
+            "url": "https://mcp.truemarkets.co/marketdata/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.truncus/mcp-server",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=co.truncus/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-03-05T11:22:55.500517Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@truncus/mcp-server"
+            ],
+            "env": {
+              "TRUNCUS_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.ultraprompt/ultra-prompt",
+      "version": "1.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://up-mcp.unpluggedfeed.workers.dev",
+      "registry_status": "active",
+      "published_at": "2026-06-18T00:02:32.433403Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ultra-prompt": {
+            "type": "http",
+            "url": "https://up-mcp.unpluggedfeed.workers.dev",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "co.valid/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.valid.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-31T21:02:27.554858Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.valid.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.vantaj/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.vantaj.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T15:01:22.104589Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://api.vantaj.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.webhook/webhook",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.webhook.co/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T12:29:01.463069Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "webhook": {
+            "type": "http",
+            "url": "https://mcp.webhook.co/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.whooshly/whooshly-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://app.whooshly.co/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T18:05:43.205695Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "whooshly-mcp": {
+            "type": "http",
+            "url": "https://app.whooshly.co/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "co.widgy/widgy",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.widgy.co",
+      "registry_status": "active",
+      "published_at": "2026-07-07T13:48:37.143064Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "widgy": {
+            "type": "http",
+            "url": "https://mcp.widgy.co"
+          }
+        }
+      }
+    },
+    {
+      "name": "coach.freddy/freddy",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://freddy.coach/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-13T14:27:16.295582Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "freddy": {
+            "type": "http",
+            "url": "https://freddy.coach/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "coach.marian/eng-leadership-toolkit",
+      "version": "1.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.marian.coach/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T20:25:30.802205Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "eng-leadership-toolkit": {
+            "type": "http",
+            "url": "https://www.marian.coach/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "codes.find/verified-codes",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://find.codes/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T23:17:21.999253Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "verified-codes": {
+            "type": "http",
+            "url": "https://find.codes/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "coffee.402/mcp",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=coffee.402/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T21:10:45.124521Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "402coffee-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.1001locals/catalog",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.1001locals.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T15:53:20.768243Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalog": {
+            "type": "http",
+            "url": "https://api.1001locals.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.100hires/100hires",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.100hires.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-15T17:31:44.493329Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "100hires": {
+            "type": "http",
+            "url": "https://mcp.100hires.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.101soundboards/search",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.101soundboards.com/mcp/search",
+      "registry_status": "active",
+      "published_at": "2026-07-14T15:01:22.958302Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "search": {
+            "type": "http",
+            "url": "https://www.101soundboards.com/mcp/search"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.1stdibs/1stDibs",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.1stdibs.com/soa/mcp/",
+      "registry_status": "active",
+      "published_at": "2025-09-16T23:01:22.451132Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "1stDibs": {
+            "type": "http",
+            "url": "https://www.1stdibs.com/soa/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.402oracle/402oracle",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://402oracle.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T22:42:24.134226Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "402oracle": {
+            "type": "http",
+            "url": "https://402oracle.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.52choujiang/douyin-insights",
+      "version": "0.2.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.52choujiang.com/douyin/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T09:05:42.089014Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "douyin-insights": {
+            "type": "http",
+            "url": "https://mcp.52choujiang.com/douyin/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.52choujiang/kuaishou-insights",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.52choujiang.com/kuaishou/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T09:05:42.41672Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kuaishou-insights": {
+            "type": "http",
+            "url": "https://mcp.52choujiang.com/kuaishou/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.52choujiang/wechat-channels-insights",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.52choujiang.com/wechat/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T08:36:57.350225Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wechat-channels-insights": {
+            "type": "http",
+            "url": "https://mcp.52choujiang.com/wechat/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.52choujiang/weibo-insights",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.52choujiang.com/weibo/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T08:36:45.446402Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "weibo-insights": {
+            "type": "http",
+            "url": "https://mcp.52choujiang.com/weibo/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.52choujiang/xhs-insights",
+      "version": "0.1.7",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.52choujiang.com/xhs/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T09:05:43.829486Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "xhs-insights": {
+            "type": "http",
+            "url": "https://mcp.52choujiang.com/xhs/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.530amodel/calculator",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.530amodel.com",
+      "registry_status": "active",
+      "published_at": "2026-07-19T15:45:18.322824Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "calculator": {
+            "type": "http",
+            "url": "https://mcp.530amodel.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.636865636b73756d/mcp-v1",
+      "version": "1.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.636865636b73756d/mcp-v1",
+      "registry_status": "active",
+      "published_at": "2026-02-23T08:41:01.175601Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-v1": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@636865636b73756d/mcp-v1"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.6ducklearn/mcp",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://6ducklearn.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-31T02:32:40.886004Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://6ducklearn.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.869biz.data-vending/data-vending-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.data-vending.869biz.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-08T01:27:00.515565Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "data-vending-mcp": {
+            "type": "http",
+            "url": "https://mcp.data-vending.869biz.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.a3eecosystem.neurotrade/signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://neurotrade.a3eecosystem.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-21T03:20:32.625925Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "signal": {
+            "type": "http",
+            "url": "https://neurotrade.a3eecosystem.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.abbyseo/mcp-server",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.abbyseo.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T22:37:12.340225Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://www.abbyseo.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ablakunio/nyilaszaro-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.ablakunio.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-29T08:31:27.420533Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nyilaszaro-mcp": {
+            "type": "http",
+            "url": "https://www.ablakunio.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.abundanceapis/abundance-apis",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://abundanceapis.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T17:55:20.700794Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "abundance-apis": {
+            "type": "http",
+            "url": "https://abundanceapis.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.abyssfallgame/mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.abyssfallgame.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T12:28:49.069174Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://www.abyssfallgame.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.accountingqb/accountingqb",
+      "version": "3.5.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.accountingqb.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T23:57:18.519122Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "accountingqb": {
+            "type": "http",
+            "url": "https://mcp.accountingqb.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.achriom/achriom",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.achriom.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T20:47:43.179989Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "achriom": {
+            "type": "http",
+            "url": "https://mcp.achriom.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.acjlabs/catalog-normalizer",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://acjlabs-catalog-normalizer.acjlabs.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T07:33:47.670626Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalog-normalizer": {
+            "type": "http",
+            "url": "https://acjlabs-catalog-normalizer.acjlabs.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.acjlabs/receipt-extraction",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://acjlabs-receipt-extraction.acjlabs.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T07:33:46.838169Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "receipt-extraction": {
+            "type": "http",
+            "url": "https://acjlabs-receipt-extraction.acjlabs.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.acprompt/acprompt",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.acprompt.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-11T19:38:05.609008Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "acprompt": {
+            "type": "http",
+            "url": "https://www.acprompt.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.acquislaw/acquis",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.acquislaw.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T08:55:37.616739Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "acquis": {
+            "type": "http",
+            "url": "https://api.acquislaw.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.actablesite/ai-crawler-robots-monitor",
+      "version": "1.4.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://actablesite.com/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-07-13T13:16:14.126526Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-crawler-robots-monitor": {
+            "type": "http",
+            "url": "https://actablesite.com/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.actuallycare/actuallycare",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.actuallycare.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T07:05:43.77054Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "actuallycare": {
+            "type": "http",
+            "url": "https://mcp.actuallycare.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.acuris-geo/acuris-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.acuris-geo.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T02:03:39.425612Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "acuris-mcp": {
+            "type": "http",
+            "url": "https://api.acuris-geo.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adbloop/meta-ads",
+      "version": "1.7.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adbloop.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-18T05:51:16.314079Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "meta-ads": {
+            "type": "http",
+            "url": "https://mcp.adbloop.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adbutler/mcp-server",
+      "version": "2.4.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adbutler.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-28T04:01:51.331691Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.adbutler.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adcritter/mcp-agent",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adcritter.com/mcp/agent",
+      "registry_status": "active",
+      "published_at": "2026-05-04T20:15:00.266197Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-agent": {
+            "type": "http",
+            "url": "https://mcp.adcritter.com/mcp/agent"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adcritter/mcp-dev",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adcritter.com/mcp/dev",
+      "registry_status": "active",
+      "published_at": "2026-05-04T20:15:00.442374Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-dev": {
+            "type": "http",
+            "url": "https://mcp.adcritter.com/mcp/dev"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.admaxxer/ads-manager",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://admaxxer.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-25T18:17:22.714591Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ads-manager": {
+            "type": "http",
+            "url": "https://admaxxer.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.admit-coach/university-data",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://admit-coach.com/mcp/sse",
+      "registry_status": "active",
+      "published_at": "2026-04-13T20:11:37.061232Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "university-data": {
+            "type": "sse",
+            "url": "https://admit-coach.com/mcp/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.admitbase/admissions",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://admitbase.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-15T08:39:22.117679Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "admissions": {
+            "type": "http",
+            "url": "https://admitbase.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adologyai/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adologyai.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T04:43:37.93425Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.adologyai.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adrianczuczka/mason",
+      "version": "0.6.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.adrianczuczka/mason",
+      "registry_status": "active",
+      "published_at": "2026-07-22T11:41:43.344657Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mason": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "mason-context"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adspirer/ads",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.adspirer.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T14:53:04.02592Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ads": {
+            "type": "http",
+            "url": "https://mcp.adspirer.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.advisorfinder/mcp",
+      "version": "1.1.5",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.advisorfinder/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-13T04:19:36.517251Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "uvx",
+            "args": [
+              "advisorfinder-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.advocatemcp/advocate",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.advocatemcp.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-05T04:24:34.72056Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "advocate": {
+            "type": "http",
+            "url": "https://api.advocatemcp.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.adwhispr/adwhispr",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://adwhispr.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T09:34:42.076934Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "adwhispr": {
+            "type": "http",
+            "url": "https://adwhispr.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aex402/rpc",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://rpc.aex402.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T13:43:53.303043Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rpc": {
+            "type": "http",
+            "url": "https://rpc.aex402.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.afdinstitute/afd-knowledge",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.afdinstitute.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T12:32:13.236025Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "afd-knowledge": {
+            "type": "http",
+            "url": "https://mcp.afdinstitute.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.affogata.app/affogata",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://app.affogata.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-06T12:58:46.901406Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "affogata": {
+            "type": "http",
+            "url": "https://app.affogata.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aftership.mcp/tracking-public",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aftership.com/tracking/public",
+      "registry_status": "active",
+      "published_at": "2026-04-16T10:54:11.985411Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tracking-public": {
+            "type": "http",
+            "url": "https://mcp.aftership.com/tracking/public"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agent-tune/agenttune",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent-tune.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T15:42:09.430273Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agenttune": {
+            "type": "http",
+            "url": "https://agent-tune.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentcat/agentcat",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.agentcat.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T19:46:33.953308Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentcat": {
+            "type": "http",
+            "url": "https://mcp.agentcat.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentdomainsearch/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentdomainsearch.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-12T13:31:23.853839Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://agentdomainsearch.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentegalicia/public-discovery",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentegalicia.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T19:36:32.330045Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "public-discovery": {
+            "type": "http",
+            "url": "https://agentegalicia.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentery/agentery",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentery.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T12:07:35.06582Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentery": {
+            "type": "http",
+            "url": "https://agentery.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentgrade/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentgrade.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-12T16:22:50.751425Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://agentgrade.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agenticpaywall/composer",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://composer.agenticpaywall.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-17T16:03:48.430692Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "composer": {
+            "type": "http",
+            "url": "https://composer.agenticpaywall.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentictotem/web-extractor",
+      "version": "1.0.5",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentictotem.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-14T18:44:59.89249Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "web-extractor": {
+            "type": "http",
+            "url": "https://agentictotem.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentorist/agentorist",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.agentorist.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T19:33:00.189436Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentorist": {
+            "type": "http",
+            "url": "https://mcp.agentorist.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentpmt/agentpmt",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.agentpmt.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-13T23:35:34.261774Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentpmt": {
+            "type": "http",
+            "url": "https://api.agentpmt.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentry/agent-directory",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://api.agentry.com/mcp/sse",
+      "registry_status": "active",
+      "published_at": "2026-03-19T02:31:07.491377Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-directory": {
+            "type": "sse",
+            "url": "https://api.agentry.com/mcp/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentsconsultants.api/docqa",
+      "version": "1.0.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.agentsconsultants.api/docqa",
+      "registry_status": "active",
+      "published_at": "2026-04-01T08:54:25.858777Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "docqa": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "docqa-mcp"
+            ],
+            "env": {
+              "DOCQA_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agentsprice/agentsprice",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agentsprice.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-12T05:23:06.515976Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentsprice": {
+            "type": "http",
+            "url": "https://agentsprice.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agialpha/agi-alpha",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agialpha.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-12T04:12:10.423144Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agi-alpha": {
+            "type": "http",
+            "url": "https://agialpha.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agilitycms/mcp-server",
+      "version": "2.2.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.agilitycms.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T15:56:22.358166Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.agilitycms.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.agishub/mcp",
+      "version": "2.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.agishub.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T08:52:33.553059Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.agishub.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai-erd/ai-erd",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai-erd.com/mcp",
+      "registry_status": "active",
+      "published_at": "2025-12-29T10:30:10.376598Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-erd": {
+            "type": "http",
+            "url": "https://ai-erd.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai-gist/aigist",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai-gist.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T19:45:44.301006Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aigist": {
+            "type": "http",
+            "url": "https://ai-gist.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai-law-tracker/ai-law-tracker",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ai-law-tracker.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T14:20:13.751297Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-law-tracker": {
+            "type": "http",
+            "url": "https://ai-law-tracker.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai-rete-rag/ai-rete-rag-mcp",
+      "version": "0.5.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.ai-rete-rag/ai-rete-rag-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T03:07:42.917442Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-rete-rag-mcp": {
+            "command": "uvx",
+            "args": [
+              "ai-rete-rag-mcp"
+            ],
+            "env": {
+              "AI_RETE_RAG_API_KEY": "${VALUE}",
+              "AI_RETE_RAG_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai-rook.agents/trading-mcp",
+      "version": "1.0.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.ai-rook.agents/trading-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T00:58:48.079601Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trading-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "ai-rook-trading-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ai2fin/ai2fin-tax-mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://taxmcp.ai2fin.com",
+      "registry_status": "active",
+      "published_at": "2026-07-03T08:10:59.486074Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai2fin-tax-mcp": {
+            "type": "http",
+            "url": "https://taxmcp.ai2fin.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aibooma/agent-registry",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.aibooma.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-12T00:50:23.092404Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-registry": {
+            "type": "http",
+            "url": "https://api.aibooma.com/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aicandidatehub/mcp",
+      "version": "0.5.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.aicandidatehub/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T08:23:30.912701Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@aicandidatehub/mcp"
+            ],
+            "env": {
+              "CANDIDATEHUB_TOKEN": "${VALUE}",
+              "CANDIDATEHUB_API_BASE": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aidemos/catalogue",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aidemos.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T08:14:37.417534Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalogue": {
+            "type": "http",
+            "url": "https://mcp.aidemos.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aidesignblueprint/blueprint",
+      "version": "1.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aidesignblueprint.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T15:18:45.648175Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "blueprint": {
+            "type": "http",
+            "url": "https://aidesignblueprint.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aidevboard/jobs",
+      "version": "1.6.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aidevboard.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-08T14:47:59.879689Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jobs": {
+            "type": "http",
+            "url": "https://aidevboard.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aidoos/virtual-delivery-center",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aidoos.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-08T05:54:39.336045Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "virtual-delivery-center": {
+            "type": "http",
+            "url": "https://aidoos.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aihomedesign/aihomedesign-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aihomedesign.com/{connector_token}/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-09T12:33:21.502661Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aihomedesign-mcp": {
+            "type": "http",
+            "url": "https://mcp.aihomedesign.com/{connector_token}/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aiinfradecoded/mcp-anvil",
+      "version": "0.2.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.aiinfradecoded/mcp-anvil",
+      "registry_status": "active",
+      "published_at": "2026-06-04T01:20:14.592456Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-anvil": {
+            "command": "uvx",
+            "args": [
+              "mcp-anvil"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aiinterviewagents/interviews",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aiinterviewagents.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-05T19:55:05.414065Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "interviews": {
+            "type": "http",
+            "url": "https://mcp.aiinterviewagents.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aim-journal/aim",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aim-journal.com/{token}/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T12:45:28.320407Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aim": {
+            "type": "http",
+            "url": "https://aim-journal.com/{token}/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aineedhelpfromotherai/reasoning-commons",
+      "version": "2.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.aineedhelpfromotherai.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-21T10:18:59.665042Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "reasoning-commons": {
+            "type": "http",
+            "url": "https://api.aineedhelpfromotherai.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aioproductos/mcp",
+      "version": "1.0.5",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://platform.aioproductos.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T10:45:59.766836Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://platform.aioproductos.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aioproductos/mcp-studio",
+      "version": "0.2.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.aioproductos/mcp-studio",
+      "registry_status": "active",
+      "published_at": "2026-07-21T10:19:41.885633Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-studio": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@aioproductoscom/mcp-studio"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aiqbee/brain",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aiqbee.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-15T05:14:18.088452Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "brain": {
+            "type": "http",
+            "url": "https://mcp.aiqbee.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/coin-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://coin-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:32.42567Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "coin-signal": {
+            "type": "http",
+            "url": "https://coin-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/commodity-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://commodity-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:35.281177Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "commodity-signal": {
+            "type": "http",
+            "url": "https://commodity-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/dubai-property-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://dubai-property-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:38.123997Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dubai-property-signal": {
+            "type": "http",
+            "url": "https://dubai-property-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/fx-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://fx-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:40.971674Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "fx-signal": {
+            "type": "http",
+            "url": "https://fx-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/inflation-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://inflation-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:43.925581Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "inflation-signal": {
+            "type": "http",
+            "url": "https://inflation-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/seoul-apt-signal",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://seoul-apt-signal.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:46.823658Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "seoul-apt-signal": {
+            "type": "http",
+            "url": "https://seoul-apt-signal.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/stock-signal-kr",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://stock-signal-kr.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:49.687288Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "stock-signal-kr": {
+            "type": "http",
+            "url": "https://stock-signal-kr.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airblockfz/stock-signal-us",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://stock-signal-us.airblock2026.workers.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T07:50:52.518673Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "stock-signal-us": {
+            "type": "http",
+            "url": "https://stock-signal-us.airblock2026.workers.dev/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airport-pickups-london/london-airport-transfers",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.airport-pickups-london.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-02T14:57:02.98993Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "london-airport-transfers": {
+            "type": "http",
+            "url": "https://mcp.airport-pickups-london.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.airtable/mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.airtable.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-08T19:18:18.585221Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.airtable.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aistackscore/aistackscore",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aistackscore.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T02:46:56.544929Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aistackscore": {
+            "type": "http",
+            "url": "https://aistackscore.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aitwire/authority",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.aitwire.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T22:11:54.07957Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "authority": {
+            "type": "http",
+            "url": "https://api.aitwire.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aitwire/tenant",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.aitwire.com/mcp/tenant",
+      "registry_status": "active",
+      "published_at": "2026-07-23T20:08:04.212983Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tenant": {
+            "type": "http",
+            "url": "https://api.aitwire.com/mcp/tenant"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.alchemy/mcp",
+      "version": "0.5.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.alchemy.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T16:51:21.201813Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.alchemy.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aleeth/authority-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.aleeth.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T11:30:53.198029Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "authority-mcp": {
+            "type": "http",
+            "url": "https://mcp.aleeth.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.algeriacertify/verification-talent",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.algeriacertify.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-31T15:49:36.946026Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "verification-talent": {
+            "type": "http",
+            "url": "https://www.algeriacertify.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.algovesta/trading",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.algovesta.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T09:04:25.094818Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trading": {
+            "type": "http",
+            "url": "https://api.algovesta.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.alleskralle/jobs",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.alleskralle.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-03T09:16:32.413976Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "jobs": {
+            "type": "http",
+            "url": "https://mcp.alleskralle.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.allgoodinsp/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.allgoodinsp.com",
+      "registry_status": "active",
+      "published_at": "2026-03-27T17:02:50.219009Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.allgoodinsp.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.allpdfmagic/allpdfmagic",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.allpdfmagic.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T05:14:18.38123Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "allpdfmagic": {
+            "type": "http",
+            "url": "https://api.allpdfmagic.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.allstacks/allstacks-mcp",
+      "version": "0.1.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.allstacks/allstacks-mcp",
+      "registry_status": "active",
+      "published_at": "2025-10-27T19:42:56.515336Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "allstacks-mcp": {
+            "command": "uvx",
+            "args": [
+              "allstacks-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.almured/marketplace",
+      "version": "1.0.3",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.almured.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-30T17:58:51.611465Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketplace": {
+            "type": "http",
+            "url": "https://api.almured.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.alpha402x/research",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://alpha402x.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T20:21:48.586361Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "research": {
+            "type": "http",
+            "url": "https://alpha402x.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.alphaassay/mcp",
+      "version": "0.6.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.alphaassay.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T15:36:51.193834Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.alphaassay.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.alpinedataworks/adw-intelligence-server",
+      "version": "0.3.6",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.alpinedataworks.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-19T05:38:49.555228Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "adw-intelligence-server": {
+            "type": "http",
+            "url": "https://api.alpinedataworks.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.altesim/esim",
+      "version": "0.41.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://altesim.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T15:18:39.162397Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "esim": {
+            "type": "http",
+            "url": "https://altesim.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.altmetric.mcp/altmetric-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.altmetric.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T10:37:26.813598Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "altmetric-mcp": {
+            "type": "http",
+            "url": "https://mcp.altmetric.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.altoviz/mcp",
+      "version": "0.0.13",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.altoviz.com",
+      "registry_status": "active",
+      "published_at": "2026-06-20T14:31:34.732152Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.altoviz.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.am-lich/vietnamese-calendar",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://am-lich.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-27T18:10:14.07316Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vietnamese-calendar": {
+            "type": "http",
+            "url": "https://am-lich.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ambermem/amber",
+      "version": "1.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.ambermem.com",
+      "registry_status": "active",
+      "published_at": "2026-05-17T16:11:45.875499Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "amber": {
+            "type": "http",
+            "url": "https://mcp.ambermem.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.amplitude/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.amplitude.com/mcp",
+      "registry_status": "active",
+      "published_at": "2025-10-16T20:22:46.742037Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.amplitude.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.anglero/speaker",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://anglero.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:30:33.247483Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "speaker": {
+            "type": "http",
+            "url": "https://anglero.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.anotepad/notes",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.anotepad.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-07T23:48:09.051205Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "notes": {
+            "type": "http",
+            "url": "https://api.anotepad.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.anots/directory",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.anots.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-19T14:31:42.037631Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "directory": {
+            "type": "http",
+            "url": "https://api.anots.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.anymailmcp/mail",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://anymailmcp.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T00:12:38.518684Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mail": {
+            "type": "http",
+            "url": "https://anymailmcp.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apideck/mcp",
+      "version": "0.1.13",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.apideck.dev/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-25T07:54:53.765783Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.apideck.dev/mcp",
+            "headers": {
+              "x-apideck-api-key": "${SECRET}",
+              "x-apideck-app-id": "${SECRET}",
+              "x-apideck-consumer-id": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apievangelist/api-evangelist",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.apievangelist.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T02:19:07.341293Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "api-evangelist": {
+            "type": "http",
+            "url": "https://mcp.apievangelist.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apify/apify-mcp-server",
+      "version": "0.12.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.apify.com/",
+      "registry_status": "active",
+      "published_at": "2026-07-23T08:06:35.259871Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "apify-mcp-server": {
+            "type": "http",
+            "url": "https://mcp.apify.com/",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apiscreenshot/screenshot",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://apiscreenshot.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T20:42:54.615713Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "screenshot": {
+            "type": "http",
+            "url": "https://apiscreenshot.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apiverve/mcp-server",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.apiverve.com/v1/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-17T05:56:41.256192Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://api.apiverve.com/v1/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apogeoapi/apogeoapi-mcp",
+      "version": "1.0.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.apogeoapi/apogeoapi-mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-11T20:08:47.845785Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "apogeoapi-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@apogeoapi/mcp"
+            ],
+            "env": {
+              "APOGEOAPI_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.app-dex/appdex",
+      "version": "1.0.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.app-dex/appdex",
+      "registry_status": "active",
+      "published_at": "2026-07-25T13:57:28.542372Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "appdex": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "appdex-mcp"
+            ],
+            "env": {
+              "APPDEX_API_KEY": "${VALUE}",
+              "APPDEX_API_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.appendix/appendix",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.appendix.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T14:51:59.867949Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "appendix": {
+            "type": "http",
+            "url": "https://mcp.appendix.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.appfigures/mcp",
+      "version": "1.0.3",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.appfigures/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-05T16:09:55.688638Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@appfigures/cli"
+            ],
+            "env": {
+              "APPFIGURES_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.apple-rag/mcp-server",
+      "version": "2.9.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.apple-rag.com",
+      "registry_status": "active",
+      "published_at": "2025-09-21T07:40:13.389326Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.apple-rag.com",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.applivery.docs/mcp",
+      "version": "2.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://docs.applivery.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T15:29:57.597989Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://docs.applivery.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.appsflyer/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.appsflyer.com/auth/mcp",
+      "registry_status": "active",
+      "published_at": "2025-11-11T15:21:47.037331Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.appsflyer.com/auth/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcadedb/mcp-server",
+      "version": "26.4.1-SNAPSHOT",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.arcadedb/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-03-10T16:22:56.207278Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "docker",
+            "args": [
+              "run",
+              "-i",
+              "--rm",
+              "docker.io/arcadedata/arcadedb:26.4.1-SNAPSHOT"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcaneforecasting/world-sense",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.arcaneforecasting.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T20:37:52.174931Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "world-sense": {
+            "type": "http",
+            "url": "https://mcp.arcaneforecasting.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcanum-plus/backlog-forge",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://backlog-forge.arcanum-plus.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T01:22:47.753639Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "backlog-forge": {
+            "type": "http",
+            "url": "https://backlog-forge.arcanum-plus.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}",
+              "X-Ado-Organization": "${SECRET}",
+              "X-Ado-Pat": "${SECRET}",
+              "X-Ado-Project": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcasos/arcasos-rentals",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.arcasos.com",
+      "registry_status": "active",
+      "published_at": "2026-05-20T08:12:52.962218Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "arcasos-rentals": {
+            "type": "http",
+            "url": "https://mcp.arcasos.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcat/arcat",
+      "version": "0.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.arcat.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T12:06:05.314648Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "arcat": {
+            "type": "http",
+            "url": "https://mcp.arcat.com/mcp",
+            "headers": {
+              "x-api-key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.archerionlabs/nasc",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://nasc.archerionlabs.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T22:34:31.686808Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nasc": {
+            "type": "http",
+            "url": "https://nasc.archerionlabs.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcjet/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.arcjet.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-23T22:05:37.064727Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.arcjet.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arcself/arc-security",
+      "version": "0.5.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.arcself/arc-security",
+      "registry_status": "active",
+      "published_at": "2026-02-17T23:43:51.442858Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "arc-security": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "arc-security-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.argosvix/server",
+      "version": "1.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.argosvix/server",
+      "registry_status": "active",
+      "published_at": "2026-07-17T01:54:48.869993Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@argosvix/mcp-server"
+            ],
+            "env": {
+              "ARGOSVIX_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aribadernatal/sideways",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://sideways.aribadernatal.com/mcp",
+      "registry_status": "active",
+      "published_at": "2025-10-22T06:51:20.015804Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sideways": {
+            "type": "http",
+            "url": "https://sideways.aribadernatal.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.artificialwit/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.artificialwit.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T09:31:32.215228Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.artificialwit.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.artifyde/artifyde-mcp",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.artifyde/artifyde-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T05:09:57.319608Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "artifyde-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "artifyde-mcp"
+            ],
+            "env": {
+              "ARTIFYDE_TOKEN": "${VALUE}",
+              "ARTIFYDE_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.arzbin/market-data",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://hub.arzbin.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-28T09:18:52.259065Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "market-data": {
+            "type": "http",
+            "url": "https://hub.arzbin.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ask-ai-data-connector/ask-ai",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ask-ai-data-connector.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T23:12:42.595818Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ask-ai": {
+            "type": "http",
+            "url": "https://ask-ai-data-connector.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.askmatchbox/matchbox",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://askmatchbox.com/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-11T13:29:49.780501Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "matchbox": {
+            "type": "http",
+            "url": "https://askmatchbox.com/api/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.asksakina/islamic-knowledge",
+      "version": "1.0.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://sakina-mcp.fly.dev/sse",
+      "registry_status": "active",
+      "published_at": "2026-05-10T13:32:39.331853Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "islamic-knowledge": {
+            "type": "sse",
+            "url": "https://sakina-mcp.fly.dev/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.assetzaar/marketplace",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://assetzaar.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T17:53:17.404962Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketplace": {
+            "type": "http",
+            "url": "https://assetzaar.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.asterwise/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.asterwise.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-25T14:04:47.903607Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.asterwise.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.astranl/mcp",
+      "version": "1.32.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://astranl.com/mcp/streamable",
+      "registry_status": "active",
+      "published_at": "2026-07-23T09:39:26.354008Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://astranl.com/mcp/streamable"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.astravue/astravue-mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.astravue.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-08T19:00:43.037655Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "astravue-mcp": {
+            "type": "http",
+            "url": "https://api.astravue.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.atagon/kogiqa-mcp",
+      "version": "1.3.29",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.atagon/kogiqa-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T13:00:34.08591Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kogiqa-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "kogiqa-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.atlasemoji/mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://atlasemoji.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T14:04:53.219763Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://atlasemoji.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.atlassian/atlassian-mcp-server",
+      "version": "1.1.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.atlassian.com/v1/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T00:01:55.705871Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "atlassian-mcp-server": {
+            "type": "http",
+            "url": "https://mcp.atlassian.com/v1/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.atom/premium-domains",
+      "version": "2.0.7",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.atom.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T14:56:33.162538Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "premium-domains": {
+            "type": "http",
+            "url": "https://mcp.atom.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.attribloom/mcp",
+      "version": "0.1.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.attribloom/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T15:26:03.600748Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@attribloom/mcp"
+            ],
+            "env": {
+              "ATTRIBLOOM_API_KEY": "${VALUE}",
+              "ATTRIBLOOM_BASE_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.attrove/mcp",
+      "version": "0.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.attrove.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T23:41:40.148397Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.attrove.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.audiala/mcp",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.audiala.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T16:11:06.005044Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.audiala.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.audioscrape/audio-intelligence",
+      "version": "1.0.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.audioscrape.com",
+      "registry_status": "active",
+      "published_at": "2026-01-30T17:32:41.076712Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "audio-intelligence": {
+            "type": "http",
+            "url": "https://mcp.audioscrape.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.aurelianflo/core",
+      "version": "0.4.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.aurelianflo.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-05T05:24:50.401509Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "core": {
+            "type": "http",
+            "url": "https://api.aurelianflo.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.auriniaxo/hostel",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://auriniaxo.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T17:39:21.268219Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hostel": {
+            "type": "http",
+            "url": "https://auriniaxo.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.auth0/mcp",
+      "version": "0.1.0-beta.10",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.auth0/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-26T15:32:18.592492Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@auth0/auth0-mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.automatedclientacquisition.www/aca",
+      "version": "1.0.2",
+      "transport": "sse",
+      "auth_mode": "static-credential",
+      "source_url": "https://www.automatedclientacquisition.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-01T07:15:16.627813Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aca": {
+            "type": "sse",
+            "url": "https://www.automatedclientacquisition.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.automox/automox-mcp",
+      "version": "2.2.9",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.automox/automox-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-22T01:44:44.40135Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "automox-mcp": {
+            "command": "uvx",
+            "args": [
+              "automox-mcp"
+            ],
+            "env": {
+              "AUTOMOX_API_KEY": "${VALUE}",
+              "AUTOMOX_ACCOUNT_UUID": "${VALUE}",
+              "AUTOMOX_ORG_ID": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/atc",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/atc",
+      "registry_status": "active",
+      "published_at": "2026-06-19T19:01:09.351311Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "atc": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/atc"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/avatax",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/avatax",
+      "registry_status": "active",
+      "published_at": "2026-06-19T18:07:56.289577Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "avatax": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/avatax"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/bl",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/bl",
+      "registry_status": "active",
+      "published_at": "2026-06-25T17:24:25.592338Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bl": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/bl"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/classification",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/classification",
+      "registry_status": "active",
+      "published_at": "2026-06-25T17:28:34.186005Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "classification": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/classification"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/cross-border",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/cross-border",
+      "registry_status": "active",
+      "published_at": "2026-06-25T17:21:50.625008Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cross-border": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/cross-border"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/docs",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/docs",
+      "registry_status": "active",
+      "published_at": "2026-06-19T18:13:25.472692Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "docs": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/docs"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/elr",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/elr",
+      "registry_status": "active",
+      "published_at": "2026-07-21T16:59:51.929669Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "elr": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/elr"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avalara/returns",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avalara.com/returns",
+      "registry_status": "active",
+      "published_at": "2026-06-19T18:57:41.67864Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "returns": {
+            "type": "http",
+            "url": "https://mcp.avalara.com/returns"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avaza/avaza-mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avaza.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T20:42:58.855857Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "avaza-mcp": {
+            "type": "http",
+            "url": "https://mcp.avaza.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.avnester.mcp/property-intelligence",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.avnester.com/public-mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-28T09:40:26.004304Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "property-intelligence": {
+            "type": "http",
+            "url": "https://mcp.avnester.com/public-mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.awardflightdaily/award-flight-daily",
+      "version": "1.26.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://awardflightdaily.com/mcp-server/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-29T04:39:15.917547Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "award-flight-daily": {
+            "type": "http",
+            "url": "https://awardflightdaily.com/mcp-server/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.axiomatic-ai/prover",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://prover.axiomatic-ai.com/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-02-23T22:16:23.957805Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "prover": {
+            "type": "http",
+            "url": "https://prover.axiomatic-ai.com/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.axiomseal/axiomseal",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.axiomseal.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T11:42:42.00184Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "axiomseal": {
+            "type": "http",
+            "url": "https://mcp.axiomseal.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.axiorank/axiorank",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://app.axiorank.com/api/mcp-server/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-08T13:48:31.15406Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "axiorank": {
+            "type": "http",
+            "url": "https://app.axiorank.com/api/mcp-server/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.ayurak/aribot-mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.aribot.ayurak.com/",
+      "registry_status": "active",
+      "published_at": "2026-07-05T08:22:23.415396Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aribot-mcp": {
+            "type": "http",
+            "url": "https://mcp.aribot.ayurak.com/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.azurecarbon/kodiak",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.azurecarbon/kodiak",
+      "registry_status": "active",
+      "published_at": "2026-07-24T19:18:32.592008Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "kodiak": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "kodiak-mcp"
+            ],
+            "env": {
+              "KODIAK_API_KEY": "${VALUE}",
+              "KODIAK_URL": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.b20check/b20check",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://b20check.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-12T18:41:43.811933Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "b20check": {
+            "type": "http",
+            "url": "https://b20check.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.b2bware/mcp-server",
+      "version": "1.13.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.b2bware.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T20:45:45.21637Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.b2bware.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.babyblueviper/invinoveritas",
+      "version": "1.12.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.babyblueviper.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T16:48:16.592866Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "invinoveritas": {
+            "type": "http",
+            "url": "https://api.babyblueviper.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.backtest360/backtest360",
+      "version": "0.4.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.backtest360.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T22:10:02.808709Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "backtest360": {
+            "type": "http",
+            "url": "https://mcp.backtest360.com/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.balladic/mcp",
+      "version": "0.4.33",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.balladic.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-01T21:14:45.121353Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.balladic.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bankruptcyobserver/mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.bankruptcyobserver.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-15T22:22:06.291721Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.bankruptcyobserver.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.barisasa.earlywire/wire",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://earlywire.barisasa.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-18T02:45:51.00183Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "wire": {
+            "type": "http",
+            "url": "https://earlywire.barisasa.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.basenull/agent-check",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent-check.basenull.com/api/mcp/{token}",
+      "registry_status": "active",
+      "published_at": "2026-07-04T14:14:45.263445Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-check": {
+            "type": "http",
+            "url": "https://agent-check.basenull.com/api/mcp/{token}"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.basenull/agent-talk",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://agent-talk.basenull.com/mcp/{channel_key}",
+      "registry_status": "active",
+      "published_at": "2026-07-04T14:14:43.933012Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-talk": {
+            "type": "http",
+            "url": "https://agent-talk.basenull.com/mcp/{channel_key}"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.basenull/exec-brief",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://exec-brief.basenull.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T14:14:45.760883Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "exec-brief": {
+            "type": "http",
+            "url": "https://exec-brief.basenull.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.basenull/okr",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://okr.basenull.com/mcp/{token}",
+      "registry_status": "active",
+      "published_at": "2026-07-04T14:14:44.543313Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "okr": {
+            "type": "http",
+            "url": "https://okr.basenull.com/mcp/{token}"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.basenull/polls",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://polls.basenull.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T14:14:50.961901Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "polls": {
+            "type": "http",
+            "url": "https://polls.basenull.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.beacio/mcp",
+      "version": "1.0.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.beacio/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-14T15:20:50.062325Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@beacio/mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.beauticslab/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.beauticslab.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-17T23:40:15.864633Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.beauticslab.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bellwethermetrics/bellwether-mcp",
+      "version": "0.1.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.bellwethermetrics/bellwether-mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-06T03:30:12.908023Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bellwether-mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "bellwether-mcp"
+            ],
+            "env": {
+              "BELLWETHER_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.benriscore/api",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.benriscore.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-24T06:34:18.45126Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "api": {
+            "type": "http",
+            "url": "https://api.benriscore.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.besot/catalogue",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.besot.com",
+      "registry_status": "active",
+      "published_at": "2026-07-13T01:50:14.737786Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalogue": {
+            "type": "http",
+            "url": "https://mcp.besot.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.besttimetobookhotels/booking-timing",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.besttimetobookhotels.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T09:34:59.984594Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "booking-timing": {
+            "type": "http",
+            "url": "https://www.besttimetobookhotels.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.beycome/listing",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.beycome.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-30T01:30:35.340412Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "listing": {
+            "type": "http",
+            "url": "https://mcp.beycome.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.beyourcover/book-cover-generator",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://beyourcover.com/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T11:09:35.346302Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "book-cover-generator": {
+            "type": "http",
+            "url": "https://beyourcover.com/api/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.biaedge/immigration-research",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.biaedge.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T03:20:56.854168Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "immigration-research": {
+            "type": "http",
+            "url": "https://mcp.biaedge.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bidda/bidda-compliance",
+      "version": "1.6.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bidda.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T14:17:54.017572Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bidda-compliance": {
+            "type": "http",
+            "url": "https://bidda.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bidsparq/mcp",
+      "version": "0.3.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bidsparq.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-29T01:29:43.107798Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://bidsparq.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bikefuchs/bikefuchs",
+      "version": "2.5.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.bikefuchs.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T15:22:12.614289Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bikefuchs": {
+            "type": "http",
+            "url": "https://mcp.bikefuchs.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.billingserv/mcp",
+      "version": "0.1.9",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.billingserv/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T18:27:49.781104Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@billingserv/mcp-server"
+            ],
+            "env": {
+              "BILLINGSERV_API_BASE_URL": "${VALUE}",
+              "BILLINGSERV_API_KEY": "${VALUE}",
+              "BILLINGSERV_TIMEOUT_MS": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.biodnd/agent-fin",
+      "version": "0.1.2",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://agent-fin.biodnd.com/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-23T09:47:11.441639Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-fin": {
+            "type": "sse",
+            "url": "https://agent-fin.biodnd.com/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.biodnd/agent-ip",
+      "version": "0.1.2",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://agent-ip.biodnd.com/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-23T09:47:07.378272Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-ip": {
+            "type": "sse",
+            "url": "https://agent-ip.biodnd.com/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.biodnd/agent-press",
+      "version": "0.1.2",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://agent-press.biodnd.com/sse",
+      "registry_status": "active",
+      "published_at": "2025-09-23T09:47:04.193457Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-press": {
+            "type": "sse",
+            "url": "https://agent-press.biodnd.com/sse"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bitpoort/on-chain-data",
+      "version": "3.4.1",
+      "transport": "sse",
+      "auth_mode": "static-credential",
+      "source_url": "https://bitpoort.com/mcp/sse",
+      "registry_status": "active",
+      "published_at": "2026-04-05T12:42:48.649681Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "on-chain-data": {
+            "type": "sse",
+            "url": "https://bitpoort.com/mcp/sse",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bitsbound/contract-analysis",
+      "version": "1.0.6",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.bitsbound/contract-analysis",
+      "registry_status": "active",
+      "published_at": "2025-12-22T13:57:28.0431Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "contract-analysis": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@bitsbound/mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bitsbound/contract-automation",
+      "version": "1.0.8",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.bitsbound/contract-automation",
+      "registry_status": "active",
+      "published_at": "2025-12-22T14:56:59.448374Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "contract-automation": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@bitsbound/mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bitvoya/bitvoya-mcp",
+      "version": "0.3.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://bitvoya.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T15:11:58.522865Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bitvoya-mcp": {
+            "type": "http",
+            "url": "https://bitvoya.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.biz-planner/mcp",
+      "version": "0.6.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://biz-planner.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-29T11:46:28.933534Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://biz-planner.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bizgigz/agent-marketplace",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://agents.bizgigz.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-22T12:06:15.198956Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agent-marketplace": {
+            "type": "http",
+            "url": "https://agents.bizgigz.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bizgigz/talent-ecosystem",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://bizgigz.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-02-22T12:06:18.808214Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "talent-ecosystem": {
+            "type": "http",
+            "url": "https://bizgigz.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackduck/mcp-server",
+      "version": "1.1.8",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.blackduck/mcp-server",
+      "registry_status": "active",
+      "published_at": "2026-07-17T21:20:00.360611Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@black-duck/mcp-server"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackswancausallabs/dagstudio-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://dagstudio-mcp.blackswancausallabs.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T05:20:21.320784Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dagstudio-mcp": {
+            "type": "http",
+            "url": "https://dagstudio-mcp.blackswancausallabs.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackswancausallabs/target-mcp",
+      "version": "0.1.2",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.blackswancausallabs/target-mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T06:28:10.599812Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "target-mcp": {
+            "command": "uvx",
+            "args": [
+              "target-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackveilsecurity/dns",
+      "version": "3.36.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://dns-mcp.blackveilsecurity.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T09:50:36.09908Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "dns": {
+            "type": "http",
+            "url": "https://dns-mcp.blackveilsecurity.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackwalltier/blackwall",
+      "version": "1.4.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.blackwalltier/blackwall",
+      "registry_status": "active",
+      "published_at": "2026-07-05T07:42:42.126675Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "blackwall": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "blackwall-mcp"
+            ],
+            "env": {
+              "BLACKWALL_API_KEY": "${VALUE}",
+              "BLACKWALL_MODE": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blackwalltier/blackwall-x402-guardrail",
+      "version": "0.1.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.blackwalltier.com",
+      "registry_status": "active",
+      "published_at": "2026-07-08T03:00:54.394849Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "blackwall-x402-guardrail": {
+            "type": "http",
+            "url": "https://mcp.blackwalltier.com"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blazesportsintel/college-baseball",
+      "version": "3.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://sabermetrics.blazesportsintel.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T10:51:59.051024Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "college-baseball": {
+            "type": "http",
+            "url": "https://sabermetrics.blazesportsintel.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blicht/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://blicht.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T22:06:37.748247Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://blicht.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blockscout/mcp-server",
+      "version": "0.16.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.blockscout.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-16T14:57:44.226473Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://mcp.blockscout.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.blockventurechaincapital/bvcc-agent-wallet",
+      "version": "0.1.6",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.blockventurechaincapital/bvcc-agent-wallet",
+      "registry_status": "active",
+      "published_at": "2026-06-29T19:56:10.555531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bvcc-agent-wallet": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@bvcc/agent-mcp"
+            ],
+            "env": {
+              "AGENT_PRIVATE_KEY": "${VALUE}",
+              "WALLET_ADDRESS": "${VALUE}",
+              "CHAIN_ID": "${VALUE}",
+              "RPC_URL": "${VALUE}",
+              "BVCC_MCP_READONLY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bluepillow/hotels",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.b2a.bluepillow.com/",
+      "registry_status": "active",
+      "published_at": "2026-07-07T15:54:05.873578Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "hotels": {
+            "type": "http",
+            "url": "https://mcp.b2a.bluepillow.com/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bmcxiv/breach402-owner-protection",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://breach402.bmcxiv.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-26T04:27:05.692038Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "breach402-owner-protection": {
+            "type": "http",
+            "url": "https://breach402.bmcxiv.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bmikit/body-composition",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bmikit.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-27T10:26:16.117289Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "body-composition": {
+            "type": "http",
+            "url": "https://bmikit.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bolotstudio/store",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bolotstudio.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T17:47:52.682204Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "store": {
+            "type": "http",
+            "url": "https://bolotstudio.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/booking-request",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/booking-request/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:49.320441Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "booking-request": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/booking-request/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/compliance-batch",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/compliance-batch/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:54.230033Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "compliance-batch": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/compliance-batch/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/content-provenance",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/content-provenance/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:40.697109Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "content-provenance": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/content-provenance/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/knox-anchor",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-01T01:35:56.303777Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "knox-anchor": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/ofac-sdn-screening",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/ofac-sdn-screening/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:34.967979Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ofac-sdn-screening": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/ofac-sdn-screening/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/registry-expansion",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/registry-expansion/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:52.742076Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "registry-expansion": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/registry-expansion/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/sstv-decoder",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bonissystems.com/api/knox/agents/sstv-decoder/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:46.722493Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "sstv-decoder": {
+            "type": "http",
+            "url": "https://bonissystems.com/api/knox/agents/sstv-decoder/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bonissystems/trustai-verify",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://trustailaw.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T15:13:54.486422Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "trustai-verify": {
+            "type": "http",
+            "url": "https://trustailaw.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bookingmaven/marketplace",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.bookingmaven.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-04T02:00:05.441275Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "marketplace": {
+            "type": "http",
+            "url": "https://mcp.bookingmaven.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.boostedchat/travel",
+      "version": "0.1.2",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.boostedchat.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-01T17:36:52.323373Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "travel": {
+            "type": "http",
+            "url": "https://api.boostedchat.com/mcp",
+            "headers": {
+              "X-API-Key": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.boostermage/mtg-prices",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.boostermage.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-13T15:19:15.60541Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mtg-prices": {
+            "type": "http",
+            "url": "https://mcp.boostermage.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.boothcheck/boothcheck",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://boothcheck.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T17:45:16.661709Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "boothcheck": {
+            "type": "http",
+            "url": "https://boothcheck.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.borisinc/aegis",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://aegis-mcp.borisinc.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T11:27:29.261707Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "aegis": {
+            "type": "http",
+            "url": "https://aegis-mcp.borisinc.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.borisinc/gamedatakit",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.borisinc.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T14:27:26.959368Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "gamedatakit": {
+            "type": "http",
+            "url": "https://mcp.borisinc.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.borisinc/memory",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mem.borisinc.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T14:27:23.361384Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "memory": {
+            "type": "http",
+            "url": "https://mem.borisinc.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.borisinc/tools",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://tools.borisinc.com/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-07-20T11:57:12.016348Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tools": {
+            "type": "http",
+            "url": "https://tools.borisinc.com/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bounceprotect.www/mcp",
+      "version": "1.0.6",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.bounceprotect.www/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-22T02:24:25.542915Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@bounceprotect/mcp"
+            ],
+            "env": {
+              "YOUR_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.braincloudservers/braincloud-mcp",
+      "version": "6.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.braincloudservers.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T18:05:10.288014Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "braincloud-mcp": {
+            "type": "http",
+            "url": "https://mcp.braincloudservers.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.braincloudservers/braincloud-mcp-helper",
+      "version": "6.0.0",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.braincloudservers/braincloud-mcp-helper",
+      "registry_status": "active",
+      "published_at": "2026-07-10T18:36:13.361428Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "braincloud-mcp-helper": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@braincloud/mcp-helper"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.brainiall/tts",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.brainiall.com/mcp/tts/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T19:14:18.70716Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "tts": {
+            "type": "http",
+            "url": "https://api.brainiall.com/mcp/tts/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.brainonbnb/bobai",
+      "version": "1.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://brainonbnb.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T04:13:56.096263Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bobai": {
+            "type": "http",
+            "url": "https://brainonbnb.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.breckenwander/travel-connector",
+      "version": "0.2.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.breckenwander.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T19:44:21.882531Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "travel-connector": {
+            "type": "http",
+            "url": "https://mcp.breckenwander.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bridgetoagent/ai-readiness",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.bridgetoagent.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T14:14:18.053342Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ai-readiness": {
+            "type": "http",
+            "url": "https://www.bridgetoagent.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.brightsec/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://{instance}.brightsec.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-01-06T14:23:23.608647Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://{instance}.brightsec.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.brokerchooser/broker-safety",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.brokerchooser.com/servers/mcp",
+      "registry_status": "active",
+      "published_at": "2025-09-29T09:55:15.328085Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "broker-safety": {
+            "type": "http",
+            "url": "https://mcp.brokerchooser.com/servers/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.browser-use/browser-use",
+      "version": "0.13.5",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.browser-use/browser-use",
+      "registry_status": "active",
+      "published_at": "2026-07-17T01:17:22.802703Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "browser-use": {
+            "command": "uvx",
+            "args": [
+              "browser-use"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.browserssh/browser-ssh",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://api.browserssh.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T00:16:20.287691Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "browser-ssh": {
+            "type": "http",
+            "url": "https://api.browserssh.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.builtwithjon/builtwithjon",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://builtwithjon.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-13T12:33:08.280448Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "builtwithjon": {
+            "type": "http",
+            "url": "https://builtwithjon.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bullpenstrategygroup.rotunda/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://rotunda.bullpenstrategygroup.com/mcp",
+      "registry_status": "active",
+      "published_at": "2025-10-12T17:18:07.009904Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://rotunda.bullpenstrategygroup.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.burnlore/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://burnlore.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T16:47:10.718861Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://burnlore.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bushdrum/events",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bushdrum.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-15T18:58:34.330713Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "events": {
+            "type": "http",
+            "url": "https://bushdrum.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bustup-monitor/mcp",
+      "version": "1.1.2",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://bustup-monitor.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-03T13:55:01.421682Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://bustup-monitor.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.buylater/buylater",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://buylater.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-02T10:41:54.098045Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "buylater": {
+            "type": "http",
+            "url": "https://buylater.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.buyukesim/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://buyukesim.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T08:23:46.300177Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://buyukesim.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bykaranteli/mcp",
+      "version": "0.1.1",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.bykaranteli/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T08:42:20.628196Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "bykaranteli-mcp"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.bzigo/bzigo",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.bzigo.com/",
+      "registry_status": "active",
+      "published_at": "2026-05-08T18:43:07.782107Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "bzigo": {
+            "type": "http",
+            "url": "https://mcp.bzigo.com/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cabal-hunter.api/cabal-hunter",
+      "version": "1.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.cabal-hunter.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-07T19:53:04.11657Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cabal-hunter": {
+            "type": "http",
+            "url": "https://api.cabal-hunter.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cajusticewatch/cajusticewatch",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cajusticewatch.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-16T07:19:19.446227Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cajusticewatch": {
+            "type": "http",
+            "url": "https://cajusticewatch.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.calcfleet/calculators",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://calcfleet.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-05T21:20:16.071362Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "calculators": {
+            "type": "http",
+            "url": "https://calcfleet.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.callingly/callingly",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.callingly.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T19:55:53.133009Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "callingly": {
+            "type": "http",
+            "url": "https://api.callingly.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.calmseo/seo-mcp",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.calmseo.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-15T20:12:13.234302Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "seo-mcp": {
+            "type": "http",
+            "url": "https://mcp.calmseo.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cambercloud.camber-mcp/camber-mcp-server",
+      "version": "1.0.4",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://camber-mcp.cambercloud.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-28T05:22:23.984337Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "camber-mcp-server": {
+            "type": "http",
+            "url": "https://camber-mcp.cambercloud.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.candidcost/mcp",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://candidcost.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T19:28:17.565224Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://candidcost.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cannonvoip/ask",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://ask.cannonvoip.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-11T02:45:25.673385Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "ask": {
+            "type": "http",
+            "url": "https://ask.cannonvoip.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.careerrift/career-rift",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.careerrift.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-16T19:15:34.967188Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "career-rift": {
+            "type": "http",
+            "url": "https://mcp.careerrift.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cashflowfrog.mcp/server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cashflowfrog.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-06T17:23:26.656353Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "server": {
+            "type": "http",
+            "url": "https://mcp.cashflowfrog.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.catalystedgescanner/catalyst-edge-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://catalystedgescanner.com/mcp/",
+      "registry_status": "active",
+      "published_at": "2026-07-05T07:38:39.959904Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catalyst-edge-mcp": {
+            "type": "http",
+            "url": "https://catalystedgescanner.com/mcp/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.catchdoms/expired-domains",
+      "version": "1.1.0",
+      "transport": "sse",
+      "auth_mode": "none",
+      "source_url": "https://catchdoms.com/mcp/catchdoms/free",
+      "registry_status": "active",
+      "published_at": "2026-04-06T11:04:59.226857Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "expired-domains": {
+            "type": "sse",
+            "url": "https://catchdoms.com/mcp/catchdoms/free"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.catchintent/catchintent",
+      "version": "2.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://engine.catchintent.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-30T10:16:46.676784Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "catchintent": {
+            "type": "http",
+            "url": "https://engine.catchintent.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cavuno/job-board-operator",
+      "version": "0.3.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cavuno.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-23T11:16:04.406675Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "job-board-operator": {
+            "type": "http",
+            "url": "https://mcp.cavuno.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cdata/cdata-connect-ai",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cloud.cdata.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-01T18:17:27.463824Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cdata-connect-ai": {
+            "type": "http",
+            "url": "https://mcp.cloud.cdata.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cerberusindex/cerberus-index",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cerberusindex.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T07:08:03.060912Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cerberus-index": {
+            "type": "http",
+            "url": "https://cerberusindex.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cerebrochain/cerebrochain",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cerebrochain.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-24T17:47:16.139868Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cerebrochain": {
+            "type": "http",
+            "url": "https://cerebrochain.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chadanalytics/chad",
+      "version": "0.2.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://chadanalytics.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-21T18:19:42.64812Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chad": {
+            "type": "http",
+            "url": "https://chadanalytics.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chaiz/mcp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.chaiz.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-25T12:08:18.631909Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://mcp.chaiz.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chalet-montagne/rentals",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.chalet-montagne.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-18T07:52:42.762332Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "rentals": {
+            "type": "http",
+            "url": "https://mcp.chalet-montagne.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.changethisfile/mcp",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://changethisfile.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-10T22:52:59.436032Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://changethisfile.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chapsoft/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://chapsoft.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-13T01:45:05.982893Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://chapsoft.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chartercaptain/charter-captain",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.chartercaptain.com/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-26T03:28:48.783584Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "charter-captain": {
+            "type": "http",
+            "url": "https://api.chartercaptain.com/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chartforgeai/chartforge",
+      "version": "0.1.4",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.chartforgeai/chartforge",
+      "registry_status": "active",
+      "published_at": "2026-06-16T23:48:35.509885Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chartforge": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "chartforge-mcp"
+            ],
+            "env": {
+              "CHARTFORGE_API_KEY": "${VALUE}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cheapestinference/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.cheapestinference.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-06T15:38:38.802669Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://api.cheapestinference.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.checkrecall/vehicle-recalls",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.checkrecall.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T18:21:40.958342Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "vehicle-recalls": {
+            "type": "http",
+            "url": "https://mcp.checkrecall.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cherokeeai/fifty50",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://cherokeeai.com/fifty50/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-09T22:59:57.893067Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "fifty50": {
+            "type": "http",
+            "url": "https://cherokeeai.com/fifty50/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chilipiper/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://fire.chilipiper.com/api/fire-edge/v1/org/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-07T15:06:27.356813Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://fire.chilipiper.com/api/fire-edge/v1/org/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.choosemylo/mind-of-mylo-quotes",
+      "version": "1.19.3",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://choosemylo.com/api/gateway/chatbot/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-24T13:40:08.377095Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mind-of-mylo-quotes": {
+            "type": "http",
+            "url": "https://choosemylo.com/api/gateway/chatbot/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chorilo/chorilo",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://backend.chorilo.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-20T05:55:20.316557Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chorilo": {
+            "type": "http",
+            "url": "https://backend.chorilo.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.chrysai.www/chrysai",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.chrysai.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-29T22:32:08.859525Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "chrysai": {
+            "type": "http",
+            "url": "https://www.chrysai.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cinderfi/retirement-planning",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.cinderfi.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-04-14T00:45:06.07236Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "retirement-planning": {
+            "type": "http",
+            "url": "https://mcp.cinderfi.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cintrasupply/cintra-quote",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.cintrasupply.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T14:26:38.653197Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cintra-quote": {
+            "type": "http",
+            "url": "https://www.cintrasupply.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.citationsafe/verifier",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://citationsafe.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-14T15:55:24.092208Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "verifier": {
+            "type": "http",
+            "url": "https://citationsafe.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.citehawk/citehawk",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://www.citehawk.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-10T12:27:25.931653Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "citehawk": {
+            "type": "http",
+            "url": "https://www.citehawk.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.citestamp/citestamp",
+      "version": "1.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://mcp.citestamp.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T01:43:41.116546Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "citestamp": {
+            "type": "http",
+            "url": "https://mcp.citestamp.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.cityparity/cityparity",
+      "version": "0.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://mcp.cityparity.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-31T23:43:04.69344Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "cityparity": {
+            "type": "http",
+            "url": "https://mcp.cityparity.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.citywalkplan/planner",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://citywalkplan.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-09T14:19:12.801367Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "planner": {
+            "type": "http",
+            "url": "https://citywalkplan.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.civic/nexus",
+      "version": "0.1.109",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://nexus.civic.com/hub/mcp",
+      "registry_status": "active",
+      "published_at": "2026-03-06T09:55:36.756665Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "nexus": {
+            "type": "http",
+            "url": "https://nexus.civic.com/hub/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.civilquants/civilquants",
+      "version": "0.0.1",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://api.civilquants.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-02T11:17:51.116893Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "civilquants": {
+            "type": "http",
+            "url": "https://api.civilquants.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.claidex/failure-intelligence",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://app.claidex.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-24T20:01:49.13518Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "failure-intelligence": {
+            "type": "http",
+            "url": "https://app.claidex.com/api/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.claribi/mcp-server",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://claribi.com/mcp/v1/",
+      "registry_status": "active",
+      "published_at": "2026-06-02T14:57:34.96247Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp-server": {
+            "type": "http",
+            "url": "https://claribi.com/mcp/v1/"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.claritybriefs/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://claritybriefs.com/api/mcp",
+      "registry_status": "active",
+      "published_at": "2026-06-22T18:51:21.778045Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://claritybriefs.com/api/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.claudeers/mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://claudeers.com/api/mcp/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-08T20:16:07.456591Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "mcp": {
+            "type": "http",
+            "url": "https://claudeers.com/api/mcp/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauderecall/recall",
+      "version": "0.96.9",
+      "transport": "stdio",
+      "auth_mode": "local-stdio",
+      "source_url": "https://registry.modelcontextprotocol.io/v0/servers?search=com.clauderecall/recall",
+      "registry_status": "active",
+      "published_at": "2026-06-30T19:09:11.690378Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "recall": {
+            "command": "npx",
+            "args": [
+              "-y",
+              "@clauderecallhq/cli"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauderegistry/plugin-catalog",
+      "version": "1.1.0",
+      "transport": "streamable-http",
+      "auth_mode": "none",
+      "source_url": "https://clauderegistry.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-07-15T03:25:01.654725Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "plugin-catalog": {
+            "type": "http",
+            "url": "https://clauderegistry.com/mcp"
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauxel.a2adependencyinspector/a2adependencyinspector-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://a2adependencyinspector.clauxel.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-20T12:22:51.10522Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "a2adependencyinspector-mcp": {
+            "type": "http",
+            "url": "https://a2adependencyinspector.clauxel.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauxel.a2aidentitytoll/a2aidentitytoll-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://a2aidentitytoll.clauxel.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-20T08:00:30.445666Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "a2aidentitytoll-mcp": {
+            "type": "http",
+            "url": "https://a2aidentitytoll.clauxel.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauxel.a2areplayreceipt/a2areplayreceipt-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://a2areplayreceipt.clauxel.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-20T12:29:08.259947Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "a2areplayreceipt-mcp": {
+            "type": "http",
+            "url": "https://a2areplayreceipt.clauxel.com/mcp",
+            "headers": {
+              "Authorization": "${SECRET}"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "com.clauxel.agentdataboundary/agentdataboundary-mcp",
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "auth_mode": "static-credential",
+      "source_url": "https://agentdataboundary.clauxel.com/mcp",
+      "registry_status": "active",
+      "published_at": "2026-05-19T03:39:57.50521Z",
+      "fetched_at": "2026-07-26",
+      "config": {
+        "mcpServers": {
+          "agentdataboundary-mcp": {
+            "type": "http",
+            "url": "https://agentdataboundary.clauxel.com/mcp",
             "headers": {
               "Authorization": "${SECRET}"
             }

--- a/research/state-of-mcp-2026/results.json
+++ b/research/state-of-mcp-2026/results.json
@@ -3,159 +3,151 @@
   "corpus": "benchmarks/data",
   "corpus_sources": {
     "crawl": 664,
-    "registry": 710
+    "registry": 1639
   },
-  "corpus_total_candidates": 1458,
-  "distinct_configs_scanned": 1374,
-  "duplicates_removed": 83,
+  "corpus_total_candidates": 2389,
+  "distinct_configs_scanned": 2303,
+  "duplicates_removed": 85,
   "unparseable_removed": 1,
   "grade_distribution": {
-    "A": 500,
-    "B": 643,
-    "C": 97,
+    "A": 632,
+    "B": 1426,
+    "C": 111,
     "D": 49,
     "F": 85
   },
-  "configs_with_critical": 494,
-  "configs_with_critical_pct": 36.0,
-  "configs_with_high": 164,
-  "configs_with_high_pct": 11.9,
+  "configs_with_critical": 1217,
+  "configs_with_critical_pct": 52.8,
+  "configs_with_high": 165,
+  "configs_with_high_pct": 7.2,
   "severity_totals": {
-    "critical": 616,
-    "high": 317,
-    "medium": 3406,
-    "low": 1045,
+    "critical": 1338,
+    "high": 318,
+    "medium": 4426,
+    "low": 1221,
     "info": 1
   },
   "transport_distribution": {
-    "stdio": 1265,
-    "streamable-http": 900,
-    "sse": 41,
+    "streamable-http": 1726,
+    "stdio": 1347,
+    "sse": 62,
     "unknown": 7
   },
   "rule_family_distribution": {
     "AAK-MCP": {
-      "configs": 1370,
-      "pct": 99.7
+      "configs": 2299,
+      "pct": 99.8
     },
     "AAK-OAUTH": {
-      "configs": 318,
-      "pct": 23.1
+      "configs": 421,
+      "pct": 18.3
     },
     "AAK-SECRET": {
       "configs": 70,
-      "pct": 5.1
+      "pct": 3.0
     },
     "AAK-TRANSPORT": {
-      "configs": 26,
-      "pct": 1.9
-    },
-    "AAK-HEALTHCARE": {
-      "configs": 1,
-      "pct": 0.1
+      "configs": 42,
+      "pct": 1.8
     },
     "AAK-INTERNAL": {
       "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     },
     "AAK-POISON": {
       "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     }
   },
   "category_hit_rate": {
     "mcp-config": {
-      "configs": 1370,
-      "pct": 99.7
+      "configs": 2299,
+      "pct": 99.8
     },
     "secret-exposure": {
       "configs": 70,
-      "pct": 5.1
+      "pct": 3.0
     },
     "transport-security": {
-      "configs": 26,
-      "pct": 1.9
+      "configs": 42,
+      "pct": 1.8
     },
     "agent-config": {
       "configs": 1,
-      "pct": 0.1
-    },
-    "legal-compliance": {
-      "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     },
     "tool-poisoning": {
       "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     }
   },
   "owasp_mcp_hit_rate": {
     "MCP07:2025": {
-      "configs": 1370,
-      "pct": 99.7
+      "configs": 2299,
+      "pct": 99.8
     },
     "MCP01:2025": {
-      "configs": 385,
-      "pct": 28.0
+      "configs": 489,
+      "pct": 21.2
     },
     "MCP03:2025": {
-      "configs": 377,
-      "pct": 27.4
+      "configs": 450,
+      "pct": 19.5
     },
     "MCP10:2025": {
-      "configs": 377,
-      "pct": 27.4
+      "configs": 450,
+      "pct": 19.5
     },
     "MCP04:2025": {
-      "configs": 205,
-      "pct": 14.9
+      "configs": 209,
+      "pct": 9.1
     },
     "MCP09:2025": {
       "configs": 44,
-      "pct": 3.2
+      "pct": 1.9
     },
     "MCP02:2025": {
       "configs": 12,
-      "pct": 0.9
+      "pct": 0.5
     },
     "MCP05:2025": {
       "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     },
     "MCP06:2025": {
       "configs": 1,
-      "pct": 0.1
+      "pct": 0.0
     }
   },
   "auth_profile_2026_07_28": {
     "no_authentication": {
-      "n": 482,
-      "denominator": 1374,
-      "pct": 35.1
+      "n": 1205,
+      "denominator": 2303,
+      "pct": 52.3
     },
     "rfc9728_prm_discovery": {
       "n": 0,
-      "denominator": 1374,
+      "denominator": 2303,
       "pct": 0.0
     },
     "remote_configs": {
-      "n": 801,
-      "denominator": 1374,
-      "pct": 58.3
+      "n": 1648,
+      "denominator": 2303,
+      "pct": 71.6
     },
     "remote_auth_static_credential": {
-      "n": 318,
-      "denominator": 318,
+      "n": 421,
+      "denominator": 421,
       "pct": 100.0
     },
     "sse_transport_stateless_break_proxy": {
-      "n": 26,
-      "denominator": 1374,
-      "pct": 1.9
+      "n": 47,
+      "denominator": 2303,
+      "pct": 2.0
     },
     "removal_clock_features_measured_from_config": {
       "n": 0,
-      "denominator": 1374,
+      "denominator": 2303,
       "pct": 0.0
     }
   },
@@ -164,71 +156,71 @@
       "rule_id": "AAK-MCP-001",
       "title": "Remote MCP server without authentication",
       "severity": "critical",
-      "configs": 482,
-      "config_pct": 35.1
+      "configs": 1205,
+      "config_pct": 52.3
     },
     {
       "rule_id": "AAK-MCP-005",
       "title": "MCP server uses npx/uvx to fetch and execute remote packages",
       "severity": "medium",
-      "configs": 377,
-      "config_pct": 27.4
+      "configs": 450,
+      "config_pct": 19.5
     },
     {
       "rule_id": "AAK-OAUTH-008",
       "title": "MCP OAuth surface with no RFC 9728 Protected Resource Metadata discovery",
       "severity": "low",
-      "configs": 318,
-      "config_pct": 23.1
+      "configs": 421,
+      "config_pct": 18.3
     },
     {
       "rule_id": "AAK-MCP-006",
       "title": "MCP server command uses relative path",
       "severity": "medium",
-      "configs": 175,
-      "config_pct": 12.7
+      "configs": 179,
+      "config_pct": 7.8
     },
     {
       "rule_id": "AAK-MCP-003",
       "title": "MCP server environment exposes secrets",
       "severity": "high",
       "configs": 70,
-      "config_pct": 5.1
+      "config_pct": 3.0
     },
     {
       "rule_id": "AAK-SECRET-007",
       "title": "Secret in MCP server environment block",
       "severity": "medium",
       "configs": 70,
-      "config_pct": 5.1
+      "config_pct": 3.0
     },
     {
       "rule_id": "AAK-MCP-STDIO-LAUNCHER-INJECT-001",
       "title": "MCP stdio server launches a shell-style interpreter with an exec flag or interpolated args",
       "severity": "high",
       "configs": 49,
-      "config_pct": 3.6
+      "config_pct": 2.1
     },
     {
       "rule_id": "AAK-MCP-009",
       "title": "MCP server URL points to localhost/internal network",
       "severity": "high",
       "configs": 44,
-      "config_pct": 3.2
+      "config_pct": 1.9
     },
     {
       "rule_id": "AAK-TRANSPORT-003",
       "title": "Deprecated SSE transport in use",
       "severity": "medium",
-      "configs": 21,
-      "config_pct": 1.5
+      "configs": 36,
+      "config_pct": 1.6
     },
     {
       "rule_id": "AAK-MCP-004",
       "title": "Excessive number of MCP servers declared",
       "severity": "high",
       "configs": 12,
-      "config_pct": 0.9
+      "config_pct": 0.5
     }
   ],
   "excluded_advisory_rules": [

--- a/research/state-of-mcp-2026/state-of-mcp-security-2026.pdf
+++ b/research/state-of-mcp-2026/state-of-mcp-security-2026.pdf
@@ -1,0 +1,86 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 9 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/PageMode /UseNone /Pages 9 0 R /Type /Catalog
+>>
+endobj
+8 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20260726161920+05'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260726161920+05'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (State of MCP Security 2026) /Trapped /False
+>>
+endobj
+9 0 obj
+<<
+/Count 1 /Kids [ 6 0 R ] /Type /Pages
+>>
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1879
+>>
+stream
+Gat%$>B?8p&:Vs/fU#@(Sj5QroB,'o:"iiU9]j"_Kn(/l@W2M312"m^5:[:'-:+Hf8^L##G5'`s/R!8Cn>Fn<UCG#r!M#bITG%T3TUVqf_%k1HUYeSQ5WUOM*^ML*C%WHm35TP/:(m!JTG.I=bG>ceAU'[/=UqS=0hd0VKgclF'_2uDcb@;K7MSS=QP1J[Z&^('$,Iuc\sq'&+8@oS`3s63ON%iA7u&$=R6K!!S5sW-IS3;[<("&U=;'Vd0rm.QkR#27Uhl6*8Ppg3CX&=QQu6ELJR3upeSEmoR3#Gd=pU<\'P7n$q6QNkU,`Rc!GXKU-*a"Q">J$P[OMi2@V>tagmBWB@9_Qc8Q<=(T^7drM"5AI4;>#ir;/3XiD]UC$sdA7^dgj9E#X/?$/IMPs-C]'2MRpV%dhSX@X^H!B'j9@G4YqIA+!,p-!?aKgd(;h%m9'Z8//sr&MQ>N2*c;@@p1qcT4h-BiLUFSm=KpJ0\$",`UI6HltX4Fe[%-R251%d2qUMJcSYYu*emiF:[=K7,1#TH3=tBGN?=9pp":<U1]!u0EU@i3-4`<X:7Wq(PaG38fsoYq3Ap?-P]egWK@,O6eZ$M>.-;'VO9)HCWpU@$-X]mqY.*B.YWJRlc06-s3]o3&k]rBUDaP-!BJjTerMEub/"3>.\I&&T^C2`-djlk+J[L;KI#tWH5b2SSP`iiXFH^4*mSo[RUg3(_$"6i:Z'$G2==/;OaOqb#c3%ebB*#c=J%iS-Q804Hh,>mc@f\D<9hMqG]OtC_[")uiHs/Zs6^biLQI-Vf/-bs00._2QCV6t_UL2s^*QShWD4!C4geR<i$Zq"OFbA=cFo.6L#6Ld7@o4%-P71uln:?+0+5BUG^/.dF'h5P?3b18Gk;2TIikfno`1rL8i6rmR(h0X^)<,upjKGR37gBNo7b"3f]qhm/h@T1#,_\KEW[mh!_!-k,ogc'mql\akGQu[._.\_Js2YkH>Rutig`BNa``8Zb0#(Z4L^KNCC/UW)k"%:8J3"rip6`'HgYhVA<8Zi.CI'17bJ=m:pSD^]TDA'YM)mDd@`*Fa"`TF#JB=btd%]Y(8Ho9mn'aDq2+5tYXD!OMoB!)p28-Vi?-I`Yo&f7c(6$de+_*(I!_--pb$DeVBenG6qGtU-hXXFZ.Z;jpi=Ll(9iIl:?W)d,_)q.PnXFK=qXN.Zb9!b5n,[PV!'-VN/-6t6H:-\g_<`1m!Ab\@#kXKs"ADl[WFl@X1hE75c2IaRo<2Pk,K#,bI8#AL?0=Y%>'&!+'J`iUj_QV>aM,@lrq'gmrRMM!:-NrAOV9uc[AD@VbSVb1%<V^J9JOsm*Qc90%ODLh@[j_#Lg[%u4S6>&%X;+rpij]b6"qS4FB@7+Uh@B\bb$+`'YHnJe`Io?.lpGQF^V6dV'2UR7hT`'^>e%r,Lt4acc.<,p[l3?WPjCd?-BLPDn:=\_P3XP`12!)UNJ98lKb"R7hN)qIQ)15`%6plZ^A=5(.Yu>N2i8ad;E">fr=AHH*&i?YKLW[3I=J$X2s#\0j6G(8'=Y!X$\6;,KA7jUHM]7+_p%iB!bngL*lUNUX"b7HdR/9*jmL_?FR7qCT6BSG1Nn9r1CC'dt@NMQA;39Ych2)G$V`g>F)IUPfh`sK8f$GXi:A2l(I:&-9$5=b)JPI?K-5s2dZiVc0^"+XELa\rq67OG)!;,ZjO8m4PdY7=1D@PPq>`2mtcd7$1KGiX@!anGte#aU.!fLi;5=mQ@u4eV-8@8H6!(HMYZ.J0d$=8ia\D!j!s%pJ,<a#o(]<^P&bkd2S1?+n/&j<o5Z0YK\VCkk>dDI4CkP(`r-&[MTnkC[U[Ws5slEi:H<?nj==dTD&",^;h*)n]"3aq*e:$c!I,3?+T~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000341 00000 n 
+0000000460 00000 n 
+0000000565 00000 n 
+0000000759 00000 n 
+0000000827 00000 n 
+0000001120 00000 n 
+0000001179 00000 n 
+trailer
+<<
+/ID 
+[<7f792f96acfddef611a7cd71ca4c7ea6><7f792f96acfddef611a7cd71ca4c7ea6>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 8 0 R
+/Root 7 0 R
+/Size 11
+>>
+startxref
+3150
+%%EOF

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -55,4 +55,4 @@ def test_gitlab_template_is_valid_yaml() -> None:
 def test_version_is_bumped() -> None:
     from agent_audit_kit import __version__
 
-    assert __version__ == "0.3.59"
+    assert __version__ == "0.3.60"


### PR DESCRIPTION
Publishes the **State of MCP Security 2026** data report — a credibility artifact, no new detection, nothing gated.

## What changed
- **Fresh corpus** (`fetch_registry.py`, live MCP Registry): **1,641** distinct latest-version servers @ **2026-07-26**, up 2.3× from 710 in July. Combined with the GitHub crawl → **2,303 distinct public MCP server configs** scanned (up from 1,374).
- **Re-ran the aggregation** (`run_report.py`, offline + deterministic) → refreshed `results.json`.
- **Rewrote `REPORT.md`** + a **human PDF** (`output/pdf_report.py::emit_report_pdf` → `state-of-mcp-security-2026.pdf`).
- README "State of MCP Security 2026" section refreshed. Counts stay canonical (270 rules / 86 scanners). Version 0.3.59 → 0.3.60.

## Headline findings (2,303 configs)
| Finding | Share |
|---|---:|
| Remote server with **no authentication** (`AAK-MCP-001`) | **52.3%** (1,205) |
| Carries a **critical** finding | 52.8% (1,217) |
| `npx`/`uvx`-fetch-execute **unpinned** packages (`AAK-MCP-005`) | 19.5% (450) |
| **No RFC 9728** PRM discovery | 100% (0 serve it) |
| Inline-auth configs that **hardcode a static credential** | 100% (421/421) |

**Reproduce:** `make report` (offline, deterministic). Full method + limitations in `research/state-of-mcp-2026/REPORT.md`.

## Test plan
`pytest` 1448 passed / 1 skipped · `ruff` clean · `mypy` clean. `test_state_of_mcp_report` ties REPORT.md to results.json. CI validates before this goes public.

---

## Launch surface — DRAFTS ONLY (do not auto-post)

**Show HN (Tue/Wed morning):**
> Title: `Show HN: We scanned 2,303 public MCP servers — 52% have no authentication`
>
> First comment:
> Hi HN. I built AgentAuditKit, an offline, deterministic security scanner for MCP-connected AI agents (the "npm audit for agents"). To pressure-test it, I scanned every public MCP server I could pull from the official registry plus a GitHub crawl — 2,303 distinct configs — and the headline surprised me: **52% declare a remote endpoint with no authentication, and not one of them serves the RFC 9728 discovery document the ratified auth spec expects.** 19.5% `npx`/`uvx`-fetch-and-execute unpinned packages — the same blast radius Shai-Hulud 2.0 rode through npm, one `.mcp.json` away.
>
> Two things I care about and would love feedback on: (1) it's **offline + deterministic** — same input, byte-identical findings, no model in the loop, so every number in the report regenerates from the committed manifest (`make report`); (2) every rule is **crosswalked to the NSA MCP Security CSI control and the OWASP Agentic Top-10 slot** it evidences, so a finding becomes audit evidence. MIT, no account, no telemetry. Not claiming to be first — public MCP surveys and vendor disclosures predate this; what's new is offline + deterministic + standards-mapped in one tool. Report + method: <REPORT link>. Repo: <repo link>. Happy to answer method/limitations questions.

**r/netsec (research framing, not promo):**
> Title: `We statically scanned 2,303 public MCP server configs; 52% expose a remote endpoint with no auth [reproducible, offline]`
> Lead with method + reproduce command; link the report; no install CTA in the body.

**Directory / community submissions (open PRs/issues, human review before submit):**
- `awesome-mcp-security` — add AgentAuditKit under scanners/tools with the report link.
- OWASP GenAI Security Project / MCP working group — share the crosswalk (`docs/crosswalk/nsa-csi-owasp-agentic.md`) + report as a data contribution.

*All of the above are drafts staged for the maintainer to post manually — nothing is auto-submitted.*