### PR TITLE
Derive every count in the repo description instead of typing two of them

### DIFF
--- a/.github/repo-metadata.yml
+++ b/.github/repo-metadata.yml
@@ -12,12 +12,17 @@
 # CI token does not have). When RULE_COUNT changes: run the render script and paste
 # its output into repo Settings. See CONTRIBUTING.md "Release checklist".
 #
-# `{RULE_COUNT}` is the only substitution. The em-dash from the old hand-written
+# Every count here is a substitution, not a literal: `{RULE_COUNT}`,
+# `{CATEGORY_COUNT}` and `{FRAMEWORK_COUNT}` are all filled from code by
+# scripts/render_repo_metadata.py. Until v0.3.84 only RULE_COUNT was, and the
+# hardcoded "12 categories" was already wrong by the time the release job read it
+# -- this file is not tracked markdown, so scripts/check_counts.py never sees it.
+# Do not re-introduce a typed count here. The em-dash from the old hand-written
 # description is deliberately dropped.
 description_template: >-
   Static scanner for MCP-connected AI agent pipelines. {RULE_COUNT} rules across
-  12 categories, 12 compliance frameworks, OWASP Agentic 10/10 + MCP 10/10,
-  GitHub Action, SARIF, public CVE-to-rule ledger.
+  {CATEGORY_COUNT} categories, {FRAMEWORK_COUNT} compliance frameworks, OWASP
+  Agentic 10/10 + MCP 10/10, GitHub Action, SARIF, public CVE-to-rule ledger.
 
 # Copied verbatim from the live repo topics (api.github.com/repos/.../topics).
 topics:

--- a/scripts/render_repo_metadata.py
+++ b/scripts/render_repo_metadata.py
@@ -53,11 +53,27 @@ def load_description_template(text: str) -> str:
 
 
 def render() -> str:
-    """The final repo description with ``{RULE_COUNT}`` substituted."""
+    """The final repo description with every derivable count substituted.
+
+    Only ``{RULE_COUNT}`` was substituted until v0.3.84; the category and
+    framework counts sat in the template as literals. That is the same drift the
+    markdown guard exists to catch, in the one surface it cannot see -- and it
+    had already happened: the template still said "12 categories" after Category
+    gained COMPOSITION, so the rendered description was wrong the moment the
+    release job asked for it. Anything computable from code is substituted here
+    rather than typed into the template.
+    """
     from agent_audit_kit import RULE_COUNT
+    from agent_audit_kit.models import Category
+    from agent_audit_kit.output import pdf_report
 
     template = load_description_template(_METADATA.read_text(encoding="utf-8"))
-    return template.replace("{RULE_COUNT}", str(RULE_COUNT))
+    return (
+        template
+        .replace("{RULE_COUNT}", str(RULE_COUNT))
+        .replace("{CATEGORY_COUNT}", str(len(list(Category))))
+        .replace("{FRAMEWORK_COUNT}", str(len(pdf_report._FRAMEWORK_TITLES)))
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

The v0.3.84 release job failed on **Repo description liveness**, and the interesting part is that the template itself was wrong, not just GitHub's About text.

`.github/repo-metadata.yml` substituted only `{RULE_COUNT}` and carried `12 categories` and `12 compliance frameworks` as literals. `Category` gained `COMPOSITION` in v0.3.84, so `make repo-description` rendered:

> Static scanner for MCP-connected AI agent pipelines. 313 rules across **12 categories**, …

A freshly generated string that was already false. This file is not tracked markdown, so `scripts/check_counts.py` never sees it — the same phrase-based blind spot the category guard just closed, one surface further out.

Both are now `{CATEGORY_COUNT}` and `{FRAMEWORK_COUNT}`, filled from `Category` and `pdf_report._FRAMEWORK_TITLES`.

The comment above the template said "`{RULE_COUNT}` is the only substitution" — true when written, and exactly the kind of stale claim this release is about. It now says what the file does and why not to type a count into it.

The live GitHub About text has been updated to the rendered string, so the liveness job passes on re-run.

## Test Plan

- `make repo-description` → `313 rules across 13 categories, 12 compliance frameworks` with no unsubstituted placeholders
- `pytest tests/test_repo_metadata_matches_code.py` passes
- Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018edXoRJo2ZHsTFaCyQSS86