### PR TITLE
Rewrite the launch checklist against the state the repo is actually in

### DIFF
--- a/docs/launch/CHECKLIST.md
+++ b/docs/launch/CHECKLIST.md
@@ -1,78 +1,122 @@
-# v0.3.0 launch checklist — things YOU do
+# Launch checklist — things only you can do
 
-Work items that require your identity or credentials. I've prepared
-everything else; these steps are for you.
+Everything that does not need your identity or credentials is already done. This
+file lists what is left, with the exact commands, and is written against the
+**current** state of the repository rather than the state it had when the
+original was drafted.
 
-## Pre-launch (T-48h)
+> **Rewritten 2026-09-12.** The previous version was titled "v0.3.0 launch
+> checklist" and was never executed; the repository is now at v0.6.1. Several of
+> its steps had since been completed by other work and are marked done below
+> rather than left as open boxes, because a checklist that asks you to redo
+> finished work is one you stop reading.
 
-- [ ] Review the current release's notes and approve.
-- [ ] Review `docs/launch/hn.md`, `reddit.md`, `x-thread.md`,
-      `press.md`. Adjust voice if anything sounds too synthetic.
-- [ ] Review `docs/disclosure-policy.md`. Confirm you're comfortable
-      being named as the security-contact address.
-- [ ] Push commits + tags to GitHub:
-      ```
-      git push origin main --follow-tags
-      ```
-- [ ] Confirm PyPI Trusted Publisher config is set up for the `pypi`
-      environment. (GitHub Settings → Environments → `pypi`.)
-- [ ] Decide whether to route the MCP Security Index domain
-      `sattyamjjain.github.io/agent-audit-kit` through Cloudflare Pages or GitHub Pages.
-      Either works. For GH Pages: enable Pages, source = `gh-pages`
-      branch. For CFP: add a CNAME record pointing at the GH Pages URL.
-- [ ] Send press emails (from `docs/launch/press.md`) with the Tuesday
-      13:00 UTC embargo.
+## Current state, for the copy you will write
 
-## Launch day (Tuesday, T=0)
+| | |
+|---|---|
+| Version | v0.6.1 (PyPI, GHCR, GitHub Releases, Sigstore-signed bundle) |
+| Rules / scanners | **348** rules, **103** scanners, 14 categories |
+| Compliance frameworks | **14** |
+| CVE-to-rule latency | median **1.0 day**, p90 **4 days**, measured over 77 CVEs |
+| Stars | 13 |
+| Licence | Apache-2.0 |
 
-- [ ] 10:00 UTC: run one final `agent-audit-kit scan .` on the repo
-      itself. Tree must be clean.
-- [ ] 11:00 UTC: `git tag -s v0.3.0 -m "Phase 1–5"` then `git push
-      origin v0.3.0`. This triggers `.github/workflows/release.yml`.
-- [ ] 11:30 UTC: watch the `release.yml` run. Expected jobs: `pypi`,
-      `docker`, `bundle-and-sign`, `github-release`. All must be
-      green before the public post.
-- [ ] 12:00 UTC: `cd vscode-extension && npm install && npm run
-      compile && npx @vscode/vsce publish`. (You need a VS Code
-      publisher account pre-created.)
-- [ ] 12:00 UTC: `npx ovsx publish -p $OPEN_VSX_TOKEN` to mirror on
-      Open VSX.
-- [ ] 12:30 UTC: submit `action.yml` to the GitHub Marketplace from
-      the release UI.
-- [ ] 13:00 UTC: submit HN post (exact text in `hn.md`). Post the
-      canned first-comment immediately.
-- [ ] 13:30 UTC: post the X thread.
-- [ ] 14:00 UTC: post to `/r/netsec`, `/r/ClaudeAI`, `/r/LocalLLaMA`,
-      `/r/mcp` (in that order, spaced ~15 min apart so moderators
-      don't auto-flag).
-- [ ] 14:00–18:00 UTC: stay in the HN thread. Answer every top-level
-      comment.
+Regenerate these before posting rather than trusting the table:
 
-## Post-launch (T+24h)
+```bash
+python -c "import agent_audit_kit as a; print(a.RULE_COUNT, a.SCANNER_COUNT)"
+python -c "from agent_audit_kit.output.pdf_report import _FRAMEWORK_TITLES as F; print(len(F))"
+grep -A4 '| Median |' docs/cve-latency.md
+```
 
-- [ ] Update `docs/metrics.md` with day-1 numbers.
-- [ ] Write the first `docs/blog/state-of-mcp-security-2026-wNN.md`
-      post from the template. Publish it Thursday, not Wednesday —
-      give the index snapshot 48h to settle before commenting on it.
+## Already done — no action needed
 
-## If things go wrong
+- [x] PyPI Trusted Publisher (OIDC) — releases publish without a token
+- [x] GitHub Pages live at https://sattyamjjain.github.io/agent-audit-kit/ (HTTP 200)
+- [x] MCP Security Index publishing on schedule
+- [x] Sigstore-signed rule bundle + CycloneDX/SPDX SBOM on every release
+- [x] Docker image to GHCR, nightly rebuild
+- [x] Release workflow green end to end
+- [x] The repo `description` is set by the release job (needs `REPO_ADMIN_TOKEN`, see below)
 
-- Release pipeline fails on Sigstore step: the wheel is already on
-  PyPI (the `pypi` job runs first). Sigstore signature can be added
-  later via `sigstore sign rules.json` locally.
-- VS Code publish fails auth: the extension is optional for launch.
-  Skip it and retry after launch. Reddit / HN / X don't depend on it.
-- HN thread gets flagged: don't re-submit. It will re-surface after
-  mod review. Submit to `/r/netsec` and X in the meantime.
-- A reporter embargoes breaks early: acknowledge it, don't complain
-  publicly. The story running 2 hours early doesn't matter.
+## 1. One secret, once
 
-## What NOT to do
+Create a fine-grained PAT with **Administration: write** on this repository and
+save it as the `REPO_ADMIN_TOKEN` secret. The release job then sets the GitHub
+"About" description from `RULE_COUNT` and verifies it. Without the secret the job
+prints the line for you to paste and the release still succeeds.
 
-- Do NOT launch on a Friday.
-- Do NOT submit to HN before the PyPI/Docker jobs are green.
-- Do NOT name vulnerable public servers in any post. The 90-day
-  window is absolute.
-- Do NOT claim "more accurate than Snyk." Verifiable claims only.
-- Do NOT offer paid tiers, accounts, or "premium" features at launch.
-  Zero-friction install is the wedge.
+Settings → Secrets and variables → Actions → New repository secret.
+
+## 2. VS Code Marketplace + Open VSX
+
+The extension compiles clean (`npm install && npm run compile` verified
+2026-09-12). It is at its own version, `0.3.3`, versioned independently of the
+Python package on purpose.
+
+You need a Marketplace publisher account (`sattyamjjain`) and an Open VSX token.
+
+```bash
+cd vscode-extension
+npm install && npm run compile
+npx @vscode/vsce package            # produces a .vsix you can install locally to smoke-test
+npx @vscode/vsce login sattyamjjain # one time
+npx @vscode/vsce publish
+npx ovsx publish -p "$OPEN_VSX_TOKEN"
+```
+
+Smoke-test the `.vsix` in a scratch window before publishing: open a folder
+containing an `.mcp.json` with a known-bad server and confirm the diagnostics
+appear.
+
+## 3. GitHub Marketplace listing for the Action
+
+From the release page for the newest tag, use "Publish this Action to the GitHub
+Marketplace". `action.yml` already carries the required `name`, `description`,
+`branding.icon` and `branding.color`.
+
+## 4. The posts
+
+Drafts are in `docs/launch/`: `hn.md`, `reddit.md`, `x-thread.md`, `press.md`.
+Their figures are kept in sync by `scripts/check_counts.py`, so they are current
+as of this commit, but re-read them for voice before posting — they were written
+in April and the project has changed shape since.
+
+Suggested order, spaced so moderators do not auto-flag:
+
+1. Show HN (Tue/Wed, 08:00–09:00 ET). Post the canned first comment immediately.
+2. `/r/netsec`, then `/r/mcp`, then `/r/ClaudeAI`, `/r/LocalLLaMA`, ~15 min apart.
+3. X thread.
+4. Press emails from `press.md`.
+
+Stay in the HN thread for the first three hours and answer every top-level
+comment.
+
+## 5. Outreach that is drafted and unsent
+
+- `launch/owasp-outreach.md` — OWASP MCP Top 10 / Agentic Security Initiative
+- `launch/awesome-list-prs/` — PR bodies for the awesome-* lists
+- `research/state-of-mcp-2026/blackhat-arsenal-abstract.md` and
+  `blackhat-briefings-abstract.md` — check the current CFP deadlines before
+  submitting; both were written against an earlier cycle
+
+## What to lead with
+
+The honest differentiators, in the order they hold up to scrutiny:
+
+1. **Compliance-evidence output.** 14 frameworks including two that are already
+   in force and that competing scanners do not map: EU AI Act Article 50
+   (transparency, live since 2026-08-02) and Colorado SB 26-189 ADMT
+   (effective 2027-01-01). Every control row cites a real paragraph, and rows
+   that cannot be evidenced say so instead of printing a tick.
+2. **A published CVE-to-rule latency number** — median 1.0 day — generated from
+   the ledger rather than asserted, with a guard that fails if the doc drifts.
+3. **Pin and verify.** Nobody else fingerprints a tool surface at approval and
+   re-verifies it afterwards. See
+   `examples/case-studies/deadbugz-delayed-metadata/`.
+4. **SBOM + VEX as a pair**, joined on purl, with the VEX emitter refusing to
+   claim `not_affected` because a static scan cannot establish it.
+
+Do not lead with the rule count. Every scanner has one and it invites a
+comparison that is not the interesting argument.


### PR DESCRIPTION
`docs/launch/CHECKLIST.md` was titled **"v0.3.0 launch checklist"** and had never
been executed. The repository is at v0.6.1.

More usefully: several of its steps had since been completed by other work and
were still sitting there as open boxes. PyPI trusted publishing, GitHub Pages,
the MCP Security Index, Sigstore signing, the release workflow, and as of #721
the repo description. A checklist that asks you to redo finished work is one you
stop reading, so those are marked done with the evidence rather than left open.

## What is actually left

Only the things that need an identity or a credential:

1. A `REPO_ADMIN_TOKEN` secret (fine-grained PAT, Administration: write)
2. VS Code Marketplace publisher account and an Open VSX token
3. The GitHub Marketplace listing for the Action
4. The posts, and the outreach that is drafted and unsent

## The extension builds

Verified from a clean install on 2026-09-12:

```
npm install  -> OK
npm run compile -> OK, out/extension.js produced
```

So `vsce publish` is the remaining step, not a build problem waiting to be
discovered mid-launch. The checklist also says to smoke-test the `.vsix` against
a known-bad `.mcp.json` before publishing.

## Figures

Current as of this commit: 348 rules, 103 scanners, 14 frameworks, CVE-to-rule
latency median **1.0 day** / p90 4 days over 77 CVEs. `check_counts.py` keeps the
drafts in sync, so the numbers in `hn.md` and `reddit.md` are right.

The checklist nonetheless says to regenerate them before posting rather than
trust the table, and gives the three commands. A launch post is the worst place
to discover a stale count.

## What to lead with

Recorded in the file, because it is the part that is easy to get wrong under
time pressure:

1. Compliance evidence — 14 frameworks, including two **already in force** that
   competing scanners do not map (EU AI Act Art. 50, live since 2026-08-02;
   Colorado SB 26-189 ADMT, effective 2027-01-01), with every control row citing
   a real paragraph and rows that cannot be evidenced saying so
2. A published, generated CVE-to-rule latency number with a guard that fails if
   it drifts
3. Pin and verify, with the Deadbugz case study
4. SBOM + VEX joined on purl, where the VEX emitter refuses `not_affected`

And what not to lead with: **the rule count**. Every scanner has one, and quoting
it invites the comparison that is not the interesting argument.

## Note

I cannot execute any of the remaining items. This PR is the preparation, so that
what is left is one sitting of your time rather than research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmqU9mBSnE1kjjSLnYUSZc
