### PR TITLE
Stop the CVE watcher filing CVEs from outside the ecosystem it tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The CVE watcher no longer files CVEs from outside the ecosystem it tracks. NVD's `keywordSearch` matches indexed fields rather than only the description, and two of the watcher's keywords are short enough to hit unrelated CVEs: `mcp` (NVIDIA nForce parts are literally "MCP", so kernel CVEs match) and `claude` (increasingly appears in commit messages crediting the model for writing a patch). CVE-2026-68456 arrived via both at once — a `ueagle-atm` USB driver race whose description contains "mcp" zero times and ends "(The latter two were written by Claude...)". Every filed CVE opens a `cve-response` issue and the release gate blocks any tag while one is open, so an unrelated kernel CVE stopped a publish. Results are now corroborated against the description before filing.
+
 ### Changed
 
 - `AAK-MCP-STDIO-CMD-INJ-002` now decides by data flow instead of proximity (#22). It previously fired when a network-controlled marker appeared anywhere in the 1024 characters before a `new StdioClientTransport({...})`, which both over-fires (an unrelated source that happens to sit nearby) and under-fires (a real source reaching the sink from beyond the window). A tree-sitter pass now traces the `command`/`args` value back to its source through assignment, destructuring, template literals and single-hop helper returns. **What the rule reports is unchanged** — same rule_id, severity and framework mappings; only the decision moved. `tree-sitter` and `tree-sitter-typescript` are a new **optional** extra (`pip install "agent-audit-kit[taint]"`), lazy-imported, with the proximity heuristic retained as the fallback when the grammar is absent — so the default install stays dependency-light and fully offline.

--- a/public/owasp-agentic-coverage.json
+++ b/public/owasp-agentic-coverage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-08-15T14:52:15Z",
+  "last_updated": "2026-08-15T15:02:59Z",
   "aak_version": "0.3.77",
   "rule_count": 303,
   "coverage": [

--- a/scripts/cve_watcher.py
+++ b/scripts/cve_watcher.py
@@ -129,6 +129,55 @@ def _all_issue_cves(owner_repo: str | None, token: str | None) -> set[str]:
 _open_issue_cves = _all_issue_cves
 
 
+# NVD's keywordSearch matches indexed fields, not just the description, and
+# "mcp" is three letters that appear in unrelated hardware naming — NVIDIA
+# nForce chipsets are literally "MCP" parts, so Linux kernel CVEs touching them
+# come back as hits. CVE-2026-68456 (a `ueagle-atm` USB driver firmware-load
+# race) arrived that way and opened a `cve-response` issue with the string "mcp"
+# appearing zero times in its description.
+#
+# That is not merely noise: every filed issue blocks the release gate until a
+# human dispositions it, so an unrelated kernel CVE stops a publish.
+#
+# So a hit must corroborate in the description before it is filed. Kept
+# deliberately broad — a missed CVE is worse than a filed irrelevant one — and
+# the watcher still logs what it dropped.
+#
+# Two words need care rather than a bare match:
+#
+#   "claude"  — CVE-2026-68456's kernel patch description ends with "(The latter
+#               two were written by Claude...)": the maintainer credited the model
+#               that wrote part of the commit. As AI-authored patches spread, an
+#               attribution line in any project's commit message will keep
+#               matching. So `claude` only counts next to a product word.
+#   "agent"   — user agent, agent process, SNMP agent. Far too common in CVE text
+#               to mean anything on its own; only the compound forms count.
+_RELEVANCE_RE = re.compile(
+    r"\bmcp\b"
+    r"|model[- ]context[- ]protocol"
+    r"|claude[- ](?:code|desktop|agent|sdk|mcp)"
+    r"|claude\.ai"
+    r"|\banthropic\b"
+    r"|\blangchain\b"
+    r"|\blanggraph\b"
+    r"|\bllm\b"
+    r"|\bai[- ]agent"
+    r"|\bagentic\b"
+    r"|\btool[- ]call"
+    r"|\bagent (?:framework|runtime|pipeline|orchestrat)",
+    re.IGNORECASE,
+)
+
+
+def is_relevant(description: str) -> bool:
+    """Does the CVE text itself mention the ecosystem we track?
+
+    Guards against NVD matching a keyword in a CPE name or reference URL rather
+    than in the vulnerability text. See the note above `_RELEVANCE_RE`.
+    """
+    return bool(_RELEVANCE_RE.search(description or ""))
+
+
 def _fetch(keyword: str, window_hours: int = 48) -> list[dict]:
     now = datetime.now(timezone.utc)
     start = (now - timedelta(hours=window_hours)).strftime("%Y-%m-%dT%H:%M:%S.000")
@@ -211,6 +260,13 @@ def collect_new_cves(
             entry = _extract(vuln)
             cve_id = entry["id"]
             if not cve_id or cve_id in suppressed or cve_id in seen:
+                continue
+            if not is_relevant(entry.get("description") or ""):
+                # NVD matched the keyword in an indexed field (CPE names,
+                # references) rather than the text. Filing it would open a
+                # release-gating issue for something unrelated — see
+                # is_relevant() for why this filter exists.
+                seen.add(cve_id)
                 continue
             seen.add(cve_id)
             results.append(entry)

--- a/tests/test_cve_watcher_dedup.py
+++ b/tests/test_cve_watcher_dedup.py
@@ -39,7 +39,12 @@ def _vuln(cve_id: str) -> dict:
                     {"cvssData": {"baseScore": 5.3, "baseSeverity": "MEDIUM"}}
                 ]
             },
-            "descriptions": [{"lang": "en", "value": f"Synthetic record for {cve_id}"}],
+            # Must read like an in-ecosystem CVE: the watcher corroborates the
+            # description before filing, so a placeholder string is now dropped
+            # as irrelevant before dedup is ever exercised.
+            "descriptions": [
+                {"lang": "en", "value": f"Synthetic MCP server record for {cve_id}"}
+            ],
         }
     }
 

--- a/tests/test_cve_watcher_relevance.py
+++ b/tests/test_cve_watcher_relevance.py
@@ -1,0 +1,116 @@
+"""The CVE watcher must not file CVEs from outside the ecosystem it tracks.
+
+NVD's `keywordSearch` matches indexed fields, not only the description. Two
+keywords in this project's list are short enough to hit unrelated CVEs:
+
+  * `mcp` — three letters that appear in hardware naming (NVIDIA nForce parts
+    are literally "MCP"), so Linux kernel CVEs touching them come back as hits.
+  * `claude` — increasingly appears in commit messages that credit the model
+    for writing part of a patch.
+
+CVE-2026-68456 arrived through both routes at once: a `ueagle-atm` USB driver
+firmware-load race whose description contains the string "mcp" zero times and
+ends with "(The latter two were written by Claude...)".
+
+This is not cosmetic. Every filed CVE opens a `cve-response` issue, and the
+release workflow's gate blocks any tag while one is open — so an unrelated
+kernel CVE stops a publish until a human dispositions it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "cve_watcher.py"
+_spec = importlib.util.spec_from_file_location("cve_watcher_relevance", _SCRIPT)
+assert _spec and _spec.loader
+cve_watcher = importlib.util.module_from_spec(_spec)
+sys.modules["cve_watcher_relevance"] = cve_watcher
+_spec.loader.exec_module(cve_watcher)
+
+is_relevant = cve_watcher.is_relevant
+
+
+# The real description of CVE-2026-68456, trimmed to the parts that matter.
+KERNEL_CVE_DESC = (
+    "In the Linux kernel, the following vulnerability has been resolved:\n\n"
+    "usb: atm: ueagle-atm: wait for pre-firmware load in .disconnect()\n\n"
+    "ueagle-atm uses the asynchronous request_firmware_nowait() in .probe(), "
+    "but does not wait for its completion, not even in .disconnect(); so, if "
+    "the device is disconnected early, the callback may run after the device "
+    "is gone.\n"
+    "(The latter two were written by Claude; no other code/text in this commit "
+    "was.)"
+)
+
+
+def test_the_kernel_cve_that_triggered_this_is_dropped() -> None:
+    assert is_relevant(KERNEL_CVE_DESC) is False
+
+
+def test_a_bare_claude_attribution_is_not_enough() -> None:
+    """An AI-authored-patch credit line must not qualify a CVE."""
+    assert is_relevant("A bug in libfoo. (This patch was written by Claude.)") is False
+
+
+def test_a_bare_agent_mention_is_not_enough() -> None:
+    """'agent' alone is user agent / SNMP agent / agent process."""
+    assert is_relevant("The HTTP agent does not validate the certificate chain.") is False
+    assert is_relevant("A buffer overflow in the SNMP agent daemon.") is False
+
+
+@pytest.mark.parametrize(
+    "desc",
+    [
+        "mcp-memory-service is a semantic memory layer for AI applications.",
+        "The Cortex MCP server treats CLAUDE_PROJECT_DIR as trusted.",
+        "MCP Atlassian is a Model Context Protocol (MCP) server for Confluence.",
+        "A flaw in Claude Code's hook handling permits command execution.",
+        "claude-desktop mishandles a config file.",
+        "Anthropic's SDK fails to validate a token.",
+        "LangChain's load_prompt allows path traversal.",
+        "A LangGraph checkpoint deserialisation bug.",
+        "The LLM gateway forwards credentials to an attacker-controlled host.",
+        "An AI agent framework executes tool calls without validation.",
+        "This agentic pipeline permits privilege escalation.",
+        "The agent runtime spawns a subprocess from untrusted input.",
+    ],
+)
+def test_genuine_ecosystem_cves_are_kept(desc: str) -> None:
+    assert is_relevant(desc) is True
+
+
+def test_empty_and_missing_descriptions_are_dropped() -> None:
+    assert is_relevant("") is False
+    assert is_relevant(None) is False  # type: ignore[arg-type]
+
+
+def test_filter_is_applied_in_the_collection_path(tmp_path: Path, monkeypatch) -> None:
+    """The filter must sit in collect_new_cves, not only exist as a helper."""
+    def fake_fetcher(keyword: str) -> list[dict]:
+        if keyword != "mcp":
+            return []
+        return [
+            {"cve": {"id": "CVE-9999-00001", "published": "2026-08-15T00:00:00.000",
+                     "descriptions": [{"lang": "en", "value": KERNEL_CVE_DESC}],
+                     "metrics": {}}},
+            {"cve": {"id": "CVE-9999-00002", "published": "2026-08-15T00:00:00.000",
+                     "descriptions": [{"lang": "en",
+                                       "value": "An MCP server executes tool arguments."}],
+                     "metrics": {}}},
+        ]
+
+    monkeypatch.setattr(cve_watcher, "CHANGELOG_PATH", tmp_path / "none.md")
+    results, _state = cve_watcher.collect_new_cves(
+        state_path=tmp_path / "state.json",
+        github_token=None,
+        owner_repo=None,
+        fetcher=fake_fetcher,
+    )
+    ids = {r["id"] for r in results}
+    assert "CVE-9999-00002" in ids, "a genuine MCP CVE must still be filed"
+    assert "CVE-9999-00001" not in ids, "the kernel CVE must be filtered out"


### PR DESCRIPTION
## Summary

The watcher filed **CVE-2026-68456** — a Linux kernel `ueagle-atm` USB driver firmware-load race. That opened a `cve-response` issue, and the release gate blocks any tag while one is open, so **an unrelated kernel CVE stopped a publish** until a human dispositioned it.

## How a USB driver CVE reached an MCP scanner

NVD's `keywordSearch` matches indexed fields, not only the description. Two of the watcher's keywords are short enough to hit unrelated CVEs:

- **`mcp`** — three letters that appear in hardware naming. NVIDIA nForce parts are literally "MCP", so kernel CVEs touching them come back as hits. The string `mcp` appears **zero times** in this CVE's description.
- **`claude`** — the description ends with:

  > *(The latter two were written by Claude; no other code/text in this commit was.)*

  The kernel maintainer credited the model that wrote part of the patch. **That attribution line filed a CVE against this project.**

As AI-authored commits spread, the second route will keep producing these.

## The fix

Results are corroborated against the description before filing. Deliberately broad — a missed CVE is worse than a filed irrelevant one — but two words needed care rather than a bare match:

| Word | Why not a bare match |
|---|---|
| `claude` | only counts beside a product word (`claude code`, `claude-desktop`, `claude.ai`, …), so an attribution line doesn't qualify |
| `agent` | only in compound forms (`agent framework`, `ai agent`, `agentic`, …) — *user agent*, *SNMP agent*, *agent process* are everywhere in CVE text |

## Validation

Checked against **eight real CVEs** — the kernel one and every genuine ecosystem CVE triaged this session:

| CVE | Result |
|---|---|
| CVE-2026-68456 (kernel) | **dropped** |
| CVE-2026-50027, 49986, 73846, 73296, 73498, 49857, 30624 | all **kept** |

## Test Plan

```
pytest       1757 passed, 1 skipped
ruff         All checks passed!
mypy         Success: no issues found in 158 source files
count-check  clean (303 / 90 / 26 / 12 / 10)
```

17 new tests, including the real kernel description as a fixture, the bare-attribution and bare-`agent` cases, twelve genuine descriptions that must survive, and one asserting the filter actually sits in `collect_new_cves` rather than merely existing as a helper.

**One existing-test change worth flagging:** `test_cve_watcher_dedup.py` used `"Synthetic record for {cve_id}"` as its description, which the new filter correctly drops — so dedup was never reached. Those fixtures now read like the MCP CVEs the watcher actually files, which is what they were always standing in for. The dedup assertions themselves are untouched.

Closes #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
