### PR TITLE
Correct transport-flip remediation that pointed at fields the MCP spec does not define

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Corrected the remediation on `AAK-DOCSGPT-MCP-STDIO-MITM-001` and `AAK-GPTRESEARCHER-MCP-STDIO-MITM-001`. Both told users to set `"deny_stdio_transport": true` or `"allowed_transports": ["sse"]` "so a MITM cannot flip the transport mid-session". Those keys are AgentAuditKit conventions, not MCP specification fields — they appear in **0 of the 748** public MCP configs in `benchmarks/data`, and searching the repo finds them only in AAK's own `rules.json`, tests and fixtures. Following that advice added a key the user's MCP client ignores, silenced the rule, and left them believing they were protected. The remediation now leads with the controls that work (the vendor version pin; TLS with certificate verification so the handshake cannot be rewritten) and states plainly what those keys are. Found while running the empirical false-positive study #162 asks for.
+
+### Fixed
+
 - `ssrf_patterns` (AAK-SSRF-001..005) now requires reachability instead of deciding file-wide. It previously reported CRITICAL when the word `fetch` appeared anywhere in a file and a user-input marker appeared anywhere else — neither had to be code, related, or nearby — so a match inside a comment, a rule title or a regex literal counted. Against AAK's own source that produced three findings, all prose, including one where the SSRF scanner flagged **its own detection pattern**. Each rule now hangs off a real outbound call site whose URL argument is traced: Python via `ast`, TS/JS via comment-stripped def-use. String literals are deliberately kept, since a genuine metadata URL lives in one. Measured across `agent_audit_kit/`, `tests/fixtures`, `benchmarks/data`, `examples` and `vscode-extension`: **3 false positives removed, all 4 true positives preserved**. Closes #593.
 
 ## [0.3.77] - 2026-08-15

--- a/agent_audit_kit/rules/builtin.py
+++ b/agent_audit_kit/rules/builtin.py
@@ -5222,12 +5222,20 @@ _r(
     "covered by AAK-MCP-STDIO-CMD-INJ-001 (Python).",
     Severity.HIGH,
     Category.SUPPLY_CHAIN,
-    "Pin `gpt-researcher` away from any pre-disclosure version when "
+    "Pin `gpt-researcher` away from any pre-disclosure version when the "
     "vendor ships a post-2026-05-01 fix (track at "
-    "https://github.com/assafelovic/gpt-researcher). For the "
-    "server-config arm, set `\"deny_stdio_transport\": true` (or "
-    "`\"allowed_transports\": [\"sse\"]`) to prevent MITM transport-flip "
-    "into the stdio cmd-injection class.",
+    "https://github.com/assafelovic/gpt-researcher). That version pin is "
+    "the control that actually works today. "
+    "For the transport-flip path itself, protect the channel rather than "
+    "the config: serve the MCP endpoint over TLS with certificate "
+    "verification enabled so a middlebox cannot rewrite the handshake, "
+    "and prefer a client that pins the transport it negotiated. "
+    "**Note on `deny_stdio_transport` / `allowed_transports`:** this rule "
+    "treats those keys as a short-circuit, but they are AgentAuditKit "
+    "conventions, not fields the MCP specification defines — they appear "
+    "in none of the 748 public MCP configs in this project's corpus. "
+    "Adding them silences this rule and is ignored by your MCP client, so "
+    "do not treat their presence as protection.",
     sarif_name="GptResearcherMcpTransportFlip",
     cve_references=["CVE-2025-65720"],
     owasp_mcp_references=["MCP01:2025", "MCP05:2025"],
@@ -5254,12 +5262,20 @@ _r(
     "check the receiver-side rules don't catch.",
     Severity.HIGH,
     Category.SUPPLY_CHAIN,
-    "Pin DocsGPT >=0.6.4 (vendor fix from the OX 2026-05-01 batch). For "
-    "the server-config arm, set `\"deny_stdio_transport\": true` (or "
-    "`\"allowed_transports\": [\"sse\"]`) so a MITM cannot flip the "
-    "transport mid-session. The receiver-side class detectors "
-    "(AAK-MCP-STDIO-CMD-INJ-*) catch the downstream cmd-injection if "
-    "the flip succeeds; this rule prevents the flip in the first place.",
+    "Pin DocsGPT >= 0.6.4 (the vendor fix from the OX 2026-05-01 batch). "
+    "That version pin is the control that actually works today. "
+    "For the transport-flip path itself, protect the channel rather than "
+    "the config: serve the MCP endpoint over TLS with certificate "
+    "verification enabled so a middlebox cannot rewrite the handshake, "
+    "and prefer a client that pins the transport it negotiated. The "
+    "receiver-side detectors (AAK-MCP-STDIO-CMD-INJ-*, AAK-STDIO-001) "
+    "catch the downstream command injection if a flip does succeed. "
+    "**Note on `deny_stdio_transport` / `allowed_transports`:** this rule "
+    "treats those keys as a short-circuit, but they are AgentAuditKit "
+    "conventions, not fields the MCP specification defines — they appear "
+    "in none of the 748 public MCP configs in this project's corpus. "
+    "Adding them silences this rule and is ignored by your MCP client, so "
+    "do not treat their presence as protection.",
     sarif_name="DocsGptMcpTransportFlip",
     cve_references=["CVE-2026-26015"],
     owasp_mcp_references=["MCP01:2025", "MCP05:2025"],

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-08-15T05:35:33Z",
+  "last_updated": "2026-08-15T06:19:25Z",
   "aak_version": "0.3.77",
   "rule_count": 303,
   "coverage": [

--- a/rules.json
+++ b/rules.json
@@ -1121,7 +1121,7 @@
         "MCP01:2025",
         "MCP05:2025"
       ],
-      "remediation": "Pin DocsGPT >=0.6.4 (vendor fix from the OX 2026-05-01 batch). For the server-config arm, set `\"deny_stdio_transport\": true` (or `\"allowed_transports\": [\"sse\"]`) so a MITM cannot flip the transport mid-session. The receiver-side class detectors (AAK-MCP-STDIO-CMD-INJ-*) catch the downstream cmd-injection if the flip succeeds; this rule prevents the flip in the first place.",
+      "remediation": "Pin DocsGPT >= 0.6.4 (the vendor fix from the OX 2026-05-01 batch). That version pin is the control that actually works today. For the transport-flip path itself, protect the channel rather than the config: serve the MCP endpoint over TLS with certificate verification enabled so a middlebox cannot rewrite the handshake, and prefer a client that pins the transport it negotiated. The receiver-side detectors (AAK-MCP-STDIO-CMD-INJ-*, AAK-STDIO-001) catch the downstream command injection if a flip does succeed. **Note on `deny_stdio_transport` / `allowed_transports`:** this rule treats those keys as a short-circuit, but they are AgentAuditKit conventions, not fields the MCP specification defines \u2014 they appear in none of the 748 public MCP configs in this project's corpus. Adding them silences this rule and is ignored by your MCP client, so do not treat their presence as protection.",
       "rule_id": "AAK-DOCSGPT-MCP-STDIO-MITM-001",
       "sarif_name": "DocsGptMcpTransportFlip",
       "severity": "high",
@@ -1290,7 +1290,7 @@
         "MCP01:2025",
         "MCP05:2025"
       ],
-      "remediation": "Pin `gpt-researcher` away from any pre-disclosure version when vendor ships a post-2026-05-01 fix (track at https://github.com/assafelovic/gpt-researcher). For the server-config arm, set `\"deny_stdio_transport\": true` (or `\"allowed_transports\": [\"sse\"]`) to prevent MITM transport-flip into the stdio cmd-injection class.",
+      "remediation": "Pin `gpt-researcher` away from any pre-disclosure version when the vendor ships a post-2026-05-01 fix (track at https://github.com/assafelovic/gpt-researcher). That version pin is the control that actually works today. For the transport-flip path itself, protect the channel rather than the config: serve the MCP endpoint over TLS with certificate verification enabled so a middlebox cannot rewrite the handshake, and prefer a client that pins the transport it negotiated. **Note on `deny_stdio_transport` / `allowed_transports`:** this rule treats those keys as a short-circuit, but they are AgentAuditKit conventions, not fields the MCP specification defines \u2014 they appear in none of the 748 public MCP configs in this project's corpus. Adding them silences this rule and is ignored by your MCP client, so do not treat their presence as protection.",
       "rule_id": "AAK-GPTRESEARCHER-MCP-STDIO-MITM-001",
       "sarif_name": "GptResearcherMcpTransportFlip",
       "severity": "high",

--- a/tests/test_transport_flip_remediation.py
+++ b/tests/test_transport_flip_remediation.py
@@ -1,0 +1,121 @@
+"""Remediation for the transport-flip rules must not promise protection it can't give.
+
+The two transport-flip rules short-circuit on `deny_stdio_transport` and
+`allowed_transports`. Measuring the 748 public MCP configs in `benchmarks/data`
+found those keys in **zero** of them, and searching this repo found them only in
+AAK's own `rules.json`, tests and fixtures — never in a spec artifact. They are
+AAK conventions, not MCP specification fields.
+
+The remediation used to read "set `deny_stdio_transport: true` ... so a MITM
+cannot flip the transport mid-session". A user who followed that added a key
+their MCP client ignores, silenced this rule, and believed they were protected.
+That is worse than no advice.
+
+These tests keep the corrected text honest: it must name a control that works,
+and it must disclose what those keys actually are.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_audit_kit.rules.builtin import RULES
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CORPUS = REPO_ROOT / "benchmarks" / "data"
+
+TRANSPORT_FLIP_RULES = (
+    "AAK-DOCSGPT-MCP-STDIO-MITM-001",
+    "AAK-GPTRESEARCHER-MCP-STDIO-MITM-001",
+)
+
+# The keys the rules short-circuit on, which are not MCP specification fields.
+AAK_ONLY_KEYS = (
+    "deny_stdio_transport",
+    "allowed_transports",
+    "reject_transport_override",
+    "stdio_fallback",
+    "transport_override",
+    "permit_transport_override",
+)
+
+
+@pytest.mark.parametrize("rule_id", TRANSPORT_FLIP_RULES)
+def test_remediation_discloses_the_keys_are_not_spec_fields(rule_id: str) -> None:
+    text = RULES[rule_id].remediation
+    assert "not fields the MCP specification defines" in text, (
+        f"{rule_id} short-circuits on AAK-only config keys; its remediation must say so"
+    )
+    assert "do not treat their presence as protection" in text
+
+
+@pytest.mark.parametrize("rule_id", TRANSPORT_FLIP_RULES)
+def test_remediation_names_a_control_that_actually_works(rule_id: str) -> None:
+    """A version pin and TLS are real; a config key the client ignores is not."""
+    text = RULES[rule_id].remediation.lower()
+    assert "pin" in text, f"{rule_id} must still recommend the version pin"
+    assert "tls" in text, f"{rule_id} must recommend protecting the channel"
+
+
+@pytest.mark.parametrize("rule_id", TRANSPORT_FLIP_RULES)
+def test_remediation_does_not_present_the_keys_as_the_fix(rule_id: str) -> None:
+    """Guard the specific phrasing that made the old text misleading.
+
+    The keys may still be *mentioned* — they have to be, since the rule
+    short-circuits on them — but not as the thing that stops the attack.
+    """
+    text = RULES[rule_id].remediation
+    for bad in (
+        "so a MITM cannot flip the transport",
+        "to prevent MITM transport-flip",
+    ):
+        assert bad not in text, f"{rule_id} still presents an AAK-only key as the fix"
+
+
+def test_the_aak_only_keys_are_still_absent_from_the_corpus() -> None:
+    """The measurement the remediation cites, kept honest.
+
+    If a future MCP spec adopts any of these, this test fails and the
+    remediation note should be revisited rather than left claiming they are
+    unknown in the wild.
+    """
+    if not CORPUS.is_dir():
+        pytest.skip("corpus not present in this checkout")
+    configs = sorted(CORPUS.glob("*.json"))
+    assert len(configs) > 100, f"corpus unexpectedly small ({len(configs)})"
+
+    found: dict[str, int] = {}
+    for path in configs:
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for key in AAK_ONLY_KEYS:
+            if key in text:
+                found[key] = found.get(key, 0) + 1
+
+    assert not found, (
+        "an AAK-only transport key now appears in real MCP configs "
+        f"({found}) — revisit the remediation note, it may no longer be true"
+    )
+
+
+def test_corpus_configs_are_real_mcp_configs() -> None:
+    """Guard the guard: if the corpus stopped being MCP configs, the test above is vacuous."""
+    if not CORPUS.is_dir():
+        pytest.skip("corpus not present in this checkout")
+    sample = sorted(CORPUS.glob("*.json"))[:50]
+    with_servers = 0
+    for path in sample:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and "mcpServers" in data:
+            with_servers += 1
+    assert with_servers > len(sample) // 2, (
+        f"only {with_servers}/{len(sample)} sampled corpus files declare mcpServers"
+    )


### PR DESCRIPTION
## Summary

`AAK-DOCSGPT-MCP-STDIO-MITM-001` and `AAK-GPTRESEARCHER-MCP-STDIO-MITM-001` both told users to set:

```json
"deny_stdio_transport": true      // or "allowed_transports": ["sse"]
```

…*"so a MITM cannot flip the transport mid-session."*

Those keys are **AgentAuditKit conventions, not MCP specification fields.**

| | |
|---|---|
| Present in real MCP configs | **0 of 748** (`benchmarks/data`) |
| Present in a spec artifact | none found |
| Present in this repo | `rules.json`, tests, fixtures — ours only |

For scale, in the same corpus: `mcpServers` 748, `command` 617, `args` 601, `env` 342, `url` 202.

## Why this needed fixing rather than filing

The advice wasn't merely useless — it was self-defeating in a specific way. A user who followed it:

1. added a key their MCP client ignores,
2. **silenced this very rule** by doing so (the detector short-circuits on it),
3. came away believing the transport-flip path was closed.

A rule that goes quiet and leaves the user less safe than before is worse than no rule. That's why this is a correctness fix on released rules rather than a roadmap item.

## What changed

Only the remediation text. Detection is untouched — the rules still short-circuit on those keys, because that's existing behaviour users may depend on.

The new text leads with controls that actually work:

- the **vendor version pin** (DocsGPT `>= 0.6.4`; gpt-researcher once a post-disclosure fix ships) — this was always the real control and is now first
- **TLS with certificate verification**, so a middlebox cannot rewrite the handshake in the first place
- for DocsGPT, a pointer to the receiver-side detectors that catch the downstream injection if a flip does succeed

and then discloses plainly what the two keys are, so nobody reads their presence as protection.

## Test Plan

```
pytest       1722 passed, 1 skipped
ruff         All checks passed!
mypy         Success: no issues found in 157 source files
count-check  clean (303 / 90 / 26 / 12 / 10)
```

`tests/test_transport_flip_remediation.py` (8 tests) keeps it honest:

- the text must name a working control (pin + TLS)
- it must carry the disclosure
- it must **not** re-acquire the old *"so a MITM cannot flip the transport"* phrasing
- it re-measures the corpus, so if a future MCP spec adopts these keys the note gets revisited rather than standing as a false claim
- plus a guard-the-guard check that the corpus is still real MCP configs, so the measurement can't quietly become vacuous

## Provenance

Found while running the empirical false-positive study #162 asks for. That study also found both detectors fire **0 times** across all 748 configs and that none of the four named vendors appears in the corpus — recorded in full on #162, which stays open pending a decision on the umbrella design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
