### PR TITLE
Install `aak` as a console script, so the documented shorthand resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `aak` is now an installed console script, aliasing `agent-audit-kit`. The docs, changelogs and release notes have used `aak scan` / `aak score` / `aak watch-cve` as shorthand for many releases, but it was never declared in `[project.scripts]`, so every one of those snippets exited 127 when copied. Both names share a single entry point, and `tests/test_console_scripts.py` asserts they stay in step — plus that every `` `aak <cmd>` `` in the docs names a command that actually exists.
+
+### Added
+
 - `AAK-MCP-AUTHFETCH-CVE-2026-49857-001` (SUPPLY_CHAIN, HIGH) — auth-fetch-mcp `<= 3.0.1`: `isPrivateV6()` misses IPv4-mapped IPv6 loopback in hex-normalised form, so `http://[::ffff:127.0.0.1]/` normalises to `[::ffff:7f00:1]`, `net.isIPv4('7f00:1')` is false, and the SSRF guard passes the URL through to loopback. Floor `>= 3.0.2` per GHSA-pvrj-8cg3-j5f8 — **not** the 3.0.1 the NVD prose names as the fix, which is inside the affected range. (#578)
 - `AAK-MCP-JSHOOK-CVE-2026-49856-001` (SUPPLY_CHAIN, MEDIUM) — @jshookmcp/jshook 0.3.1 enforces its SSRF authorization policy only on the raw HTTP/TCP/TLS tools; ICMP probe and traceroute call the native sink directly, giving internal reachability mapping with private-network access disabled. Floor `>= 0.3.2`. (#577)
 - `CVE-2026-73601` added to `AAK-FLOWISE-001` — the Custom MCP node stdio RCE shares Flowise's 3.1.3 fix floor, which that rule's detector already enforces, so it is a reference addition rather than a duplicate pin. (#575)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ appear as **inline PR annotations** and in the **Security tab**. See
 ```bash
 pip install agent-audit-kit
 agent-audit-kit scan .
+
+# `aak` is installed as a shorthand for the same command
+aak scan .
 ```
 
 ### Pre-commit Hook

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-08-14T08:18:27Z",
+  "last_updated": "2026-08-15T03:24:07Z",
   "aak_version": "0.3.76",
   "rule_count": 298,
   "coverage": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ dev = [
 
 [project.scripts]
 agent-audit-kit = "agent_audit_kit.cli:cli"
+# `aak` is the shorthand the docs, changelogs and release notes have used for
+# many releases (`aak scan`, `aak score`, `aak watch-cve`, ...) without ever
+# being installable, so every one of those snippets exits 127 when copied.
+# Same entry point, so the two names cannot drift.
+aak = "agent_audit_kit.cli:cli"
 
 [project.urls]
 Homepage = "https://github.com/sattyamjjain/agent-audit-kit"

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -1,0 +1,83 @@
+"""The declared console scripts must match the commands the docs tell people to run.
+
+`aak` had been used as shorthand throughout the README, changelogs and release
+notes for many releases without ever being declared in `[project.scripts]`, so
+every one of those snippets exited 127 when a user copied it. These tests keep
+the two in step: both names install, both dispatch to the same Click group, and
+any command named in the docs as `aak <cmd>` actually exists.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # 3.9 / 3.10 — the project ships tomli for these
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+
+from agent_audit_kit.cli import cli
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPECTED_SCRIPTS = {"agent-audit-kit", "aak"}
+
+
+def _declared_scripts() -> dict[str, str]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["scripts"]
+
+
+def test_both_console_scripts_are_declared() -> None:
+    assert set(_declared_scripts()) == EXPECTED_SCRIPTS
+
+
+def test_both_scripts_share_one_entry_point() -> None:
+    """Same target, so the two names cannot drift apart."""
+    targets = set(_declared_scripts().values())
+    assert targets == {"agent_audit_kit.cli:cli"}
+
+
+@pytest.mark.parametrize("script", sorted(EXPECTED_SCRIPTS))
+def test_script_is_installed_and_runs(script: str) -> None:
+    """A declared script that is not on PATH is the 127 this test exists to catch."""
+    exe = Path(sys.executable).parent / script
+    if not exe.exists():
+        pytest.skip(f"{script} not installed in this environment (pip install -e .)")
+    out = subprocess.run([str(exe), "--version"], capture_output=True, text=True, check=False)
+    assert out.returncode == 0, out.stderr
+    assert script in out.stdout
+
+
+def test_docs_only_reference_commands_that_exist() -> None:
+    """`aak <cmd>` in prose must name a real command.
+
+    Catches the other half of the problem: a working binary invoked with a
+    command that was renamed or never shipped.
+    """
+    known = set(cli.commands)
+    # Words that follow `aak ` in prose but are not commands.
+    prose = {"is", "the", "and", "as", "to", "in", "or", "a", "it", "does", "for", "with"}
+
+    offenders: list[str] = []
+    for path in REPO_ROOT.rglob("*.md"):
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel.startswith(("node_modules/", "site/", ".venv/", "releases/", "vscode-extension/node_modules/")):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for match in re.finditer(r"`aak ([a-z][a-z-]*)", text):
+            cmd = match.group(1)
+            if cmd in prose or cmd in known:
+                continue
+            offenders.append(f"{rel}: `aak {cmd}`")
+
+    assert not offenders, (
+        "docs reference commands that do not exist:\n  " + "\n  ".join(sorted(set(offenders)))
+    )


### PR DESCRIPTION
## Summary

`aak` has been the shorthand in this repo's README, changelogs and release notes for many releases — `aak scan`, `aak score`, `aak watch-cve`, `aak coverage`, `aak rule`, `aak inspect-ide`, `aak parity` — across dozens of snippets. It was never declared in `[project.scripts]`, so every one of them exits **127, command not found**.

This surfaced during the v0.3.76 release smoke test: the documented `aak scan --help` failed against a wheel that was otherwise completely healthy. The wheel was fine; the docs were describing a binary that did not exist.

Both names now point at `agent_audit_kit.cli:cli`, so they cannot drift. The only difference in output is Click's usage line (`Usage: aak ...` vs `Usage: agent-audit-kit ...`), verified as the sole delta.

## Test Plan

`tests/test_console_scripts.py` covers both directions of this failure:

- both scripts are declared, and share **one** entry point
- each installed script runs and reports its version (the 127 this PR fixes)
- every `` `aak <cmd>` `` in tracked markdown names a command that actually exists — the inverse failure, where the binary works but the docs invoke a renamed or never-shipped subcommand

```
pytest   1652 passed, 1 skipped
ruff     All checks passed!
mypy     Success: no issues found in 155 source files
```

The docs-consistency test passes against the current docs, so nothing needed renaming.

## Note

`tomllib` is 3.11+, so the test uses the same `tomli` fallback the project already uses in `oauth_surface.py` and `marketplace_manifest.py` — the package already declares `tomli>=2.0; python_version < '3.11'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
