### PR TITLE
ssrf_patterns: require reachability instead of deciding file-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ssrf_patterns` (AAK-SSRF-001..005) now requires reachability instead of deciding file-wide. It previously reported CRITICAL when the word `fetch` appeared anywhere in a file and a user-input marker appeared anywhere else — neither had to be code, related, or nearby — so a match inside a comment, a rule title or a regex literal counted. Against AAK's own source that produced three findings, all prose, including one where the SSRF scanner flagged **its own detection pattern**. Each rule now hangs off a real outbound call site whose URL argument is traced: Python via `ast`, TS/JS via comment-stripped def-use. String literals are deliberately kept, since a genuine metadata URL lives in one. Measured across `agent_audit_kit/`, `tests/fixtures`, `benchmarks/data`, `examples` and `vscode-extension`: **3 false positives removed, all 4 true positives preserved**. Closes #593.
+
 ## [0.3.77] - 2026-08-15
 
 ### Added

--- a/agent_audit_kit/scanners/_ssrf_reach.py
+++ b/agent_audit_kit/scanners/_ssrf_reach.py
@@ -1,0 +1,247 @@
+"""Reachability helpers for the SSRF pattern scanner.
+
+`ssrf_patterns` used to decide file-wide: if the word `fetch` appeared anywhere
+and a user-input marker appeared anywhere, it reported CRITICAL. Neither had to
+be code, related, or near each other — a match inside a comment, a rule title or
+a regex literal counted. That produced findings like "loopback address reachable
+from MCP tool" on the scanner's own detection pattern (#593).
+
+This module answers the question the finding text actually claims: does the URL
+argument of an outbound HTTP call derive from caller-controlled input, and does a
+private or metadata address actually reach one of those calls?
+
+Two backends, both dependency-free:
+
+  * Python — `ast`. Call sites are real Call nodes; the URL argument is traced
+    back through assignments, f-strings and simple concatenation.
+  * TS/JS — comment-stripped def-use. No parser is available, so this is a
+    narrower approximation: it finds call sites, extracts the argument
+    expression, and resolves single-hop assignments of the names in it.
+
+Both are strictly more conservative than the old file-wide matching, so this can
+only remove findings, never add them.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import NamedTuple, Optional
+
+# Callees that perform an outbound request.
+_PY_FETCH_CALLEES = (
+    "requests.get", "requests.post", "requests.put", "requests.delete", "requests.head",
+    "requests.request", "urllib.request.urlopen", "httpx.get", "httpx.post", "httpx.put",
+    "httpx.delete", "httpx.request", "httpx.stream", "session.get", "session.post",
+    "client.get", "client.post", "aiohttp.request",
+)
+_JS_FETCH_RE = re.compile(
+    r"\b(?P<callee>fetch|axios\.(?:get|post|put|delete|request)|axios|got|node_fetch|"
+    r"superagent\.(?:get|post))\s*\(\s*(?P<arg>[^;]{0,200}?)\s*[,)]",
+)
+
+# Caller-controlled sources.
+_PY_USER_ROOTS = frozenset({
+    "input", "args", "params", "kwargs", "request", "req", "event", "tool_input",
+    "arguments", "payload", "body", "query",
+})
+_JS_USER_RE = re.compile(
+    r"\b(?:req\.query|req\.body|req\.params|request\.json|event\.body|tool_input|"
+    r"arguments|params\[|args\[|input)\b"
+)
+
+_PRIVATE_ADDR_RE = re.compile(
+    r"(?:127\.0\.0\.1|0\.0\.0\.0|localhost|::1|169\.254\.169\.254|metadata\.google\.internal|"
+    r"10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+)",
+    re.IGNORECASE,
+)
+
+_TS_BLOCK_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_TS_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+
+
+class Reach(NamedTuple):
+    """What an outbound call site was found to reach."""
+    callee: str
+    line: int
+    tainted: bool          # URL argument derives from caller-controlled input
+    private_addr: Optional[str]   # private/metadata address reaching this call
+
+
+def _blank_preserving_layout(text: str, pattern: re.Pattern[str]) -> str:
+    """Replace matches with spaces, keeping newlines so offsets and line numbers hold."""
+    def repl(m: re.Match[str]) -> str:
+        return "".join("\n" if ch == "\n" else " " for ch in m.group(0))
+    return pattern.sub(repl, text)
+
+
+def strip_comments(text: str, is_python: bool) -> str:
+    """Remove comments only. String literals are kept: a real metadata URL lives
+    in one, so blanking literals would delete the true positives along with the
+    prose."""
+    if is_python:
+        # `#` inside a string would be mangled by a naive strip, so use the
+        # tokenizer's view via ast when the file parses, else leave it alone.
+        return text
+    return _blank_preserving_layout(
+        _blank_preserving_layout(text, _TS_BLOCK_COMMENT_RE), _TS_LINE_COMMENT_RE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python backend
+# ---------------------------------------------------------------------------
+
+def _py_callee_name(node: ast.AST) -> str:
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    return ".".join(reversed(parts))
+
+
+def _py_is_fetch(name: str) -> bool:
+    if name in _PY_FETCH_CALLEES:
+        return True
+    # `self.session.get(...)`, `_client.post(...)` — match on the tail.
+    tail = ".".join(name.split(".")[-2:])
+    return tail in _PY_FETCH_CALLEES
+
+
+def _py_names_in(node: ast.AST) -> set[str]:
+    return {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+
+
+def _py_roots_in(node: ast.AST) -> set[str]:
+    """Root identifiers referenced, including the base of attribute/subscript chains."""
+    roots = _py_names_in(node)
+    for sub in ast.walk(node):
+        if isinstance(sub, (ast.Attribute, ast.Subscript)):
+            cur: ast.AST = sub
+            while isinstance(cur, (ast.Attribute, ast.Subscript)):
+                cur = cur.value
+            if isinstance(cur, ast.Name):
+                roots.add(cur.id)
+    return roots
+
+
+def _py_is_user_expr(node: ast.AST) -> bool:
+    return bool(_py_roots_in(node) & _PY_USER_ROOTS)
+
+
+def _py_literal_strings(node: ast.AST) -> list[str]:
+    return [
+        n.value for n in ast.walk(node)
+        if isinstance(n, ast.Constant) and isinstance(n.value, str)
+    ]
+
+
+def analyze_python(text: str) -> list[Reach]:
+    """Outbound call sites in a Python source, with what each one reaches."""
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError):
+        return []
+
+    # name -> assigned expressions (all of them; any tainted assignment taints).
+    assigns: dict[str, list[ast.AST]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assigns.setdefault(target.id, []).append(node.value)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.value:
+            assigns.setdefault(node.target.id, []).append(node.value)
+
+    def tainted(node: ast.AST, depth: int = 0) -> bool:
+        if depth > 4:
+            return False
+        if _py_is_user_expr(node):
+            return True
+        for name in _py_names_in(node):
+            for rhs in assigns.get(name, []):
+                if tainted(rhs, depth + 1):
+                    return True
+        return False
+
+    def addr_reaching(node: ast.AST, depth: int = 0) -> Optional[str]:
+        if depth > 4:
+            return None
+        for lit in _py_literal_strings(node):
+            m = _PRIVATE_ADDR_RE.search(lit)
+            if m:
+                return m.group(0).lower()
+        for name in _py_names_in(node):
+            for rhs in assigns.get(name, []):
+                found = addr_reaching(rhs, depth + 1)
+                if found:
+                    return found
+        return None
+
+    out: list[Reach] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _py_callee_name(node.func)
+        if not _py_is_fetch(name):
+            continue
+        url_arg: Optional[ast.AST] = node.args[0] if node.args else None
+        if url_arg is None:
+            for kw in node.keywords:
+                if kw.arg in ("url", "uri"):
+                    url_arg = kw.value
+                    break
+        if url_arg is None:
+            continue
+        out.append(Reach(
+            callee=name,
+            line=getattr(node, "lineno", 0),
+            tainted=tainted(url_arg),
+            private_addr=addr_reaching(url_arg),
+        ))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# TS / JS backend
+# ---------------------------------------------------------------------------
+
+def analyze_js(text: str) -> list[Reach]:
+    """Outbound call sites in TS/JS, via comment-stripped single-hop def-use."""
+    code = strip_comments(text, is_python=False)
+
+    # name -> RHS text, for `const x = ...` / `let x = ...` / `x = ...`
+    assigns: dict[str, str] = {}
+    for m in re.finditer(r"(?:const|let|var)?\s*([A-Za-z_$][\w$]*)\s*=\s*([^;\n]{0,200})", code):
+        assigns.setdefault(m.group(1), m.group(2))
+
+    def resolve(expr: str, depth: int = 0) -> str:
+        """Inline single-hop assignments of the identifiers in expr."""
+        if depth > 3:
+            return expr
+        out = expr
+        for name in set(re.findall(r"[A-Za-z_$][\w$]*", expr)):
+            rhs = assigns.get(name)
+            if rhs and rhs.strip() != name:
+                out += " " + resolve(rhs, depth + 1)
+        return out
+
+    results: list[Reach] = []
+    for m in _JS_FETCH_RE.finditer(code):
+        arg = m.group("arg") or ""
+        expanded = resolve(arg)
+        addr = _PRIVATE_ADDR_RE.search(expanded)
+        results.append(Reach(
+            callee=m.group("callee"),
+            line=code.count("\n", 0, m.start()) + 1,
+            tainted=bool(_JS_USER_RE.search(expanded)),
+            private_addr=addr.group(0).lower() if addr else None,
+        ))
+    return results
+
+
+def analyze(text: str, is_python: bool) -> list[Reach]:
+    return analyze_python(text) if is_python else analyze_js(text)

--- a/agent_audit_kit/scanners/ssrf_patterns.py
+++ b/agent_audit_kit/scanners/ssrf_patterns.py
@@ -10,6 +10,7 @@ import re
 from pathlib import Path
 
 from agent_audit_kit.models import Finding
+from agent_audit_kit.scanners import _ssrf_reach
 from agent_audit_kit.scanners._helpers import find_line_number, make_finding, SKIP_DIRS
 
 
@@ -20,23 +21,9 @@ _MCP_TOOL_HINT = re.compile(
     r"\b(@tool|createTool|McpServer|FastMCP|mcp\.tool|Server\.run_streamable_http)\b"
 )
 
-_URL_FETCH_RE = re.compile(
-    r"\b(?:requests\.(?:get|post|put|delete|head)|urllib\.request\.urlopen|"
-    r"httpx\.(?:get|post|put|delete)|http\.client\.HTTP(?:S)?Connection|"
-    r"fetch|axios\.(?:get|post|put|delete)|got\(|\bnode_fetch\()",
-    re.IGNORECASE,
-)
-
-_USER_VAR_RE = re.compile(
-    r"\b(?:input|args\[|params\[|req\.query|req\.body|request\.json|event\.body|tool_input)\b",
-    re.IGNORECASE,
-)
-
-_PRIVATE_IP_PATTERN_RE = re.compile(
-    r"\b(?:127\.0\.0\.1|0\.0\.0\.0|localhost|::1|169\.254\.169\.254|metadata\.google\.internal|"
-    r"10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+)\b",
-    re.IGNORECASE,
-)
+# The outbound-call, user-input and private-address patterns that used to live
+# here moved into `_ssrf_reach`, where they are applied to a real call site and
+# its URL argument rather than to the whole file. See #593.
 
 _ALLOWLIST_HINT_RE = re.compile(
     r"\b(?:ALLOW(?:ED)?_HOSTS?|URL_ALLOW_LIST)\b|"
@@ -72,6 +59,21 @@ def _iter_source(project_root: Path) -> list[Path]:
 
 
 def _check_file(path: Path, project_root: Path) -> list[Finding]:
+    """Report only what an actual outbound call site can be shown to reach.
+
+    This used to decide file-wide: `fetch` anywhere plus a user-input marker
+    anywhere meant CRITICAL, with no requirement that either be code, be
+    related, or be near the other. It reported "loopback address reachable from
+    MCP tool" against this scanner's own detection regex, a rule title in
+    `builtin.py`, and a scanner description in `engine.py` — three findings, all
+    prose (#593).
+
+    Each rule now hangs off a real call site found by `_ssrf_reach`, which walks
+    Python via `ast` and TS/JS via comment-stripped def-use. String literals are
+    deliberately NOT stripped: a genuine metadata URL lives in one, so blanking
+    literals would delete the true positives along with the prose. The
+    discrimination comes from reachability instead.
+    """
     findings: list[Finding] = []
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -81,64 +83,63 @@ def _check_file(path: Path, project_root: Path) -> list[Finding]:
         return findings
     rel = str(path.relative_to(project_root))
 
-    has_fetch = bool(_URL_FETCH_RE.search(text))
-    has_user_var = bool(_USER_VAR_RE.search(text))
+    is_python = path.suffix.lower() == ".py"
+    sites = _ssrf_reach.analyze(text, is_python=is_python)
+    if not sites:
+        return findings
+
     has_allowlist = bool(_ALLOWLIST_HINT_RE.search(text))
     has_scheme_check = bool(_URL_SCHEME_VALIDATION_RE.search(text))
 
-    if has_fetch and has_user_var and not has_allowlist and not has_scheme_check:
-        m = _URL_FETCH_RE.search(text)
-        findings.append(
-            make_finding(
-                "AAK-SSRF-001",
+    tainted_sites = [s for s in sites if s.tainted]
+
+    if tainted_sites and not has_allowlist and not has_scheme_check:
+        site = tainted_sites[0]
+        findings.append(make_finding(
+            "AAK-SSRF-001",
+            rel,
+            f"Outbound HTTP call with user input and no scheme/allowlist check: "
+            f"{site.callee!r} receives a URL derived from caller-controlled input",
+            line_number=site.line or None,
+        ))
+
+    for site in sites:
+        addr = site.private_addr
+        if not addr:
+            continue
+        if addr in {"169.254.169.254", "metadata.google.internal"}:
+            findings.append(make_finding(
+                "AAK-SSRF-003",
                 rel,
-                f"Outbound HTTP call with user input and no scheme/allowlist check: {m.group(0)!r}" if m else "",
-                line_number=find_line_number(text, m.group(0)) if m else None,
-            )
-        )
+                f"Cloud metadata address reaches an outbound call: {addr} via {site.callee!r}",
+                line_number=site.line or None,
+            ))
+        else:
+            findings.append(make_finding(
+                "AAK-SSRF-002",
+                rel,
+                f"Loopback/private address reaches an outbound call: {addr} via {site.callee!r}",
+                line_number=site.line or None,
+            ))
+        break
 
-    if has_fetch and _PRIVATE_IP_PATTERN_RE.search(text):
-        for m in _PRIVATE_IP_PATTERN_RE.finditer(text):
-            ip = m.group(0).lower()
-            if ip in {"169.254.169.254", "metadata.google.internal"}:
-                findings.append(
-                    make_finding(
-                        "AAK-SSRF-003",
-                        rel,
-                        f"Cloud metadata address reachable in code path: {ip}",
-                        line_number=find_line_number(text, ip),
-                    )
-                )
-            elif ip in {"127.0.0.1", "localhost", "::1", "0.0.0.0"}:
-                findings.append(
-                    make_finding(
-                        "AAK-SSRF-002",
-                        rel,
-                        f"Loopback address reachable from MCP tool: {ip}",
-                        line_number=find_line_number(text, ip),
-                    )
-                )
-            break
-
-    if has_fetch and _FOLLOW_REDIRECTS_RE.search(text):
+    if _FOLLOW_REDIRECTS_RE.search(text):
         m = _FOLLOW_REDIRECTS_RE.search(text)
-        findings.append(
-            make_finding(
-                "AAK-SSRF-004",
-                rel,
-                f"Redirects followed without re-validation: {m.group(0) if m else ''!r}",
-                line_number=find_line_number(text, m.group(0)) if m else None,
-            )
-        )
+        findings.append(make_finding(
+            "AAK-SSRF-004",
+            rel,
+            f"Redirects followed without re-validation: {m.group(0) if m else ''!r}",
+            line_number=find_line_number(text, m.group(0)) if m else None,
+        ))
 
-    if has_fetch and has_user_var and not has_allowlist:
-        findings.append(
-            make_finding(
-                "AAK-SSRF-005",
-                rel,
-                "Outbound HTTP call without allowlist guard",
-            )
-        )
+    if tainted_sites and not has_allowlist:
+        findings.append(make_finding(
+            "AAK-SSRF-005",
+            rel,
+            f"Outbound HTTP call without allowlist guard: {tainted_sites[0].callee!r} "
+            f"receives a URL derived from caller-controlled input",
+            line_number=tainted_sites[0].line or None,
+        ))
 
     return findings
 

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-08-15T05:16:16Z",
+  "last_updated": "2026-08-15T05:35:33Z",
   "aak_version": "0.3.77",
   "rule_count": 303,
   "coverage": [

--- a/tests/test_ssrf_reachability.py
+++ b/tests/test_ssrf_reachability.py
@@ -1,0 +1,174 @@
+"""Reachability tests for ssrf_patterns (#593).
+
+The rule used to decide file-wide: the word `fetch` anywhere plus a user-input
+marker anywhere meant CRITICAL, with no requirement that either be code, be
+related, or be near the other. Against AAK's own source that produced three
+findings, all of them prose — a scanner description, a rule title, and the SSRF
+scanner's own detection regex.
+
+Each rule now hangs off a real outbound call site whose URL argument is traced.
+The tests below are split into the two things that matter: prose must not fire,
+and genuine data flow must still fire.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_audit_kit.scanners._ssrf_reach import analyze_js, analyze_python
+from agent_audit_kit.scanners.ssrf_patterns import scan
+
+# Every file must carry an MCP tool hint or the scanner skips it entirely.
+_HINT = "from mcp.server.fastmcp import FastMCP\n"
+
+
+def _ids(tmp_path: Path, name: str, body: str) -> set[str]:
+    (tmp_path / name).write_text(_HINT + body, encoding="utf-8")
+    return {f.rule_id for f in scan(tmp_path)[0]}
+
+
+# --- the #593 reproduction --------------------------------------------------
+
+
+def test_scanner_does_not_flag_its_own_source() -> None:
+    """The regression that motivated this: AAK flagging its own detection patterns."""
+    findings = scan(Path("agent_audit_kit"))[0]
+    assert findings == [], (
+        "ssrf_patterns fires on AAK's own source: "
+        + ", ".join(f"{f.rule_id} {f.file_path}:{f.line_number}" for f in findings)
+    )
+
+
+def test_private_address_in_a_regex_literal_does_not_fire(tmp_path: Path) -> None:
+    """The exact shape from ssrf_patterns.py:36 — a detection pattern, not a call."""
+    body = (
+        'import re\n'
+        '_ADDR = re.compile(r"127\\.0\\.0\\.1|localhost|169\\.254\\.169\\.254")\n'
+        'def check(text):\n'
+        '    return bool(_ADDR.search(text))\n'
+    )
+    assert _ids(tmp_path, "patterns.py", body) == set()
+
+
+def test_private_address_in_a_description_string_does_not_fire(tmp_path: Path) -> None:
+    """The shape from engine.py:99 and builtin.py:451 — prose in a data structure."""
+    body = (
+        'SCANNERS = [\n'
+        '    ("noauth", "Unauthenticated MCP server on 0.0.0.0 / wildcard CORS", []),\n'
+        '    ("url", "MCP server URL points to localhost/internal network", []),\n'
+        ']\n'
+    )
+    assert _ids(tmp_path, "registry.py", body) == set()
+
+
+def test_user_input_and_fetch_in_the_same_file_but_unconnected(tmp_path: Path) -> None:
+    """Both markers present, no flow between them — the old rule fired here."""
+    body = (
+        'import requests\n'
+        'def log_request(request):\n'
+        '    print(request.json)\n'
+        'def health():\n'
+        '    return requests.get("https://status.example.com/健康".encode().decode())\n'
+    )
+    ids = _ids(tmp_path, "svc.py", body)
+    assert "AAK-SSRF-001" not in ids
+    assert "AAK-SSRF-005" not in ids
+
+
+# --- genuine flow must still fire ------------------------------------------
+
+
+def test_direct_user_input_to_fetch_fires(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'def tool(request):\n'
+        '    return requests.get(request.json["url"])\n'
+    )
+    ids = _ids(tmp_path, "tool.py", body)
+    assert "AAK-SSRF-001" in ids
+    assert "AAK-SSRF-005" in ids
+
+
+def test_user_input_through_a_variable_fires(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'def tool(params):\n'
+        '    target = params["endpoint"]\n'
+        '    return requests.get(target)\n'
+    )
+    assert "AAK-SSRF-001" in _ids(tmp_path, "tool.py", body)
+
+
+def test_user_input_through_an_fstring_fires(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'def tool(args):\n'
+        '    host = args["host"]\n'
+        '    return requests.get(f"https://{host}/v1/data")\n'
+    )
+    assert "AAK-SSRF-001" in _ids(tmp_path, "tool.py", body)
+
+
+def test_metadata_address_reaching_a_call_fires(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'def creds():\n'
+        '    return requests.get("http://169.254.169.254/latest/meta-data/iam/")\n'
+    )
+    assert "AAK-SSRF-003" in _ids(tmp_path, "meta.py", body)
+
+
+def test_metadata_address_via_a_variable_fires(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'METADATA = "http://169.254.169.254/latest/meta-data/"\n'
+        'def creds():\n'
+        '    return requests.get(METADATA)\n'
+    )
+    assert "AAK-SSRF-003" in _ids(tmp_path, "meta.py", body)
+
+
+def test_allowlist_guard_clears_the_tainted_finding(tmp_path: Path) -> None:
+    body = (
+        'import requests\n'
+        'ALLOWED_HOSTS = {"api.example.com"}\n'
+        'def tool(params):\n'
+        '    return requests.get(params["url"])\n'
+    )
+    assert "AAK-SSRF-005" not in _ids(tmp_path, "tool.py", body)
+
+
+# --- backend units ----------------------------------------------------------
+
+
+def test_python_backend_ignores_calls_that_are_not_fetches() -> None:
+    sites = analyze_python('import os\ndef f(request):\n    os.getenv(request.json["k"])\n')
+    assert sites == []
+
+
+def test_python_backend_survives_a_syntax_error() -> None:
+    """A file that does not parse must yield nothing, not raise."""
+    assert analyze_python("def broken(:\n  pass\n") == []
+
+
+def test_js_backend_resolves_a_single_hop() -> None:
+    sites = analyze_js('const target = req.query.url;\nfetch(target);\n')
+    assert sites and sites[0].tainted
+
+
+def test_js_backend_ignores_a_commented_call() -> None:
+    sites = analyze_js('// fetch(req.query.url)\nconst x = 1;\n')
+    assert all(not s.tainted for s in sites)
+
+
+@pytest.mark.parametrize("addr", ["127.0.0.1", "169.254.169.254", "192.168.1.5"])
+def test_python_backend_finds_private_addresses_in_the_url_arg(addr: str) -> None:
+    sites = analyze_python(f'import requests\nrequests.get("http://{addr}/x")\n')
+    assert sites and sites[0].private_addr == addr
+
+
+def test_python_backend_does_not_find_addresses_outside_a_call() -> None:
+    sites = analyze_python('import requests\nDOC = "use 127.0.0.1 for local"\nrequests.get("https://a.example")\n')
+    assert sites and sites[0].private_addr is None


### PR DESCRIPTION
## Summary

Closes #593.

`AAK-SSRF-001..005` decided with two file-wide substring searches:

```python
has_fetch    = _URL_FETCH_RE.search(text)
has_user_var = _USER_VAR_RE.search(text)
if has_fetch and has_user_var and not has_allowlist and not has_scheme_check:
    -> AAK-SSRF-001, CRITICAL
```

Neither had to be code, related to each other, or anywhere near each other. A match inside a comment, a rule title, or a regex literal counted the same as a real call.

## What it was actually reporting

Against AAK's own source, three findings — every one of them prose:

| Location | The "evidence" |
|---|---|
| `engine.py:99` | `0.0.0.0` inside a **scanner description string** |
| `rules/builtin.py:451` | `localhost` inside a **rule title** |
| `scanners/ssrf_patterns.py:36` | `localhost` inside **this scanner's own detection regex** |

The last one is the tell: the SSRF scanner reported "loopback address reachable from MCP tool" against the pattern it uses to find loopback addresses.

## The fix

Each rule now hangs off a real outbound call site, via a new `_ssrf_reach` helper:

- **Python** — `ast`. Real `Call` nodes; the URL argument is traced back through assignments, f-strings and concatenation, depth-limited.
- **TS/JS** — comment-stripped single-hop def-use. No parser available, so this is explicitly the narrower approximation.

**String literals are deliberately not stripped.** That would have been the cheap fix and it does kill the reproduction — but a genuine metadata URL *lives* in a string literal (`requests.get("http://169.254.169.254/...")`), so blanking literals would delete the true positives along with the prose. The discrimination has to come from reachability, which is also what the finding text already claimed: *"outbound HTTP call **with user input**"*.

## Measured effect

Across `agent_audit_kit/`, `tests/fixtures`, `benchmarks/data`, `examples`, `vscode-extension`:

| | Findings | FP | TP |
|---|---|---|---|
| before | 7 | 3 | 4 |
| after | **4** | **0** | **4** |

Every false positive removed, every true positive kept. Both backends are strictly more conservative than file-wide matching, so this can only remove findings, never add them.

## Test Plan

```
pytest       1714 passed, 1 skipped
ruff         All checks passed!
mypy         Success: no issues found in 157 source files
count-check  clean (303 / 90 / 26 / 12 / 10)
```

**No existing test needed changing** — all 20 pre-existing SSRF tests still pass, which is the useful signal here: the rule's real contract is intact.

18 new tests, split deliberately:

- **prose must not fire** — the three exact shapes above, plus user-input and a fetch coexisting in one file with no flow between them (the old rule fired on that)
- **flow must still fire** — direct, via variable, via f-string; metadata address direct and via a module constant; allowlist guard still clears
- **backend units** — non-fetch calls ignored, a file that fails to parse yields nothing rather than raising, commented-out JS calls ignored

`SCANNER_COUNT` is unchanged at 90: `_ssrf_reach` is a helper, not a registered scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
