### PR TITLE
chore(dependabot): stop re-proposing the ruff cap bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # ruff's minor is pinned in pyproject.toml (`ruff>=0.15,<0.16`) so CI lint
+      # stays reproducible. A new ruff minor adds rules that turn CI red without a
+      # deliberate `ruff check --fix` adoption, so don't auto-propose the cap bump
+      # (that was PR #494 — closed, failed all four `test` jobs). Adopting a newer
+      # ruff is a manual, reviewed change with the auto-fixes committed alongside;
+      # patch updates within 0.15.x are still allowed.
+      - dependency-name: "ruff"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Follow-up to closing #494. Dependabot keeps proposing to widen the ruff cap, but the pin is deliberate: `pyproject.toml` keeps `ruff>=0.15,<0.16` so CI lint stays reproducible, and a new ruff minor adds rules that turn CI red without a deliberate `ruff check --fix` adoption.

This adds an `ignore` for ruff `semver-minor`/`semver-major` under the pip ecosystem (mirroring the existing docker `python` major-ignore precedent in the same file), so Dependabot stops re-opening the cap bump. Patch updates within 0.15.x still flow, and adopting a newer ruff stays a manual, reviewed change with the auto-fixes committed alongside.

No code impact — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FvRehMNiJTULqJE3rmt9cs